### PR TITLE
requests: Create manual permission requests from CLI

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -121,3 +121,10 @@ export const login = async (
 
   sys.exit(0);
 };
+
+export const loginArgs = (yargs: yargs.Argv<{}>) =>
+  yargs.positional("tenant", {
+    demandOption: true,
+    type: "string",
+    describe: "Your P0 tenant ID",
+  });

--- a/src/commands/request.ts
+++ b/src/commands/request.ts
@@ -1,0 +1,13 @@
+import yargs from "yargs";
+import * as snowflake from "../integrations/snowflake";
+
+const plugins = [snowflake];
+
+export const requestArgs = (yargs: yargs.Argv<{}>) => {
+  plugins
+    .reduce((y, p) => p.requestArgs(y), yargs)
+    .demandCommand(1)
+    .strict();
+};
+
+export const request = (_args: yargs.ArgumentsCamelCase<{}>) => {};

--- a/src/common/permission.ts
+++ b/src/common/permission.ts
@@ -1,0 +1,36 @@
+import { addDoc } from "firebase/firestore";
+import * as firestore from "../drivers/firestore";
+import { auth } from "../drivers/firestore";
+import { readLine } from "../util";
+
+// TODO: Restructure permission-request table
+// TODO: Use IDP data for principal
+const submit = async <P>(type: string, permission: P) => {
+  if (auth.currentUser === null || auth.tenantId === null)
+    throw "not logged in";
+  const uid = auth.currentUser?.uid;
+  const tenantId = auth.tenantId;
+  const now = Date.now() * 1e-3; // Permissions are in epoch seconds
+
+  console.log(`Please enter a brief description of why you need access:`);
+  process.stdout.write("$ ");
+  const reason = await readLine();
+
+  const data = {
+    status: "NEW",
+    requestedTimestamp: now,
+    lastUpdatedTimestamp: now,
+    uid,
+    type,
+    reason,
+    permission,
+  };
+  const doc = await addDoc(
+    firestore.collection(`o/${tenantId}/permission-events`),
+    data
+  );
+  console.log(`Created request with ID ${doc.id}`);
+  return doc.id;
+};
+
+export default { submit };

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -31,6 +31,7 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 export const FIRESTORE = getFirestore(app);
+export const auth = getAuth();
 
 export const IDENTITY_FILE_PATH = path.join(
   os.homedir(),
@@ -49,8 +50,8 @@ export const authenticate = async () => {
     creds.accessToken
   );
 
-  const auth = getAuth();
   auth.tenantId = storedCredential.tenantId;
+
   const userCredential = await signInWithCredential(auth, googleCredential);
 
   return userCredential.user;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,28 @@
 import { sys } from "typescript";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { login } from "./commands/login";
+import { login, loginArgs } from "./commands/login";
+import { request, requestArgs } from "./commands/request";
+
+const VERSION = "0.1.0";
 
 export const main = () =>
   yargs(hideBin(process.argv))
-    .command(
-      "login [tenant]",
+    .scriptName("p0cli")
+    .command<{ tenant: string }>(
+      "login <tenant>",
       "Login to p0 using a web browser",
-      (yargs) =>
-        yargs.positional("tenant", {
-          demandOption: true,
-          type: "string",
-          describe: "Your P0 tenant ID",
-        }),
+      loginArgs,
       login
     )
+    .command<{}>(
+      "request <resource> [...arguments]",
+      "Manually request permissions on a resource",
+      requestArgs,
+      request
+    )
     .strict()
+    .version(VERSION)
     .demandCommand(1).argv;
 
 if (require.main === module) {

--- a/src/integrations/snowflake.ts
+++ b/src/integrations/snowflake.ts
@@ -1,0 +1,83 @@
+import yargs from "yargs";
+import { authenticateMiddleware } from "../middleware";
+import { noop } from "../util";
+import permission from "../common/permission";
+import { sys } from "typescript";
+
+export const requestArgs = (yargs: yargs.Argv<{}>): yargs.Argv<{}> =>
+  yargs.command(
+    "snowflake [role|object|query]",
+    "Request roles, table-level, or query grants in Snowflake",
+    (yargs) =>
+      yargs
+        .command(
+          "role <role>",
+          "Request a known role",
+          (y) =>
+            y
+              .positional("role", {
+                description: "A pre-existing Snowflake role",
+                type: "string",
+              })
+              .strict(),
+          requestRole,
+          middlewares
+        )
+        .command(
+          "object [...options] <object>",
+          "Request an object-level grant",
+          (y) =>
+            y
+              .positional("object", {
+                description:
+                  "A fully-qualified Snowflake object (e.g. tables should be DATABASE.SCHEMA.TABLE)",
+                type: "string",
+              })
+              .option("permission", {
+                alias: "p",
+                description: "A Snowflake permission for this grant",
+                type: "string",
+                default: "SELECT",
+              })
+              .option("type", {
+                alias: "t",
+                description: "The class or type of this object",
+                type: "string",
+                default: "TABLE",
+              }),
+          requestTable,
+          middlewares
+        )
+        .command(
+          "query <query>",
+          "Request all grants needed to execute a query.\n\nCurrently only queries compatible with Postgres SQL are supported.",
+          (y) =>
+            y.positional("query", {
+              description: "One or more Snowflake queries (separate with ;)",
+              type: "string",
+            }),
+          requestQuery,
+          middlewares
+        )
+        .demandCommand(1)
+        .strict()
+  );
+
+const middlewares = [authenticateMiddleware];
+
+const requestRole = async (
+  args: yargs.ArgumentsCamelCase<{ role: string }>
+) => {
+  await permission.submit("snowflake", { type: "role", roleName: args.role });
+  sys.exit(0);
+};
+
+const requestTable = (
+  _args: yargs.ArgumentsCamelCase<{
+    table: string;
+    permission: string;
+    type: string;
+  }>
+) => {};
+
+const requestQuery = (_args: yargs.ArgumentsCamelCase<{ query: string }>) => {};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,8 @@
+import yargs from "yargs";
+import { authenticate } from "./drivers/firestore";
+
+export const authenticateMiddleware = async (
+  _args: yargs.ArgumentsCamelCase<{}>
+) => {
+  await authenticate();
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,2 +1,9 @@
 export const sleep = (timeoutMillis: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, timeoutMillis));
+
+export const noop = () => {};
+
+export const readLine = () =>
+  new Promise<string>((resolve) =>
+    process.stdin.on("data", (d) => resolve(d.toString()))
+  );


### PR DESCRIPTION
I use a new "permission-events" collection in Firebase to better secure these:

- Identity is passed using only authenticated `uid` field
- Only "NEW" events can be created from the CLI