### PR TITLE
login: Support new oidc-pkce provider

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -13,6 +13,7 @@ const pluginLoginMap: Record<string, (org: OrgData) => Promise<TokenResponse>> =
   {
     google: googleLogin,
     okta: oktaLogin,
+    "oidc-pkce": async (org) => await pluginLoginMap[org.providerType!]!(org),
   };
 
 export const login = async (

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -1,4 +1,3 @@
-import { loadCredentials } from "./auth";
 import { initializeApp } from "firebase/app";
 import { getAuth, OAuthProvider, signInWithCredential } from "firebase/auth";
 import {

--- a/src/plugins/okta/login.ts
+++ b/src/plugins/okta/login.ts
@@ -28,7 +28,7 @@ const authorize = async (org: OrgData) => {
     headers: OIDC_HEADERS,
     body: urlEncode({
       client_id: org.clientId,
-      scope: "openid email profile okta.apps.sso okta.apps.read",
+      scope: "openid email profile okta.apps.sso",
     }),
   };
   validateProviderDomain(org);

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -3,7 +3,14 @@ export type OrgData = {
   clientId: string;
   providerId: string;
   providerDomain?: string;
-  ssoProvider: "azure-oidc" | "google" | "microsoft" | "google-oidc" | "okta";
+  providerType?: "okta";
+  ssoProvider:
+    | "azure-oidc"
+    | "google"
+    | "microsoft"
+    | "google-oidc"
+    | "okta"
+    | "oidc-pkce";
   slug: string;
   tenantId: string;
 };


### PR DESCRIPTION
In order to support Okta native app login on p0.app, we've added a new oidc-pkce login method. Migrate Okta login to this new method.