### PR TITLE
Configure for multiple environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "private": true,
   "dependencies": {
     "@rgrove/parse-xml": "^4.1.0",
+    "dotenv": "^16.4.1",
     "express": "^4.18.2",
     "firebase": "^10.7.2",
     "jsdom": "^24.0.0",

--- a/src/commands/request.ts
+++ b/src/commands/request.ts
@@ -1,4 +1,5 @@
 import { authenticate } from "../drivers/auth";
+import { config } from "../drivers/env";
 import { doc, guard } from "../drivers/firestore";
 import { Unsubscribe, onSnapshot } from "firebase/firestore";
 import { sys } from "typescript";
@@ -41,8 +42,7 @@ export const requestCommand = (yargs: yargs.Argv) =>
     guard(request)
   );
 
-const requestUrl = (tenant: string) =>
-  `http://localhost:8088/o/${tenant}/command/`;
+const requestUrl = (tenant: string) => `${config.appUrl}/o/${tenant}/command/`;
 
 const waitForRequest = async (tenantId: string, requestId: string) => {
   return new Promise<number>((resolve) => {

--- a/src/drivers/env.ts
+++ b/src/drivers/env.ts
@@ -1,0 +1,27 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const { env } = process;
+
+export const config = {
+  fs: {
+    // Falls back to public production Firestore credentials
+    apiKey: env.P0_FS_API_KEY ?? "AIzaSyCaL-Ik_l_5tdmgNUNZ4Nv6NuR4o5_PPfs",
+    authDomain: env.P0_FS_AUTH_DOMAIN ?? "p0-prod.firebaseapp.com",
+    projectId: env.P0_FS_PROJECT_ID ?? "p0-prod",
+    storageBucket: env.P0_FS_STORAGE_BUCKET ?? "p0-prod.appspot.com",
+    messagingSenderId: env.P0_FS_MESSAGING_SENDER_ID ?? "228132571547",
+    appId: env.P0_FS_APP_ID ?? "1:228132571547:web:4da03aeb78add86fe6b93e",
+  },
+  google: {
+    clientId:
+      env.P0_GOOGLE_OIDC_CLIENT_ID ??
+      "228132571547-kilcq1er15hlbl6mitghttnacp7u58l8.apps.googleusercontent.com",
+    // Despite the name, this is not actually "secret" in any sense of the word.
+    // Instead, the client is protected by requiring PKCE and defining the redirect URIs.
+    clientSecret:
+      env.P0_GOOGLE_OIDC_CLIENT_SECRET ?? "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",
+  },
+  appUrl: env.P0_APP_URL ?? "https://api.p0.app",
+};

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -1,3 +1,4 @@
+import { config } from "./env";
 import { initializeApp } from "firebase/app";
 import { getAuth, OAuthProvider, signInWithCredential } from "firebase/auth";
 import {
@@ -10,14 +11,7 @@ import {
 } from "firebase/firestore";
 
 // Your web app's Firebase configuration
-const firebaseConfig = {
-  apiKey: "AIzaSyC9A5VXSwDDS-Vp4WH_UIanEqJvv_7XdlQ",
-  authDomain: "p0-gcp-project.firebaseapp.com",
-  projectId: "p0-gcp-project",
-  storageBucket: "p0-gcp-project.appspot.com",
-  messagingSenderId: "398809717501",
-  appId: "1:398809717501:web:6dd1cab893b2faeb06fc94",
-};
+const firebaseConfig = config.fs;
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);

--- a/src/plugins/google/login.ts
+++ b/src/plugins/google/login.ts
@@ -1,6 +1,7 @@
 import { OIDC_HEADERS } from "../../common/auth/oidc";
 import { withRedirectServer } from "../../common/auth/server";
 import { urlEncode, validateResponse } from "../../common/fetch";
+import { config } from "../../drivers/env";
 import { AuthorizeRequest, TokenResponse } from "../../types/oidc";
 import open from "open";
 
@@ -15,17 +16,11 @@ const GOOGLE_OIDC_REDIRECT_PORT = 52700;
 const GOOGLE_OIDC_REDIRECT_URL = `http://127.0.0.1:${GOOGLE_OIDC_REDIRECT_PORT}`;
 const PKCE_LENGTH = 128;
 
-const GOOGLE_OIDC_CLIENT_ID =
-  "398809717501-j4j8ldjicsspidl4ecj6nj1oomo9eda1.apps.googleusercontent.com";
-// Despite the name, this is not actually "secret" in any sense of the word.
-// Instead, the client is protected by requiring PKCE and defining the redirect URIs.
-const GOOGLE_OIDC_CLIENT_SECRET = "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";
-
 const requestAuth = async () => {
   const pkceChallenge = (await import("pkce-challenge")).default as any;
   const pkce = await pkceChallenge(PKCE_LENGTH);
   const authBody: AuthorizeRequest = {
-    client_id: GOOGLE_OIDC_CLIENT_ID,
+    client_id: config.google.clientId,
     code_challenge: pkce.code_challenge,
     code_challenge_method: "S256",
     redirect_uri: GOOGLE_OIDC_REDIRECT_URL,
@@ -41,8 +36,8 @@ const requestToken = async (
   pkce: { code_challenge: string; code_verifier: string }
 ) => {
   const body = {
-    client_id: GOOGLE_OIDC_CLIENT_ID,
-    client_secret: GOOGLE_OIDC_CLIENT_SECRET,
+    client_id: config.google.clientId,
+    client_secret: config.google.clientSecret,
     code,
     code_verifier: pkce.code_verifier,
     grant_type: "authorization_code",

--- a/yarn.lock
+++ b/yarn.lock
@@ -950,6 +950,11 @@ destroy@1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
+dotenv@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.1.tgz#1d9931f1d3e5d2959350d1250efab299561f7f11"
+  integrity sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
This commit adds dotenv support for defining runtime environments. The CLI is only deployed with the production environment.

Use github.com/p0-security/p0cli-env for .env template files.

Closes ENG-1525.