### PR TITLE
ssh: Forward TTY to ssm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "firebase": "^10.7.2",
     "jsdom": "^24.0.0",
     "lodash": "^4.17.21",
-    "node-pty": "^1.0.0",
     "open": "^8.4.0",
     "pkce-challenge": "^4.1.0",
     "typescript": "^4.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,22 +2222,10 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.17.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.18.0.tgz#26a6faae7ffbeb293a39660e88a76b82e30b7554"
-  integrity sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==
-
 negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
-
-node-pty@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.0.0.tgz#7daafc0aca1c4ca3de15c61330373af4af5861fd"
-  integrity sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==
-  dependencies:
-    nan "^2.17.0"
 
 nwsapi@^2.2.7:
   version "2.2.7"


### PR DESCRIPTION
Previously, I couldn't figure out how to forward the calling TTY to the spawned `aws ssm` process. This is because I was manually piping stdio from the calling TTY to the spawned process's io. Node provides no mechanism to enabled a spawned process's io to operate as a TTY. This causes:
1. A potential lack of proper interpretation of ANSI escape sequences.
2. Inability to size / resize the resulting display.

I had been working around this by shimming the process with a pty (pseudoterminal) implementation. However, this has two drawbacks:
1. The pty bindings require native bindings to be compiled on installation, reducing the portability of the p0 CLI.
2. Pseudoterminals only support a single output stream, meaning a caller could not separate output to stdout vs. stderr. This meant that the output of `p0 ssh` could not be properly piped to another process.

This commit solves all of the above by _replacing_ the spawned process's stdio with the p0 CLI's stdio directly, using the `'inherit'` option on node's `child_process.spawn` function.