### PR TITLE
auth: Cache credentials

### DIFF
--- a/src/plugins/aws/assumeRole.ts
+++ b/src/plugins/aws/assumeRole.ts
@@ -1,9 +1,9 @@
 import { urlEncode, validateResponse } from "../../common/fetch";
 import { parseXml } from "../../common/xml";
+import { cached } from "../../drivers/auth";
 import { arnPrefix } from "./api";
 import { AWS_API_VERSION } from "./api";
 import { AwsCredentials } from "./types";
-import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 
 const roleArn = (args: { account: string; role: string }) =>
   `${arnPrefix(args.account)}:role/${args.role}`;

--- a/src/plugins/okta/aws.ts
+++ b/src/plugins/okta/aws.ts
@@ -1,0 +1,27 @@
+import { initOktaSaml } from "../../commands/aws/role";
+import { cached } from "../../drivers/auth";
+import { Authn } from "../../types/identity";
+import { assumeRoleWithSaml } from "../aws/assumeRole";
+
+export const assumeRoleWithOktaSaml = async (
+  authn: Authn,
+  args: { account?: string; role: string }
+) =>
+  await cached(
+    `aws-okta-${args.account}-${args.role}`,
+    async () => {
+      const { account, config, samlResponse } = await initOktaSaml(
+        authn,
+        args.account
+      );
+      return await assumeRoleWithSaml({
+        account,
+        role: args.role,
+        saml: {
+          providerName: config.uidLocation.samlProviderName,
+          response: samlResponse,
+        },
+      });
+    },
+    { duration: 3600e3 }
+  );


### PR DESCRIPTION
Speed up operations by reusing previously gained credentials between runs.

Unfortunately this does not work for Firebase, as there is no mechanism to rehydrate the cached credential into the Firebase UserCredential object.

Therefore this is effectively just applied to aws role assumption with Okta SAML.

Doing this shaves about 2 seconds off `p0 ssh`.