### PR TITLE
Use session document to log in dedicated user

### DIFF
--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -11,6 +11,9 @@ export type Request<T = object> = {
   generatedRoles: {
     role: string;
   }[];
+  generated: {
+    documentName: string;
+  }
   permission: T;
   principal: string;
 };


### PR DESCRIPTION
Add the session document name argument to the access tester command and the actual start-session child process.
Make it clearer that these arguments need to match by constructing the args in the access tester and reusing them in the child process.