### PR TITLE
requests: Keep types generic

### DIFF
--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -8,6 +8,7 @@ import {
   DENIED_STATUSES,
   DONE_STATUSES,
   ERROR_STATUSES,
+  PluginRequest,
   Request,
 } from "../types/request";
 import { request } from "./request";
@@ -34,14 +35,14 @@ export const sshCommand = (yargs: yargs.Argv) =>
 
 // TODO: Move this to a shared utility
 /** Waits until P0 grants access for a request */
-const waitForProvisioning = async <T extends object>(
+const waitForProvisioning = async <P extends PluginRequest>(
   authn: Authn,
   requestId: string
 ) => {
   let cancel: NodeJS.Timeout | undefined = undefined;
-  const result = await new Promise<Request<T>>((resolve, reject) => {
+  const result = await new Promise<Request<P>>((resolve, reject) => {
     let isResolved = false;
-    const unsubscribe = onSnapshot<Request<T>, object>(
+    const unsubscribe = onSnapshot<Request<P>, object>(
       doc(`o/${authn.identity.org.tenantId}/permission-requests/${requestId}`),
       (snap) => {
         const data = snap.data();

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -34,8 +34,13 @@ export type AwsConfig = {
 // -- Specific AWS permission types
 
 export type AwsSsh = {
-  spec: {
-    arn: string;
+  permission: {
+    spec: {
+      arn: string;
+    };
+    type: "session";
   };
-  type: "session";
+  generated: {
+    documentName: string;
+  };
 };

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -6,15 +6,18 @@ export const ERROR_STATUSES = [
   "ERRORED_NOTIFIED",
 ] as const;
 
-export type Request<T = object> = {
+export type PluginRequest = {
+  permission: object;
+  generated?: object;
+};
+
+export type Request<P extends PluginRequest = { permission: object }> = {
   status: string;
   generatedRoles: {
     role: string;
   }[];
-  generated: {
-    documentName: string;
-  };
-  permission: T;
+  generated: P["generated"];
+  permission: P["permission"];
   principal: string;
 };
 


### PR DESCRIPTION
Commit 845736ea5c updated the generic Request type to include an AWS SSM-specific entry.

This commit restores the generic nature of the request type, and moves anything AWS-specific to an AWS-specific type.