### PR TITLE
add vscode settings file for autoformatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
This PR adds a settings.json file to the vscode folder and a rule for auto formatting typescript. This is the same rule in the p0 repo.

https://github.com/p0-security/app/blob/ea35031a5cd7e71161a4531e9cc285a18cfbfa31/.vscode/settings.json#L12-L15