### PR TITLE
Show requestable resources in p0 request --help

### DIFF
--- a/src/commands/request.ts
+++ b/src/commands/request.ts
@@ -40,7 +40,7 @@ const isCompletedStatus = (
 const requestArgs = <T>(yargs: yargs.Argv<T>) =>
   yargs
     .parserConfiguration({ "unknown-options-as-args": true })
-    .help(false)
+    .help(false) // Turn off help in order to forward the --help command to the backend so P0 can provide the available requestable resources
     .option("wait", {
       alias: "w",
       boolean: true,


### PR DESCRIPTION
 Addresses ENG-1652. Disable default yargs help on request command so that our backend provides more detailed help.

Previously:

``` p0 request --help
p0 request [arguments..]

Manually request permissions on a resource

Options:
      --help       Show help                                           [boolean]
      --version    Show version number                                 [boolean]
  -w, --wait       Block until the command is completed
                                                      [boolean] [default: false]
      --arguments                                          [array] [default: []] 
```

Now:

```./p0 request --help
p0 request

Request access to a resource using P0

Commands:
  p0 request aws                Amazon Web Services
  p0 request azure-ad           Entra ID
  p0 request gcloud             Google Cloud
  p0 request okta               Okta
  p0 request ssh <destination>  Secure Shell (SSH) session
  p0 request workspace          Google Workspace

Options:
      --help    Show help                                              [boolean]
      --reason  Reason access is needed                                 [string]
  -w, --wait    Block until the request is completed                   [boolean]
```
