### PR TITLE
Sudo access

### DIFF
--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -165,7 +165,7 @@ const ssh = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
         args.destination,
         "--provider",
         "aws",
-        ...(args.sudo ? ["--sudo"] : []),
+        ...(args.sudo || args.command === "sudo" ? ["--sudo"] : []),
         ...(args.reason ? ["--reason", args.reason] : []),
       ],
       wait: true,


### PR DESCRIPTION
Adds the sudo argument to the access request if either an explicit `--sudo` flag is set or the command begins with `sudo`.