### PR TITLE
SSH: allow numbers to be used as arguments to ssh commands

### DIFF
--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -163,7 +163,7 @@ const commandParameter = (args: SshCommandArgs) =>
           (argument) =>
             // escape all double quotes (") in commands such as `p0 ssh <instance>> echo 'hello; "world"'` because we
             // need to encapsulate command arguments in double quotes as we pass them along to the remote shell
-            `"${argument.toString().replace(/"/g, '\\"')}"`
+            `"${String(argument).replace(/"/g, '\\"')}"`
         )
         .join(" ")}`.trim()
     : undefined;


### PR DESCRIPTION
This PR fixes a problem preventing users from using numbers as arguments e.g. `p0 ssh private-node sleep 10`

```
TypeError: argument.replace is not a function
    at /Users/miguelcampos/src/p0cli/dist/plugins/aws/ssm/index.js:119:18
    at Array.map (<anonymous>)
    at commandParameter (/Users/miguelcampos/src/p0cli/dist/plugins/aws/ssm/index.js:116:10)
    at /Users/miguelcampos/src/p0cli/dist/plugins/aws/ssm/index.js:141:18
    at Generator.next (<anonymous>)
    at fulfilled (/Users/miguelcampos/src/p0cli/dist/plugins/aws/ssm/index.js:5:58)
```