### PR TITLE
WIP: gain ssh access to a group of nodes in one approval

### DIFF
--- a/src/commands/__tests__/request.test.ts
+++ b/src/commands/__tests__/request.test.ts
@@ -31,7 +31,7 @@ describe("request", () => {
   describe("when valid request command", () => {
     const command = "request gcloud role viewer";
 
-    function mockFetch(response?: Partial<RequestResponse>) {
+    function mockFetch(response?: Partial<RequestResponse<unknown>>) {
       mockFetchCommand.mockResolvedValue({
         ok: true,
         message: "a message",

--- a/src/commands/request.ts
+++ b/src/commands/request.ts
@@ -92,7 +92,7 @@ const waitForRequest = async (
     }, WAIT_TIMEOUT);
   });
 
-export const request = async (
+export const request = async <T>(
   args: yargs.ArgumentsCamelCase<{
     arguments: string[];
     wait?: boolean;
@@ -101,10 +101,10 @@ export const request = async (
   options?: {
     message?: "all" | "approval-required" | "none";
   }
-): Promise<RequestResponse | undefined> => {
+): Promise<RequestResponse<T> | undefined> => {
   const resolvedAuthn = authn ?? (await authenticate());
   const { userCredential } = resolvedAuthn;
-  const data = await fetchCommand<RequestResponse>(resolvedAuthn, args, [
+  const data = await fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
     "request",
     ...args.arguments,
   ]);

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -168,6 +168,7 @@ const ssh = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
       ...pick(args, "$0", "_"),
       arguments: [
         "ssh",
+        "session",
         args.destination,
         "--provider",
         "aws",

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -163,8 +163,7 @@ const ssh = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
   // Prefix is required because the backend uses it to determine that this is an AWS request
   const authn = await authenticate();
   await validateSshInstall(authn);
-  console.log("making request");
-  const response = await request(
+  const response = await request<AwsSsh>(
     {
       ...pick(args, "$0", "_"),
       arguments: [
@@ -185,22 +184,13 @@ const ssh = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
     print2("Did not receive access ID from server");
     return;
   }
-  // If preexisting, you don't get an id because you don't need to wait for access
-  const { id, arn, isPreexisting } = response;
+
+  const { id, isPreexisting, event } = response;
   if (!isPreexisting) print2("Waiting for access to be provisioned");
 
-  // if isPreexisting is true, we don't have to wait for the access.
-  // otherwise we can wait for provisioning.
-  console.log("Waiting for access to be provisioned", JSON.stringify(response));
-  // TODO the arn might have.
   const requestData = await waitForProvisioning<AwsSsh>(authn, id);
-  const requestWithId = { ...requestData, id };
+  // When access to a node is provided based on group membership, the resource request will not include a specific instance arn. We will need to use the original request's resource arn to connect to the correct instance.
+  const requestWithId = { ...requestData, id, permission: event.permission };
 
-  // split up the arn and pass it to SSM.
-
-  const match = arn.match(INSTANCE_ARN_PATTERN);
-  if (!match) throw "Did not receive a properly formatted instance identifier";
-  const [, region, account, instance] = match;
-
-  await ssm(authn, region, account, instance, args);
+  await ssm(authn, requestWithId, args);
 };

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -367,7 +367,8 @@ export const ssm = async (
   if (!isInstalled)
     throw "Please try again after installing the required AWS utilities";
 
-  const match = request.permission.spec.arn.match(INSTANCE_ARN_PATTERN);
+  const match =
+    request.permission.spec.resource.arn.match(INSTANCE_ARN_PATTERN);
   if (!match) throw "Did not receive a properly formatted instance identifier";
   const [, region, account, instance] = match;
 

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -358,7 +358,6 @@ const commandParameter = (args: SshCommandArgs) =>
 /** Connect to an SSH backend using AWS Systems Manager (SSM) */
 export const ssm = async (
   authn: Authn,
-  // region, account, instance
   request: Request<AwsSsh> & {
     id: string;
   },
@@ -367,9 +366,8 @@ export const ssm = async (
   const isInstalled = await ensureSsmInstall();
   if (!isInstalled)
     throw "Please try again after installing the required AWS utilities";
-
-  // TODO: break
-  const match = request.permission.spec.arn.match(INSTANCE_ARN_PATTERN);
+  const match =
+    request.permission.spec.resource.arn.match(INSTANCE_ARN_PATTERN);
   if (!match) throw "Did not receive a properly formatted instance identifier";
   const [, region, account, instance] = match;
 
@@ -419,6 +417,5 @@ const startSsmProcesses = async (
     );
   }
 
-  console.log("executing commands", commands);
   await Promise.all(processes);
 };

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -358,6 +358,7 @@ const commandParameter = (args: SshCommandArgs) =>
 /** Connect to an SSH backend using AWS Systems Manager (SSM) */
 export const ssm = async (
   authn: Authn,
+  // region, account, instance
   request: Request<AwsSsh> & {
     id: string;
   },
@@ -367,8 +368,8 @@ export const ssm = async (
   if (!isInstalled)
     throw "Please try again after installing the required AWS utilities";
 
-  const match =
-    request.permission.spec.resource.arn.match(INSTANCE_ARN_PATTERN);
+  // TODO: break
+  const match = request.permission.spec.arn.match(INSTANCE_ARN_PATTERN);
   if (!match) throw "Did not receive a properly formatted instance identifier";
   const [, region, account, instance] = match;
 
@@ -418,5 +419,6 @@ const startSsmProcesses = async (
     );
   }
 
+  console.log("executing commands", commands);
   await Promise.all(processes);
 };

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -46,7 +46,9 @@ export type AwsConfig = {
 export type AwsSsh = {
   permission: {
     spec: {
-      arn: string;
+      resource: {
+        arn: string;
+      };
     };
     type: "session";
   };

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -46,7 +46,10 @@ export type AwsConfig = {
 export type AwsSsh = {
   permission: {
     spec: {
-      arn: string;
+      resource: {
+        arn: string;
+        type: "arn";
+      };
     };
     type: "session";
   };

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -46,10 +46,7 @@ export type AwsConfig = {
 export type AwsSsh = {
   permission: {
     spec: {
-      resource: {
-        arn: string;
-        type: "arn";
-      };
+      arn: string;
     };
     type: "session";
   };

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -31,10 +31,11 @@ export type Request<P extends PluginRequest = { permission: object }> = {
   principal: string;
 };
 
-export type RequestResponse = {
+export type RequestResponse<T> = {
   ok: true;
   message: string;
   id: string;
+  event: T;
   isPreexisting: boolean;
   isPersistent: boolean;
 };


### PR DESCRIPTION
This PR adds support for providing SSH access to a group of nodes. It implements the following methods:

```
p0 request ssh group <group-id>

p0 ls ssh group <group-id>
```