### PR TITLE
Update ssh session cli command

### DIFF
--- a/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
+++ b/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
@@ -7,6 +7,7 @@ exports[`ssh ephemeral access should call p0 request with reason arg: args 1`] =
   ],
   "arguments": [
     "ssh",
+    "session",
     "some-instance",
     "--provider",
     "aws",
@@ -41,6 +42,7 @@ exports[`ssh persistent access should call p0 request with reason arg: args 1`] 
   ],
   "arguments": [
     "ssh",
+    "session",
     "some-instance",
     "--provider",
     "aws",

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -168,6 +168,7 @@ const ssh = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
       ...pick(args, "$0", "_"),
       arguments: [
         "ssh",
+        "session",
         args.destination,
         "--provider",
         "aws",


### PR DESCRIPTION
This PR updates the ssh session cli command from `ssh <destination> --provider ...` to `ssh session <destination> --provider ...`

This is required due to changes from https://github.com/p0-security/app/pull/1514