### PR TITLE
Add support for p0 request ssh group <name>

### DIFF
--- a/src/commands/__tests__/request.test.ts
+++ b/src/commands/__tests__/request.test.ts
@@ -31,7 +31,7 @@ describe("request", () => {
   describe("when valid request command", () => {
     const command = "request gcloud role viewer";
 
-    function mockFetch(response?: Partial<RequestResponse>) {
+    function mockFetch(response?: Partial<RequestResponse<unknown>>) {
       mockFetchCommand.mockResolvedValue({
         ok: true,
         message: "a message",

--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -55,6 +55,19 @@ describe("ssh", () => {
         id: "abcefg",
         isPreexisting: false,
         isPersistent,
+        event: {
+          permission: {
+            type: "session",
+            spec: {
+              resource: {
+                arn: "arn:aws:ec2:us-west-2:391052057035:instance/i-0b1b7b7b7b7b7b7b7",
+              },
+            },
+          },
+          generated: {
+            documentName: "documentName",
+          },
+        },
       });
     });
 

--- a/src/commands/request.ts
+++ b/src/commands/request.ts
@@ -92,7 +92,7 @@ const waitForRequest = async (
     }, WAIT_TIMEOUT);
   });
 
-export const request = async (
+export const request = async <T>(
   args: yargs.ArgumentsCamelCase<{
     arguments: string[];
     wait?: boolean;
@@ -101,10 +101,10 @@ export const request = async (
   options?: {
     message?: "all" | "approval-required" | "none";
   }
-): Promise<RequestResponse | undefined> => {
+): Promise<RequestResponse<T> | undefined> => {
   const resolvedAuthn = authn ?? (await authenticate());
   const { userCredential } = resolvedAuthn;
-  const data = await fetchCommand<RequestResponse>(resolvedAuthn, args, [
+  const data = await fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
     "request",
     ...args.arguments,
   ]);

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -367,7 +367,8 @@ export const ssm = async (
   if (!isInstalled)
     throw "Please try again after installing the required AWS utilities";
 
-  const match = request.permission.spec.arn.match(INSTANCE_ARN_PATTERN);
+  const match =
+    request.permission.spec.resource.arn.match(INSTANCE_ARN_PATTERN);
   if (!match) throw "Did not receive a properly formatted instance identifier";
   const [, region, account, instance] = match;
 

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -368,7 +368,9 @@ export const ssm = async (
     throw "Please try again after installing the required AWS utilities";
 
   const match =
-    request.permission.spec.resource.arn.match(INSTANCE_ARN_PATTERN);
+    request.permission.spec.awsResourcePermission.resource.arn.match(
+      INSTANCE_ARN_PATTERN
+    );
   if (!match) throw "Did not receive a properly formatted instance identifier";
   const [, region, account, instance] = match;
 

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -46,8 +46,10 @@ export type AwsConfig = {
 export type AwsSsh = {
   permission: {
     spec: {
-      resource: {
-        arn: string;
+      awsResourcePermission: {
+        resource: {
+          arn: string;
+        };
       };
     };
     type: "session";

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -46,7 +46,9 @@ export type AwsConfig = {
 export type AwsSsh = {
   permission: {
     spec: {
-      arn: string;
+      resource: {
+        arn: string;
+      };
     };
     type: "session";
   };

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -31,10 +31,11 @@ export type Request<P extends PluginRequest = { permission: object }> = {
   principal: string;
 };
 
-export type RequestResponse = {
+export type RequestResponse<T> = {
   ok: true;
   message: string;
   id: string;
+  event: T;
   isPreexisting: boolean;
   isPersistent: boolean;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,14 +4610,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.5.3, semver@^7.5.4:
-  version "7.6.0"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz"
-  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.6.0:
+semver@^7.0.0, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==


### PR DESCRIPTION
In a [different PR for our app](https://github.com/p0-security/app/pull/1526) the permission spec for `ssh sessions` has changed. This change was required to support requesting access to a group of nodes.