### PR TITLE
Change ssh instance ls display to use instance ids instead of full arn

### DIFF
--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -12,7 +12,7 @@ import { fetchCommand } from "../drivers/api";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
 import { print2, print1, Ansi } from "../drivers/stdio";
-import { max, isEqual} from "lodash";
+import { max, isEqual } from "lodash";
 import pluralize from "pluralize";
 import yargs from "yargs";
 
@@ -41,14 +41,13 @@ export const lsCommand = (yargs: yargs.Argv) =>
     guard(ls)
   );
 
-
 /** Applies any command-specific formatting to the p0 ls display */
-const displayLsResource = (args: string[], key: string) => 
-{
-  if (isEqual(args, ["ssh", "session", "destination"])) return key.split("/")[1] ?? key
+const displayLsResource = (args: string[], key: string) => {
+  if (isEqual(args, ["ssh", "session", "destination"]))
+    return key.split("/")[1] ?? key;
 
-  return key
-}
+  return key;
+};
 const ls = async (
   args: yargs.ArgumentsCamelCase<{
     arguments: string[];
@@ -81,7 +80,7 @@ const ls = async (
     const maxLength = max(data.items.map((i) => i.key.length)) || 0;
     for (const item of data.items) {
       const tagPart = `${item.group ? `${item.group} / ` : ""}${item.value}`;
-      const displayedItem = displayLsResource(args.arguments, item.key)
+      const displayedItem = displayLsResource(args.arguments, item.key);
       print1(
         isSameValue
           ? displayedItem


### PR DESCRIPTION

The other info in the ARN is redundant since it's already available from the "group"

<img width="515" alt="image" src="https://github.com/p0-security/p0cli/assets/117865035/f2018709-f7c0-45c5-a4cb-ffaeef929276">
