### PR TITLE
Fix version command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,7 +15,6 @@ import { loginCommand } from "./login";
 import { lsCommand } from "./ls";
 import { requestCommand } from "./request";
 import { sshCommand } from "./ssh";
-import { VERSION } from "lodash";
 import { sys } from "typescript";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -32,7 +31,6 @@ export const cli = commands
   .reduce((m, c) => c(m), yargs(hideBin(process.argv)))
   .middleware(checkVersion)
   .strict()
-  .version(VERSION)
   .demandCommand(1)
   .fail((message, error, yargs) => {
     if (error) print2(error);


### PR DESCRIPTION
This was accidentally hard-coded to the lodash version. Instead use the package.json version (this is the yargs default, so we get this behavior merely by deleting existing code).