### PR TITLE
Add support for the --account argument to p0 ssh

### DIFF
--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -35,6 +35,7 @@ export type SshCommandArgs = {
   arguments: string[];
   sudo?: boolean;
   reason?: string;
+  account?: string;
 };
 
 // Matches strings with the pattern "digits:digits" (e.g. 1234:5678)
@@ -92,6 +93,10 @@ export const sshCommand = (yargs: yargs.Argv) =>
         .option("reason", {
           describe: "Reason access is needed",
           type: "string",
+        })
+        .option("account", {
+          type: "string",
+          describe: "The account on which the instance is located",
         }),
     guard(ssh)
   );
@@ -174,6 +179,7 @@ const ssh = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
         "aws",
         ...(args.sudo || args.command === "sudo" ? ["--sudo"] : []),
         ...(args.reason ? ["--reason", args.reason] : []),
+        ...(args.account ? ["--account", args.account] : []),
       ],
       wait: true,
     },


### PR DESCRIPTION
When a user has multiple AWS accounts configured they are unable to disambiguate the destination themselves using `--account` because it is not currently implemented.

### Problem
Make the request: `p0 ssh <destination> with multiple accounts.

![image](https://github.com/p0-security/p0cli/assets/12995427/8d57dd75-358f-41f2-a0d7-163833f044b4)

The CLI tells the user to use `--account` argument, but this argument is not supported.