### PR TITLE
Set AWS_SECURITY_TOKEN environment variable

### DIFF
--- a/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
+++ b/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
@@ -21,7 +21,8 @@ exports[`aws role a single installed account with Okta SAML assume should assume
   [
     "  export AWS_ACCESS_KEY_ID=test-access-key
   export AWS_SECRET_ACCESS_KEY=secret-access-key
-  export AWS_SESSION_TOKEN=session-token",
+  export AWS_SESSION_TOKEN=session-token
+  export AWS_SECURITY_TOKEN=session-token",
   ],
 ]
 `;

--- a/src/plugins/aws/__mocks__/assumeRole.ts
+++ b/src/plugins/aws/__mocks__/assumeRole.ts
@@ -14,4 +14,5 @@ export const assumeRoleWithSaml = async (): Promise<AwsCredentials> => ({
   AWS_ACCESS_KEY_ID: "test-access-key-id",
   AWS_SECRET_ACCESS_KEY: "test-secret-access-key",
   AWS_SESSION_TOKEN: "test-session-token",
+  AWS_SECURITY_TOKEN: "test-session-token",
 });

--- a/src/plugins/aws/assumeRole.ts
+++ b/src/plugins/aws/assumeRole.ts
@@ -33,6 +33,7 @@ const stsAssume = async (
     AWS_ACCESS_KEY_ID: stsCredentials.AccessKeyId,
     AWS_SECRET_ACCESS_KEY: stsCredentials.SecretAccessKey,
     AWS_SESSION_TOKEN: stsCredentials.SessionToken,
+    AWS_SECURITY_TOKEN: stsCredentials.SessionToken,
   };
 };
 

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -12,6 +12,8 @@ export type AwsCredentials = {
   AWS_ACCESS_KEY_ID: string;
   AWS_SECRET_ACCESS_KEY: string;
   AWS_SESSION_TOKEN: string;
+  // AWS_SECURITY_TOKEN is the legacy version of AWS_SESSION_TOKEN. It does seem to take precedence over AWS_SESSION_TOKEN. The okta-aws-cli sets both: https://github.com/okta/okta-aws-cli/blob/f1e09eab509e295a7e7b3002d14f2a96b8c60914/internal/output/envvar.go#L49L63
+  AWS_SECURITY_TOKEN: string;
 };
 
 export type AwsIamLogin = {


### PR DESCRIPTION
`AWS_SECURITY_TOKEN` is the legacy version of `AWS_SESSION_TOKEN`. 

It does seem to take precedence over `AWS_SESSION_TOKEN`. 

The okta-aws-cli sets both: https://github.com/okta/okta-aws-cli/blob/f1e09eab509e295a7e7b3002d14f2a96b8c60914/internal/output/envvar.go#L49L63

This causes an issue where if someone uses the okta-aws-cli to log in and then uses p0, the environment variables end up in  an inconsistent state.