### PR TITLE
SCP command for copying from local to remote

### DIFF
--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -10,7 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { fetchCommand } from "../../drivers/api";
 import { print1, print2 } from "../../drivers/stdio";
-import { ssm } from "../../plugins/aws/ssm";
+import { ssmSsh } from "../../plugins/aws/ssm/ssh";
 import { mockGetDoc } from "../../testing/firestore";
 import { sleep } from "../../util";
 import { sshCommand } from "../ssh";
@@ -21,10 +21,10 @@ import yargs from "yargs";
 jest.mock("../../drivers/api");
 jest.mock("../../drivers/auth");
 jest.mock("../../drivers/stdio");
-jest.mock("../../plugins/aws/ssm");
+jest.mock("../../plugins/aws/ssm/ssh");
 
 const mockFetchCommand = fetchCommand as jest.Mock;
-const mockSsm = ssm as jest.Mock;
+const mockSsm = ssmSsh as jest.Mock;
 const mockPrint1 = print1 as jest.Mock;
 const mockPrint2 = print2 as jest.Mock;
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@ import { awsCommand } from "./aws";
 import { loginCommand } from "./login";
 import { lsCommand } from "./ls";
 import { requestCommand } from "./request";
+import { scpCommand } from "./scp";
 import { sshCommand } from "./ssh";
 import { sys } from "typescript";
 import yargs from "yargs";
@@ -25,6 +26,7 @@ const commands = [
   lsCommand,
   requestCommand,
   sshCommand,
+  scpCommand,
 ];
 
 export const cli = commands

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -1,0 +1,87 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { guard } from "../drivers/firestore";
+import { print2 } from "../drivers/stdio";
+import { sshRequest } from "../plugins/aws/ssm/request";
+import { detectPathType, ssmScpLocalToRemote } from "../plugins/aws/ssm/scp";
+import { ScpCommandArgs } from "./types";
+import yargs from "yargs";
+
+const PORT_PATTERN = /^\d+$/;
+
+export const scpCommand = (yargs: yargs.Argv) =>
+  yargs.command<ScpCommandArgs>(
+    "scp <source> <destination>",
+    'Securely copy files to remote machine. The source and destination may be specified as a local pathname, a remote host with optional path in the form host:[path], or a URI in the form scp://host[:port][/path]. Local file names can be made explicit using absolute or relative pathnames to avoid scp treating file names containing ":" as host specifiers.',
+    (yargs) =>
+      yargs
+        .positional("source", {
+          type: "string",
+          demandOption: true,
+        })
+        .positional("destination", {
+          type: "string",
+          demandOption: true,
+        })
+        .check((argv: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
+          if (argv.port == null) return true;
+          return argv.port.match(PORT_PATTERN) || "Port must be a number";
+        })
+        .option("port", {
+          type: "string",
+          alias: "P",
+          describe:
+            "The port to set up port-forwarding. It is used both on the local and remote machine.",
+        })
+        .option("sudo", {
+          type: "boolean",
+          describe: "Add user to sudoers file",
+        })
+        .option("reason", {
+          describe: "Reason access is needed",
+          type: "string",
+        })
+        .option("account", {
+          type: "string",
+          describe: "The account on which the instance is located",
+        }),
+    guard(scp)
+  );
+
+const scp = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
+  const source = args.source;
+  const destination = args.destination;
+  const sourcePath = detectPathType(source);
+  const destinationPath = detectPathType(destination);
+
+  // TODO support remote to local
+  if (sourcePath.type !== "local" || destinationPath.type !== "remote") {
+    print2(
+      `Source must be local and destination must be remote. Got: source is ${sourcePath.type} and destination is ${destinationPath.type}.`
+    );
+    return;
+  }
+
+  const baseArgs = { ...args, destination: destinationPath.host };
+
+  const response = await sshRequest(baseArgs);
+  if (!response) return;
+
+  const { authn, requestWithId } = response;
+
+  await ssmScpLocalToRemote(
+    authn,
+    requestWithId,
+    args,
+    sourcePath,
+    destinationPath
+  );
+};

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -8,43 +8,14 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { authenticate } from "../drivers/auth";
-import { doc, guard } from "../drivers/firestore";
-import { print2 } from "../drivers/stdio";
-import { ssm } from "../plugins/aws/ssm";
-import { AwsSsh } from "../plugins/aws/types";
-import { SshConfig } from "../plugins/ssh/types";
-import { Authn } from "../types/identity";
-import {
-  DENIED_STATUSES,
-  DONE_STATUSES,
-  ERROR_STATUSES,
-  PluginRequest,
-  Request,
-} from "../types/request";
-import { request } from "./request";
-import { getDoc, onSnapshot } from "firebase/firestore";
-import { pick } from "lodash";
+import { guard } from "../drivers/firestore";
+import { sshRequest } from "../plugins/aws/ssm/request";
+import { ssmSsh } from "../plugins/aws/ssm/ssh";
+import { SshCommandArgs } from "./types";
 import yargs from "yargs";
-
-export type SshCommandArgs = {
-  destination: string;
-  command?: string;
-  L?: string; // Port forwarding option
-  N?: boolean; // No remote command
-  arguments: string[];
-  sudo?: boolean;
-  reason?: string;
-  account?: string;
-};
 
 // Matches strings with the pattern "digits:digits" (e.g. 1234:5678)
 const LOCAL_PORT_FORWARD_PATTERN = /^\d+:\d+$/;
-
-/** Maximum amount of time to wait after access is approved to wait for access
- *  to be configured
- */
-const GRANT_TIMEOUT_MILLIS = 60e3;
 
 export const sshCommand = (yargs: yargs.Argv) =>
   yargs.command<SshCommandArgs>(
@@ -101,62 +72,6 @@ export const sshCommand = (yargs: yargs.Argv) =>
     guard(ssh)
   );
 
-const validateSshInstall = async (authn: Authn) => {
-  const configDoc = await getDoc<SshConfig, object>(
-    doc(`o/${authn.identity.org.tenantId}/integrations/ssh`)
-  );
-  const configItems = configDoc.data()?.["iam-write"];
-
-  const items = Object.entries(configItems ?? {}).filter(
-    ([key, value]) => value.state == "installed" && key.startsWith("aws")
-  );
-  if (items.length === 0) {
-    throw "This organization is not configured for SSH access via the P0 CLI";
-  }
-};
-
-// TODO: Move this to a shared utility
-/** Waits until P0 grants access for a request */
-const waitForProvisioning = async <P extends PluginRequest>(
-  authn: Authn,
-  requestId: string
-) => {
-  let cancel: NodeJS.Timeout | undefined = undefined;
-  const result = await new Promise<Request<P>>((resolve, reject) => {
-    let isResolved = false;
-    const unsubscribe = onSnapshot<Request<P>, object>(
-      doc(`o/${authn.identity.org.tenantId}/permission-requests/${requestId}`),
-      (snap) => {
-        const data = snap.data();
-        if (!data) return;
-        if (DONE_STATUSES.includes(data.status as any)) {
-          resolve(data);
-        } else if (DENIED_STATUSES.includes(data.status as any)) {
-          reject("Your access request was denied");
-        } else if (ERROR_STATUSES.includes(data.status as any)) {
-          reject(
-            "Your access request encountered an error (see Slack for details)"
-          );
-        } else {
-          return;
-        }
-        isResolved = true;
-        unsubscribe();
-      }
-    );
-    // Skip timeout in test; it holds a ref longer than the test lasts
-    if (process.env.NODE_ENV === "test") return;
-    cancel = setTimeout(() => {
-      if (!isResolved) {
-        unsubscribe();
-        reject("Timeout awaiting SSH access grant");
-      }
-    }, GRANT_TIMEOUT_MILLIS);
-  });
-  clearTimeout(cancel);
-  return result;
-};
-
 /** Connect to an SSH backend
  *
  * Implicitly gains access to the SSH resource if required.
@@ -165,48 +80,10 @@ const waitForProvisioning = async <P extends PluginRequest>(
  * - AWS EC2 via SSM with Okta SAML
  */
 const ssh = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
-  // Prefix is required because the backend uses it to determine that this is an AWS request
-  const authn = await authenticate();
-  await validateSshInstall(authn);
-  const response = await request<AwsSsh>(
-    {
-      ...pick(args, "$0", "_"),
-      arguments: [
-        "ssh",
-        "session",
-        args.destination,
-        "--provider",
-        "aws",
-        ...(args.sudo || args.command === "sudo" ? ["--sudo"] : []),
-        ...(args.reason ? ["--reason", args.reason] : []),
-        ...(args.account ? ["--account", args.account] : []),
-      ],
-      wait: true,
-    },
-    authn,
-    { message: "approval-required" }
-  );
-  if (!response) {
-    print2("Did not receive access ID from server");
-    return;
-  }
-  const { id, isPreexisting, event } = response;
-  if (!isPreexisting) print2("Waiting for access to be provisioned");
+  const response = await sshRequest(args);
+  if (!response) return;
 
-  /**
-   * TODO TECH-DEBT ENG-1813:
-   * We use the id and waitForProvisioning to find the permission request document which has
-   * critical data, such as the document name and generated role, that we need to build up a
-   * viable SSM request.
-   *
-   * Replacing the permission with event.permission is necessary when trying to connect to an
-   * instance which has been granted approval through it's group. The event.permission object
-   * will contain details about the specific instance we are trying to connect to such as the
-   * instance id. Without an instance id, which an SSH group permission request document does
-   * not contain we cannot construct a valid SSM command.
-   */
-  const requestData = await waitForProvisioning<AwsSsh>(authn, id);
-  const requestWithId = { ...requestData, id, permission: event.permission };
+  const { authn, requestWithId } = response;
 
-  await ssm(authn, requestWithId, args);
+  await ssmSsh(authn, requestWithId, args);
 };

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,28 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+export type BaseSshCommandArgs = {
+  destination: string;
+  sudo?: boolean;
+  reason?: string;
+  account?: string;
+};
+
+export type SshCommandArgs = BaseSshCommandArgs & {
+  command?: string;
+  L?: string; // Port forwarding option
+  N?: boolean; // No remote command
+  arguments: string[];
+};
+
+export type ScpCommandArgs = BaseSshCommandArgs & {
+  source: string;
+  port?: string;
+};

--- a/src/plugins/aws/ssm/__tests__/scp.test.ts
+++ b/src/plugins/aws/ssm/__tests__/scp.test.ts
@@ -1,0 +1,180 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import {
+  detectPathType,
+  isExplicitlyLocal,
+  isRemoteWithColon,
+  isRemoteWithUri,
+} from "../scp";
+
+describe("Path", () => {
+  describe.each([
+    [
+      "path/to/file.zip",
+      false,
+      { isMatch: false },
+      { isMatch: false },
+      { type: "local", path: "path/to/file.zip" },
+    ],
+    [
+      "/path/to/file.zip",
+      true,
+      { isMatch: false },
+      { isMatch: false },
+      { type: "local", path: "/path/to/file.zip" },
+    ],
+    [
+      "./path/to/file.zip",
+      true,
+      { isMatch: false },
+      { isMatch: false },
+      { type: "local", path: "./path/to/file.zip" },
+    ],
+    [
+      "../path/to/file.zip",
+      true,
+      { isMatch: false },
+      { isMatch: false },
+      { type: "local", path: "../path/to/file.zip" },
+    ],
+    [
+      "host:/path/to/file.zip",
+      false,
+      { isMatch: true, host: "host:", path: "/path/to/file.zip" },
+      { isMatch: false },
+      { type: "remote", host: "host", path: "/path/to/file.zip" },
+    ],
+    [
+      "host:/path/to:file.zip",
+      false,
+      { isMatch: true, host: "host:", path: "/path/to:file.zip" },
+      { isMatch: false },
+      { type: "remote", host: "host", path: "/path/to:file.zip" },
+    ],
+    [
+      "host:path/to/file.zip",
+      false,
+      { isMatch: true, host: "host:", path: "path/to/file.zip" },
+      { isMatch: false },
+      { type: "remote", host: "host", path: "path/to/file.zip" },
+    ],
+    [
+      "host:file.zip",
+      false,
+      { isMatch: true, host: "host:", path: "file.zip" },
+      { isMatch: false },
+      { type: "remote", host: "host", path: "file.zip" },
+    ],
+    [
+      "host:",
+      false,
+      { isMatch: true, host: "host:", path: "" },
+      { isMatch: false },
+      { type: "remote", host: "host", path: "" },
+    ],
+    [
+      "/path/with:colon/file.zip",
+      true,
+      { isMatch: true, host: "/path/with:", path: "colon/file.zip" },
+      { isMatch: false },
+      { type: "local", path: "/path/with:colon/file.zip" },
+    ],
+    [
+      "./path/with:colon/file.zip",
+      true,
+      { isMatch: true, host: "./path/with:", path: "colon/file.zip" },
+      { isMatch: false },
+      { type: "local", path: "./path/with:colon/file.zip" },
+    ],
+    [
+      "../path/with:colon/file.zip",
+      true,
+      { isMatch: true, host: "../path/with:", path: "colon/file.zip" },
+      { isMatch: false },
+      { type: "local", path: "../path/with:colon/file.zip" },
+    ],
+    [
+      "scp://host:1234/path/to/file.zip",
+      false,
+      { isMatch: false },
+      { isMatch: true, host: "host", port: ":1234", path: "/path/to/file.zip" },
+      { type: "remote", host: "host", port: "1234", path: "/path/to/file.zip" },
+    ],
+    [
+      "scp://host:/path/to/file.zip",
+      false,
+      { isMatch: false },
+      { isMatch: true, host: "host", port: ":", path: "/path/to/file.zip" },
+      { type: "remote", host: "host", port: "", path: "/path/to/file.zip" },
+    ],
+    [
+      "scp://host:path/to/file.zip",
+      false,
+      { isMatch: false },
+      { isMatch: true, host: "host", port: ":", path: "path/to/file.zip" },
+      { type: "remote", host: "host", port: "", path: "path/to/file.zip" },
+    ],
+    [
+      "scp://host/path/to/file.zip",
+      false,
+      { isMatch: false },
+      { isMatch: true, host: "host", port: "", path: "/path/to/file.zip" },
+      { type: "remote", host: "host", port: "", path: "/path/to/file.zip" },
+    ],
+    [
+      "scp://host",
+      false,
+      { isMatch: false },
+      { isMatch: true, host: "host", port: "", path: "" },
+      { type: "remote", host: "host", port: "", path: "" },
+    ],
+    [
+      "scp://host:",
+      false,
+      { isMatch: false },
+      { isMatch: true, host: "host", port: ":", path: "" },
+      { type: "remote", host: "host", port: "", path: "" },
+    ],
+    [
+      "scp://host/",
+      false,
+      { isMatch: false },
+      { isMatch: true, host: "host", port: "", path: "/" },
+      { type: "remote", host: "host", port: "", path: "/" },
+    ],
+  ])(
+    "%s should match expectation",
+    (
+      path,
+      expectedIsLocal,
+      expectedIsRemoteWithColon,
+      expectedIsRemoteWithUri,
+      expectedPathType
+    ) => {
+      it("when tested for isExplicitlyLocal", () => {
+        const result = isExplicitlyLocal(path);
+        expect(result).toEqual(expectedIsLocal);
+      });
+      it("when tested for isRemoteWithColon", () => {
+        const result = isRemoteWithColon(path);
+        expect(result).toEqual(expectedIsRemoteWithColon);
+      });
+      it("when tested for isRemoteWithUri", () => {
+        const result = isRemoteWithUri(path);
+        expect(result).toEqual(expectedIsRemoteWithUri);
+      });
+      it("when tested for detectPathType", () => {
+        const result = detectPathType(path);
+        expect(result).toEqual(expectedPathType);
+      });
+    }
+  );
+});

--- a/src/plugins/aws/ssm/net.ts
+++ b/src/plugins/aws/ssm/net.ts
@@ -1,0 +1,73 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import fs from "node:fs";
+import net from "node:net";
+
+const CONNECT_TIMEOUT_MS = 10000;
+const RETRY_DELAY_MS = 250;
+const MAX_ATTEMPTS = 60000 / RETRY_DELAY_MS; // Try for one minute
+
+type SendFileOptions = {
+  fileToSend: string;
+  port: string;
+  attemptsRemaining?: number;
+};
+
+/**
+ * Writes a file to a port on localhost.
+ *
+ * Waits until the port is open by retrying  after a brief delay if the connection is refused.
+ */
+export const waitForLocalPortAndWriteFile = (
+  options: SendFileOptions
+): Promise<number | null> =>
+  new Promise((resolve, reject) => {
+    // TODO: read and write the file in chunks
+    const data = fs.readFileSync(options.fileToSend);
+
+    const client = net.createConnection(
+      {
+        timeout: CONNECT_TIMEOUT_MS,
+        port: Number(options.port),
+        host: "127.0.0.1",
+      },
+      () => {}
+    );
+
+    client.on("ready", () => {
+      client.write(data);
+      client.end();
+    });
+
+    client.on("error", (error) => {
+      if ((error as any).code === "ECONNREFUSED") {
+        const attemptsRemaining = options.attemptsRemaining || MAX_ATTEMPTS;
+        if (attemptsRemaining > 0) {
+          setTimeout(() => {
+            waitForLocalPortAndWriteFile({
+              ...options,
+              attemptsRemaining: attemptsRemaining - 1,
+            })
+              .then(resolve)
+              .catch(reject);
+          }, RETRY_DELAY_MS);
+        } else {
+          reject(error);
+        }
+      } else {
+        reject(error);
+      }
+    });
+
+    client.on("close", () => {
+      resolve(0);
+    });
+  });

--- a/src/plugins/aws/ssm/request.ts
+++ b/src/plugins/aws/ssm/request.ts
@@ -1,0 +1,138 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { request } from "../../../commands/request";
+import { BaseSshCommandArgs } from "../../../commands/types";
+import { authenticate } from "../../../drivers/auth";
+import { doc } from "../../../drivers/firestore";
+import { print2 } from "../../../drivers/stdio";
+import { Authn } from "../../../types/identity";
+import {
+  DENIED_STATUSES,
+  DONE_STATUSES,
+  ERROR_STATUSES,
+  PluginRequest,
+  Request,
+} from "../../../types/request";
+import { SshConfig } from "../../ssh/types";
+import { AwsSsh } from "../types";
+import { getDoc, onSnapshot } from "firebase/firestore";
+import { pick } from "lodash";
+import yargs from "yargs";
+
+/** Maximum amount of time to wait after access is approved to wait for access
+ *  to be configured
+ */
+const GRANT_TIMEOUT_MILLIS = 60e3;
+
+const validateSshInstall = async (authn: Authn) => {
+  const configDoc = await getDoc<SshConfig, object>(
+    doc(`o/${authn.identity.org.tenantId}/integrations/ssh`)
+  );
+  const configItems = configDoc.data()?.["iam-write"];
+
+  const items = Object.entries(configItems ?? {}).filter(
+    ([key, value]) => value.state == "installed" && key.startsWith("aws")
+  );
+  if (items.length === 0) {
+    throw "This organization is not configured for SSH access via the P0 CLI";
+  }
+};
+
+// TODO: Move this to a shared utility
+/** Waits until P0 grants access for a request */
+const waitForProvisioning = async <P extends PluginRequest>(
+  authn: Authn,
+  requestId: string
+) => {
+  let cancel: NodeJS.Timeout | undefined = undefined;
+  const result = await new Promise<Request<P>>((resolve, reject) => {
+    let isResolved = false;
+    const unsubscribe = onSnapshot<Request<P>, object>(
+      doc(`o/${authn.identity.org.tenantId}/permission-requests/${requestId}`),
+      (snap) => {
+        const data = snap.data();
+        if (!data) return;
+        if (DONE_STATUSES.includes(data.status as any)) {
+          resolve(data);
+        } else if (DENIED_STATUSES.includes(data.status as any)) {
+          reject("Your access request was denied");
+        } else if (ERROR_STATUSES.includes(data.status as any)) {
+          reject(
+            "Your access request encountered an error (see Slack for details)"
+          );
+        } else {
+          return;
+        }
+        isResolved = true;
+        unsubscribe();
+      }
+    );
+    // Skip timeout in test; it holds a ref longer than the test lasts
+    if (process.env.NODE_ENV === "test") return;
+    cancel = setTimeout(() => {
+      if (!isResolved) {
+        unsubscribe();
+        reject("Timeout awaiting SSH access grant");
+      }
+    }, GRANT_TIMEOUT_MILLIS);
+  });
+  clearTimeout(cancel);
+  return result;
+};
+
+export const sshRequest = async (
+  args: yargs.ArgumentsCamelCase<BaseSshCommandArgs>
+) => {
+  // Prefix is required because the backend uses it to determine that this is an AWS request
+  const authn = await authenticate();
+  await validateSshInstall(authn);
+  const response = await request<AwsSsh>(
+    {
+      ...pick(args, "$0", "_"),
+      arguments: [
+        "ssh",
+        "session",
+        args.destination,
+        "--provider",
+        "aws",
+        ...(args.sudo || args.command === "sudo" ? ["--sudo"] : []),
+        ...(args.reason ? ["--reason", args.reason] : []),
+        ...(args.account ? ["--account", args.account] : []),
+      ],
+      wait: true,
+    },
+    authn,
+    { message: "approval-required" }
+  );
+  if (!response) {
+    print2("Did not receive access ID from server");
+    return;
+  }
+  const { id, isPreexisting, event } = response;
+  if (!isPreexisting) print2("Waiting for access to be provisioned");
+
+  /**
+   * TODO TECH-DEBT ENG-1813:
+   * We use the id and waitForProvisioning to find the permission request document which has
+   * critical data, such as the document name and generated role, that we need to build up a
+   * viable SSM request.
+   *
+   * Replacing the permission with event.permission is necessary when trying to connect to an
+   * instance which has been granted approval through it's group. The event.permission object
+   * will contain details about the specific instance we are trying to connect to such as the
+   * instance id. Without an instance id, which an SSH group permission request document does
+   * not contain we cannot construct a valid SSM command.
+   */
+  const requestData = await waitForProvisioning<AwsSsh>(authn, id);
+  const requestWithId = { ...requestData, id, permission: event.permission };
+
+  return { authn, requestWithId };
+};

--- a/src/plugins/aws/ssm/scp.ts
+++ b/src/plugins/aws/ssm/scp.ts
@@ -1,0 +1,187 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+
+/** Connect to an SSH backend using AWS Systems Manager (SSM) for copying local files to remote */
+import {
+  SsmArgs,
+  SsmCommands,
+  createInteractiveShellCommand,
+  createPortForwardingCommand,
+  credsAndInstance,
+  startSsmProcesses,
+} from ".";
+import { ScpCommandArgs } from "../../../commands/types";
+import { Authn } from "../../../types/identity";
+import { Request } from "../../../types/request";
+import { AwsSsh } from "../types";
+import { waitForLocalPortAndWriteFile } from "./net";
+
+const DEFAULT_PORT = "28657";
+
+/** An explicit local pattern decidedly marks a path as local. Begins with /, ., or .. followed by any characters */
+const EXPLICIT_LOCAL_PATTERN = /^(\/|\.\/|\.\.\/).*$/;
+
+/** If a path is not explicitly local, use this pattern to determine if it's remote */
+const REMOTE_PATTERN_COLON = /^([^:]+:)(.*)$/; // Matches host:[path]
+
+/** Secondary pattern to to determine whether the path is remote */
+const REMOTE_PATTERN_URI = /^scp:\/\/([^:/]+)(:[0-9]*)?(\/?.*)?$/; // Matches scp://host[:port][/path]
+
+const createSsmCommands = (
+  args: Omit<SsmArgs, "requestId"> &
+    Required<Pick<SsmArgs, "forwardPortAddress">>
+): SsmCommands => {
+  return {
+    subCommands: [
+      createInteractiveShellCommand(args),
+      createPortForwardingCommand(args),
+    ],
+  };
+};
+
+type PathType =
+  | {
+      type: "local";
+      path: string;
+    }
+  | {
+      type: "remote";
+      host: string;
+      path: string;
+      port?: string;
+    };
+
+const rightTrim = (end: string, str?: string) => {
+  if (str === undefined) return str;
+  if (str.endsWith(end)) {
+    return str.slice(0, -end.length);
+  }
+  return str;
+};
+
+const leftTrim = (start: string, str?: string) => {
+  if (str === undefined) return str;
+  if (str.startsWith(start)) {
+    return str.slice(start.length);
+  }
+  return str;
+};
+
+export const isExplicitlyLocal = (path: string) =>
+  EXPLICIT_LOCAL_PATTERN.test(path);
+
+export const isRemoteWithColon = (path: string) => {
+  if (path.startsWith("scp://")) {
+    return {
+      isMatch: false,
+    };
+  }
+  const match = path.match(REMOTE_PATTERN_COLON);
+  if (match !== null && match[1] !== undefined && match[2] !== undefined) {
+    return {
+      isMatch: true,
+      host: match[1],
+      path: match[2],
+    };
+  }
+  return {
+    isMatch: false,
+  };
+};
+
+export const isRemoteWithUri = (path: string) => {
+  const match = path.match(REMOTE_PATTERN_URI);
+  // match[2] and match[3] can be undefined
+  if (match && match[1] !== undefined) {
+    return {
+      isMatch: true,
+      host: match[1],
+      port: match[2] || "",
+      path: match[3] || "",
+    };
+  }
+  return {
+    isMatch: false,
+  };
+};
+
+export const detectPathType = (path: string): PathType => {
+  if (isExplicitlyLocal(path)) {
+    return {
+      type: "local",
+      path,
+    };
+  }
+  const remoteWithColon = isRemoteWithColon(path);
+  if (remoteWithColon.isMatch) {
+    return {
+      type: "remote",
+      host: rightTrim(":", remoteWithColon.host) || "",
+      path: remoteWithColon.path || "",
+    };
+  }
+  const remoteWithUri = isRemoteWithUri(path);
+  if (remoteWithUri.isMatch) {
+    return {
+      type: "remote",
+      host: remoteWithUri.host || "",
+      port: leftTrim(":", remoteWithUri.port),
+      path: remoteWithUri.path || "",
+    };
+  }
+  return {
+    type: "local",
+    path,
+  };
+};
+
+export const ssmScpLocalToRemote = async (
+  authn: Authn,
+  request: Request<AwsSsh> & {
+    id: string;
+  },
+  args: ScpCommandArgs,
+  sourcePath: Extract<PathType, { type: "local" }>,
+  destinationPath: Extract<PathType, { type: "remote" }>
+) => {
+  const port = args.port || destinationPath.port || DEFAULT_PORT;
+  args.destination = destinationPath.host;
+
+  const { credential, region, instance } = await credsAndInstance(
+    authn,
+    request
+  );
+
+  const ssmArgs = {
+    instance: instance!,
+    region: region!,
+    documentName: request.generated.documentName,
+    requestId: request.id,
+    forwardPortAddress: `${port}:${port}`,
+    // The netcat utility must be installed on the remote for this to work.
+    // In non-debian-based systems that have bash we could use the /dev/tcp file descriptor that bash creates.
+    // `-l` Used to specify that nc should listen for an incoming connection rather than initiate a connection to a remote host
+    // `-p` Specifies the source port nc should use, subject to privilege restrictions and availability
+    command: `nc -l -p ${port} > ${destinationPath.path}`,
+  };
+
+  const ssmCommands = createSsmCommands(ssmArgs);
+
+  await Promise.all([
+    startSsmProcesses(credential, ssmCommands),
+    // Note: instead of waiting we could capture when the port is open
+    // and only then write the file. That would require changing how startSsmProcesses works.
+    waitForLocalPortAndWriteFile({
+      fileToSend: sourcePath.path,
+      port,
+    }),
+  ]);
+};

--- a/src/plugins/aws/ssm/ssh.ts
+++ b/src/plugins/aws/ssm/ssh.ts
@@ -1,0 +1,86 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import {
+  SsmArgs,
+  SsmCommands,
+  createInteractiveShellCommand,
+  createPortForwardingCommand,
+  credsAndInstance,
+  startSsmProcesses,
+} from ".";
+import { SshCommandArgs } from "../../../commands/types";
+import { Authn } from "../../../types/identity";
+import { Request } from "../../../types/request";
+import { AwsSsh } from "../types";
+
+/** Convert an SshCommandArgs into an SSM document "command" parameter */
+const commandParameter = (args: SshCommandArgs) =>
+  args.command
+    ? `${args.command} ${args.arguments
+        .map(
+          (argument) =>
+            // escape all double quotes (") in commands such as `p0 ssh <instance>> echo 'hello; "world"'` because we
+            // need to encapsulate command arguments in double quotes as we pass them along to the remote shell
+            `"${String(argument).replace(/"/g, '\\"')}"`
+        )
+        .join(" ")}`.trim()
+    : undefined;
+
+const createSsmCommands = (args: Omit<SsmArgs, "requestId">): SsmCommands => {
+  const interactiveShellCommand = createInteractiveShellCommand(args);
+
+  const forwardPortAddress = args.forwardPortAddress;
+  if (!forwardPortAddress) {
+    return { shellCommand: interactiveShellCommand };
+  }
+
+  const portForwardingCommand = createPortForwardingCommand({
+    ...args,
+    forwardPortAddress,
+  });
+
+  if (args.noRemoteCommands) {
+    return { shellCommand: portForwardingCommand };
+  }
+
+  return {
+    shellCommand: interactiveShellCommand,
+    subCommands: [portForwardingCommand],
+  };
+};
+
+/** Connect to an SSH backend using AWS Systems Manager (SSM) */
+export const ssmSsh = async (
+  authn: Authn,
+  request: Request<AwsSsh> & {
+    id: string;
+  },
+  args: SshCommandArgs
+) => {
+  const { credential, region, instance } = await credsAndInstance(
+    authn,
+    request
+  );
+
+  const ssmArgs = {
+    instance: instance!,
+    region: region!,
+    documentName: request.generated.documentName,
+    requestId: request.id,
+    forwardPortAddress: args.L,
+    noRemoteCommands: args.N,
+    command: commandParameter(args),
+  };
+
+  const ssmCommands = createSsmCommands(ssmArgs);
+
+  await startSsmProcesses(credential, ssmCommands);
+};


### PR DESCRIPTION
Adds `p0 scp <source> <destination>` command to copy a single file from local to remote.

The instance name can be used (while the instance IP cannot):

https://github.com/p0-security/p0cli/assets/5836460/27f47de5-5ce0-4c9a-bb25-5cd95632be6b



We detect if the source / destination args refer to a local or a remote file using the same rules as the real `scp` command, however copying from remote to local is not supported and throws an error.

The implementation uses two ssm subprocesses:
1. Open a port using the AWS-StartPortForwardingSession document
2. Run a non-interactive command `nc -l -p ${port} > ${destination}` on the remote - this waits for the data to arrive on the remote and dumps it into a file

In the local machine a third operation writes the file contents to the specified port. (The same port is used on the local and the remote.) This is done using a TCP socket from the `node:net`package instead of running a local subprocess with netcat.
Reading the file is synchronous and the transfer is not chunked. That will be optimized in a follow-up.

Other things I tried:

- Using a pipe and reading from stdin on the remote
      ```cat configmap.yml.zip | aws ssm start-session --region us-west-2 --target i-043db199de9ac0c53 --document P0SshAsUser-FYEbC0gpZpvigekLuGMe-gergely-danyi --parameters command='cat - > configmap.yml.zip'```
     Unfortunately this doesn't work, likely an issue with how ssm is implemented.
- Real SCP by running a AWS-StartPortForwardingSession document to port 22 of the remote (with a running OpenSSH server). This works but requires a keypair and we do not want to manage keys.

The PR moves some functions for reuse with scp.