### PR TITLE
Do not allow private key to appear in bash history or process logs

### DIFF
--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -507,13 +507,14 @@ export const scp = async (
   });
 
   /**
-   * Spawns a child process to add a private key to the ssh-agent. The SSH agent is included in the OpenSSH suite of tools
-   * and is used to hold private keys during a session. The SSH agent typically does not persist keys across system reboots
-   * or logout/login cycles. Once you log out or restart your system, any keys added to the SSH agent during that session
-   * will need to be added again in subsequent sessions.
+   * Spawns a child process to add a private key to the ssh-agent. The SSH agent is included in the OpenSSH suite
+   * of tools and is used to hold private keys during a session. The SSH agent typically does not persist keys
+   * across system reboots or logout/login cycles. Once you log out or restart your system, any keys added to
+   * the SSH agent during that session will need to be added again in subsequent sessions.
    */
   const writeStdin = [
-    // completely disable bash history for this session
+    // This_might be overkill because we are already spawning a subprocess that will run the commands for us
+    // but just in case someone enters that subprocess we're also disabling the history of commands run.
     `unset HISTFILE`,
     `eval $(ssh-agent) >/dev/null 2>&1`,
     `trap 'kill $SSH_AGENT_PID' EXIT`,

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -513,7 +513,7 @@ export const scp = async (
    * the SSH agent during that session will need to be added again in subsequent sessions.
    */
   const writeStdin = [
-    // This_might be overkill because we are already spawning a subprocess that will run the commands for us
+    // This might be overkill because we are already spawning a subprocess that will run the commands for us
     // but just in case someone enters that subprocess we're also disabling the history of commands run.
     `unset HISTFILE`,
     `eval $(ssh-agent) >/dev/null 2>&1`,


### PR DESCRIPTION
This PR introduces a new method of executing our SCP command. Our previous method accidentally included the ssh key in the name which accidentally revealed the private key. This new method starts a `bash` process and then pipes in the `scp` command through `stdin` preventing the private key from being revealed. We're also unsetting that subcommands history, this should prevent anyone who somehow gains access to that subcommand from searching for the private key in the command history.

## Before The Fix
![image](https://github.com/p0-security/p0cli/assets/12995427/30643c68-c2e4-4b86-a66b-0abb79b7cdfa)

## After The Fix
![image](https://github.com/p0-security/p0cli/assets/12995427/396fd40f-dde1-4ec6-b716-fbf2d5d759d3)
