### PR TITLE
Add debug mode for scp

### DIFF
--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -53,6 +53,10 @@ export const scpCommand = (yargs: yargs.Argv) =>
         .option("sudo", {
           type: "boolean",
           describe: "Add user to sudoers file",
+        })
+        .option("debug", {
+          type: "boolean",
+          describe: "Print debug information, dangerous for sensitive data",
         }),
     guard(scpAction)
   );

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -54,6 +54,7 @@ export type ScpCommandArgs = BaseSshCommandArgs & {
   source: string;
   destination: string;
   recursive?: boolean;
+  debug?: boolean;
 };
 
 export type SshCommandArgs = BaseSshCommandArgs & {

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -553,22 +553,22 @@ export const scp = async (
     `exit $SCP_EXIT_CODE`,
   ];
 
-  // Print commands that can be individually executed to reproduce behavior
-  // Remove the debug information - can be executed manually between steps
-  const reproCommands = without(
-    [
-      "bash",
-      ...Object.entries(process.env).map(
-        ([key, value]) => `export ${key}='${value}'`
-      ),
-      ...Object.entries(credential).map(
-        ([key, value]) => `export ${key}='${value}'`
-      ),
-      ...writeStdin,
-    ],
-    ...debug
-  );
   if (args.debug) {
+    // Print commands that can be individually executed to reproduce behavior
+    // Remove the debug information - can be executed manually between steps
+    const reproCommands = without(
+      [
+        "bash",
+        ...Object.entries(process.env).map(
+          ([key, value]) => `export ${key}='${value}'`
+        ),
+        ...Object.entries(credential).map(
+          ([key, value]) => `export ${key}='${value}'`
+        ),
+        ...writeStdin,
+      ],
+      ...debug
+    );
     print2(
       `Execute the following commands to create a similar SCP session:\n *** COMMANDS BEGIN ***\n${reproCommands.join("\n")}\n *** COMMANDS END ***`
     );


### PR DESCRIPTION
This PR enables a debug mode for SCP that:
- displays information about the `ssh-agent`
- prints the private key that will be used to connect to the requested node.
- provides manual commands to run for local testing.

### Example
**Sample Command**
```
p0 scp 10mb.txt clone-node-2:10mb.txt --debug
```

![image](https://github.com/p0-security/p0cli/assets/12995427/c18f0ed8-6815-40c9-a1ec-286b086af960)
