### PR TITLE
Do not allow user ssh settings to override the identity agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -476,6 +476,9 @@ const createProxyCommands = (
     scp: [
       "scp",
       ...(debug ? ["-v"] : []),
+      // ignore any overrides in the user's config file, we only want to use the ssh-agent we've set up for the session
+      "-o",
+      "IdentityAgent=$SSH_AUTH_SOCK",
       "-o",
       `ProxyCommand='${ssmCommand.join(" ")}'`,
       // if a response is not received after three 5 minute attempts,


### PR DESCRIPTION
Our implementation of scp requires that we spin up a special agent to store ephemeral private keys in. We'll lose access to the local `ssh-agent` if a user overrides the identity agent using their config settings in either `/etc/ssh/ssh_config` or `~/.ssh/config`.

**Example config**
```
Host *
	IdentityAgent "~/X/Y/Z/agent.sock"
```

Command line options have the highest precedence. By adding a `-o` argument we prevent users from overriding this setting.