### PR TITLE
Ping Identity OIDC login

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -13,7 +13,7 @@ import { doc, guard } from "../drivers/firestore";
 import { print2 } from "../drivers/stdio";
 import { pluginLoginMap } from "../plugins/login";
 import { TokenResponse } from "../types/oidc";
-import { OrgData } from "../types/org";
+import { OrgData, RawOrgData } from "../types/org";
 import { getDoc } from "firebase/firestore";
 import * as fs from "fs/promises";
 import * as path from "path";
@@ -28,7 +28,7 @@ export const login = async (
   args: { org: string },
   options?: { skipAuthenticate?: boolean }
 ) => {
-  const orgDoc = await getDoc<Omit<OrgData, "slug">, object>(
+  const orgDoc = await getDoc<RawOrgData, object>(
     doc(`orgs/${args.org}`)
   );
   const orgData = orgDoc.data();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -28,9 +28,7 @@ export const login = async (
   args: { org: string },
   options?: { skipAuthenticate?: boolean }
 ) => {
-  const orgDoc = await getDoc<RawOrgData, object>(
-    doc(`orgs/${args.org}`)
-  );
+  const orgDoc = await getDoc<RawOrgData, object>(doc(`orgs/${args.org}`));
   const orgData = orgDoc.data();
   if (!orgData) throw "Could not find organization";
 

--- a/src/plugins/login.ts
+++ b/src/plugins/login.ts
@@ -12,6 +12,7 @@ import { TokenResponse } from "../types/oidc";
 import { OrgData } from "../types/org";
 import { googleLogin } from "./google/login";
 import { oktaLogin } from "./okta/login";
+import { pingLogin } from "./ping/login";
 
 export const pluginLoginMap: Record<
   string,
@@ -19,5 +20,6 @@ export const pluginLoginMap: Record<
 > = {
   google: googleLogin,
   okta: oktaLogin,
+  ping: pingLogin,
   "oidc-pkce": async (org) => await pluginLoginMap[org.providerType!]!(org),
 };

--- a/src/plugins/oidc/login.ts
+++ b/src/plugins/oidc/login.ts
@@ -20,8 +20,7 @@ import open from "open";
 const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 
 export const validateProviderDomain = (org: OrgData) => {
-  if (!org.providerDomain)
-    throw "Login requires a configured provider domain.";
+  if (!org.providerDomain) throw "Login requires a configured provider domain.";
 };
 
 /** Executes the first step of a device-authorization grant flow */
@@ -41,11 +40,12 @@ const authorize = async (org: OrgData, scope: string) => {
   validateProviderDomain(org);
   // This is the "org" authorization server; the okta.apps.* scopes are not
   // available with custom authorization servers
-  const url = org.providerType === "okta"
-    ? `https:${org.providerDomain}/oauth2/v1/device/authorize`
-    : org.providerType === "ping"
-    ? `https://${org.providerDomain}/${org.environmentId}/as/device_authorization`
-    : throwAssertNever(org.providerType);
+  const url =
+    org.providerType === "okta"
+      ? `https:${org.providerDomain}/oauth2/v1/device/authorize`
+      : org.providerType === "ping"
+        ? `https://${org.providerDomain}/${org.environmentId}/as/device_authorization`
+        : throwAssertNever(org.providerType);
   const response = await fetch(url, init);
   await validateResponse(response);
   return (await response.json()) as AuthorizeResponse;
@@ -71,11 +71,12 @@ const fetchOidcToken = async (org: OrgData, authorize: AuthorizeResponse) => {
     }),
   };
   validateProviderDomain(org);
-  const url = org.providerType === "okta"
-    ? `https:${org.providerDomain}/oauth2/v1/token`
-    : org.providerType === "ping"
-    ? `https://${org.providerDomain}/${org.environmentId}/as/token`
-    : throwAssertNever(org.providerType);
+  const url =
+    org.providerType === "okta"
+      ? `https:${org.providerDomain}/oauth2/v1/token`
+      : org.providerType === "ping"
+        ? `https://${org.providerDomain}/${org.environmentId}/as/token`
+        : throwAssertNever(org.providerType);
   const response = await fetch(url, init);
 
   if (!response.ok) {

--- a/src/plugins/oidc/login.ts
+++ b/src/plugins/oidc/login.ts
@@ -1,0 +1,125 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { OIDC_HEADERS } from "../../common/auth/oidc";
+import { urlEncode, validateResponse } from "../../common/fetch";
+import { print2 } from "../../drivers/stdio";
+import { AuthorizeResponse, TokenResponse } from "../../types/oidc";
+import { OrgData } from "../../types/org";
+import { sleep, throwAssertNever } from "../../util";
+import { capitalize } from "lodash";
+import open from "open";
+
+const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+export const validateProviderDomain = (org: OrgData) => {
+  if (!org.providerDomain)
+    throw "Login requires a configured provider domain.";
+};
+
+/** Executes the first step of a device-authorization grant flow */
+// cf. https://developer.okta.com/docs/guides/device-authorization-grant/main/
+const authorize = async (org: OrgData, scope: string) => {
+  if (org.providerType === undefined) {
+    throw "Login requires a configured provider type.";
+  }
+  const init = {
+    method: "POST",
+    headers: OIDC_HEADERS,
+    body: urlEncode({
+      client_id: org.clientId,
+      scope,
+    }),
+  };
+  validateProviderDomain(org);
+  // This is the "org" authorization server; the okta.apps.* scopes are not
+  // available with custom authorization servers
+  const url = org.providerType === "okta"
+    ? `https:${org.providerDomain}/oauth2/v1/device/authorize`
+    : org.providerType === "ping"
+    ? `https://${org.providerDomain}/${org.environmentId}/as/device_authorization`
+    : throwAssertNever(org.providerType);
+  const response = await fetch(url, init);
+  await validateResponse(response);
+  return (await response.json()) as AuthorizeResponse;
+};
+
+/** Attempts to fetch this device's OIDC token
+ *
+ * The authorization may or may not be granted at this stage. If it is not, the
+ * authorization server will return "authorization_pending", in which case this
+ * function will return undefined.
+ */
+const fetchOidcToken = async (org: OrgData, authorize: AuthorizeResponse) => {
+  if (org.providerType === undefined) {
+    throw "Login requires a configured provider type.";
+  }
+  const init = {
+    method: "POST",
+    headers: OIDC_HEADERS,
+    body: urlEncode({
+      client_id: org.clientId,
+      device_code: authorize.device_code,
+      grant_type: DEVICE_GRANT_TYPE,
+    }),
+  };
+  validateProviderDomain(org);
+  const url = org.providerType === "okta"
+    ? `https:${org.providerDomain}/oauth2/v1/token`
+    : org.providerType === "ping"
+    ? `https://${org.providerDomain}/${org.environmentId}/as/token`
+    : throwAssertNever(org.providerType);
+  const response = await fetch(url, init);
+
+  if (!response.ok) {
+    if (response.status === 400) {
+      const data = await response.json();
+      if (data.error === "authorization_pending") return undefined;
+    }
+    await validateResponse(response);
+  }
+  return (await response.json()) as TokenResponse;
+};
+
+/** Waits until user device authorization is complete
+ *
+ * Returns the OIDC token after completion.
+ */
+const waitForActivation = async (
+  org: OrgData,
+  authorize: AuthorizeResponse
+) => {
+  const start = Date.now();
+  while (Date.now() - start <= authorize.expires_in * 1e3) {
+    const response = await fetchOidcToken(org, authorize);
+    if (!response) await sleep(authorize.interval * 1e3);
+    else return response;
+  }
+  throw "Expired awaiting in-browser authorization.";
+};
+
+/** Logs in to an Identity Provider via OIDC */
+export const oidcLogin = async (org: OrgData, scope: string) => {
+  if (org.providerType === undefined) {
+    throw "Login requires a configured provider type.";
+  }
+  const authorizeResponse = await authorize(org, scope);
+  print2(`Please use the opened browser window to continue your P0 login.
+  
+When prompted, confirm that ${capitalize(org.providerType)} displays this code:
+
+  ${authorizeResponse.user_code}
+
+Waiting for authorization...
+`);
+  void open(authorizeResponse.verification_uri_complete);
+  const oidcResponse = await waitForActivation(org, authorizeResponse);
+  return oidcResponse;
+};

--- a/src/plugins/okta/login.ts
+++ b/src/plugins/okta/login.ts
@@ -10,107 +10,18 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { OIDC_HEADERS } from "../../common/auth/oidc";
 import { urlEncode, validateResponse } from "../../common/fetch";
-import { print2 } from "../../drivers/stdio";
 import { Identity } from "../../types/identity";
-import { AuthorizeResponse, TokenResponse } from "../../types/oidc";
+import { TokenResponse } from "../../types/oidc";
 import { OrgData } from "../../types/org";
-import { sleep, throwAssertNever } from "../../util";
 import { AwsFederatedLogin } from "../aws/types";
 import { JSDOM } from "jsdom";
-import { capitalize, omit } from "lodash";
-import open from "open";
+import { omit } from "lodash";
+import { oidcLogin, validateProviderDomain } from "../oidc/login";
 
-const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
 const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 const ID_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id_token";
 const TOKEN_EXCHANGE_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
 const WEB_SSO_TOKEN_TYPE = "urn:okta:oauth:token-type:web_sso_token";
-
-const validateProviderDomain = (org: OrgData) => {
-  if (!org.providerDomain)
-    throw "Login requires a configured provider domain.";
-};
-
-/** Executes the first step of a device-authorization grant flow */
-// cf. https://developer.okta.com/docs/guides/device-authorization-grant/main/
-const authorize = async (org: OrgData, scope: string) => {
-  if (org.providerType === undefined) {
-    throw "Login requires a configured provider type.";
-  }
-  const init = {
-    method: "POST",
-    headers: OIDC_HEADERS,
-    body: urlEncode({
-      client_id: org.clientId,
-      scope,
-    }),
-  };
-  validateProviderDomain(org);
-  // This is the "org" authorization server; the okta.apps.* scopes are not
-  // available with custom authorization servers
-  const url = org.providerType === "okta"
-    ? `https:${org.providerDomain}/oauth2/v1/device/authorize`
-    : org.providerType === "ping"
-    ? `https://${org.providerDomain}/${org.environmentId}/as/device_authorization`
-    : throwAssertNever(org.providerType);
-  const response = await fetch(url, init);
-  await validateResponse(response);
-  return (await response.json()) as AuthorizeResponse;
-};
-
-/** Attempts to fetch this device's OIDC token
- *
- * The authorization may or may not be granted at this stage. If it is not, the
- * authorization server will return "authorization_pending", in which case this
- * function will return undefined.
- */
-const fetchOidcToken = async (org: OrgData, authorize: AuthorizeResponse) => {
-  if (org.providerType === undefined) {
-    throw "Login requires a configured provider type.";
-  }
-  const init = {
-    method: "POST",
-    headers: OIDC_HEADERS,
-    body: urlEncode({
-      client_id: org.clientId,
-      device_code: authorize.device_code,
-      grant_type: DEVICE_GRANT_TYPE,
-    }),
-  };
-  validateProviderDomain(org);
-  const url = org.providerType === "okta"
-    ? `https:${org.providerDomain}/oauth2/v1/token`
-    : org.providerType === "ping"
-    ? `https://${org.providerDomain}/${org.environmentId}/as/token`
-    : throwAssertNever(org.providerType);
-  const response = await fetch(url, init);
-
-  if (!response.ok) {
-    if (response.status === 400) {
-      const data = await response.json();
-      if (data.error === "authorization_pending") return undefined;
-    }
-    await validateResponse(response);
-  }
-  return (await response.json()) as TokenResponse;
-};
-
-/** Waits until user device authorization is complete
- *
- * Returns the OIDC token after completion.
- */
-const waitForActivation = async (
-  org: OrgData,
-  authorize: AuthorizeResponse
-) => {
-  const start = Date.now();
-  while (Date.now() - start <= authorize.expires_in * 1e3) {
-    const response = await fetchOidcToken(org, authorize);
-    if (!response) await sleep(authorize.interval * 1e3);
-    else return response;
-  }
-  throw "Expired awaiting in-browser authorization.";
-};
 
 /** Exchanges an Okta OIDC SSO token for an Okta app SSO token */
 const fetchSsoWebToken = async (
@@ -166,24 +77,6 @@ const fetchSamlResponse = async (
 /** Logs in to Okta via OIDC */
 export const oktaLogin = async (org: OrgData) =>
   oidcLogin(org, "openid email profile okta.apps.sso");
-
-export const oidcLogin = async (org: OrgData, scope: string) => {
-  if (org.providerType === undefined) {
-    throw "Login requires a configured provider type.";
-  }
-  const authorizeResponse = await authorize(org, scope);
-  print2(`Please use the opened browser window to continue your P0 login.
-  
-When prompted, confirm that ${capitalize(org.providerType)} displays this code:
-
-  ${authorizeResponse.user_code}
-
-Waiting for authorization...
-`);
-  void open(authorizeResponse.verification_uri_complete);
-  const oidcResponse = await waitForActivation(org, authorizeResponse);
-  return oidcResponse;
-};
 
 /** Retrieves a SAML response for an okta app */
 // TODO: Inject Okta app

--- a/src/plugins/okta/login.ts
+++ b/src/plugins/okta/login.ts
@@ -14,9 +14,9 @@ import { Identity } from "../../types/identity";
 import { TokenResponse } from "../../types/oidc";
 import { OrgData } from "../../types/org";
 import { AwsFederatedLogin } from "../aws/types";
+import { oidcLogin, validateProviderDomain } from "../oidc/login";
 import { JSDOM } from "jsdom";
 import { omit } from "lodash";
-import { oidcLogin, validateProviderDomain } from "../oidc/login";
 
 const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 const ID_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id_token";

--- a/src/plugins/ping/login.ts
+++ b/src/plugins/ping/login.ts
@@ -1,0 +1,6 @@
+import { OrgData } from "../../types/org";
+import { oidcLogin } from "../okta/login";
+
+/** Logs in to PingOne via OIDC */
+export const pingLogin = async (org: OrgData) => 
+  oidcLogin(org, "openid email profile");

--- a/src/plugins/ping/login.ts
+++ b/src/plugins/ping/login.ts
@@ -12,5 +12,5 @@ import { OrgData } from "../../types/org";
 import { oidcLogin } from "../oidc/login";
 
 /** Logs in to PingOne via OIDC */
-export const pingLogin = async (org: OrgData) => 
+export const pingLogin = async (org: OrgData) =>
   oidcLogin(org, "openid email profile");

--- a/src/plugins/ping/login.ts
+++ b/src/plugins/ping/login.ts
@@ -1,5 +1,15 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
 import { OrgData } from "../../types/org";
-import { oidcLogin } from "../okta/login";
+import { oidcLogin } from "../oidc/login";
 
 /** Logs in to PingOne via OIDC */
 export const pingLogin = async (org: OrgData) => 

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -21,19 +21,20 @@ type BaseOrgData = {
     | "oidc-pkce"
     | "okta";
   tenantId: string;
-}
+};
 
 /** Publicly readable organization data */
-export type RawOrgData = BaseOrgData & (
-  | {
-      providerType?: "okta"
-    }
-  | {
-      providerType?: "ping";
-      environmentId: string;
-    }
-);
+export type RawOrgData = BaseOrgData &
+  (
+    | {
+        providerType?: "okta";
+      }
+    | {
+        providerType?: "ping";
+        environmentId: string;
+      }
+  );
 
 export type OrgData = RawOrgData & {
   slug: string;
-}
+};

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -8,12 +8,11 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-/** Publicly readable organization data */
-export type OrgData = {
+
+type BaseOrgData = {
   clientId: string;
   providerId: string;
   providerDomain?: string;
-  providerType?: "okta";
   ssoProvider:
     | "azure-oidc"
     | "google-oidc"
@@ -21,6 +20,20 @@ export type OrgData = {
     | "microsoft"
     | "oidc-pkce"
     | "okta";
-  slug: string;
   tenantId: string;
-};
+}
+
+/** Publicly readable organization data */
+export type RawOrgData = BaseOrgData & (
+  | {
+      providerType?: "okta"
+    }
+  | {
+      providerType?: "ping";
+      environmentId: string;
+    }
+);
+
+export type OrgData = RawOrgData & {
+  slug: string;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -85,3 +85,15 @@ export const exec = async (
       }
     }
   );
+
+
+export const throwAssertNever = (value: never) => {
+  throw assertNever(value);
+};
+
+export const assertNever = (value: never) => {
+  return unexpectedValueError(value);
+};
+
+export const unexpectedValueError = (value: any) =>
+  new Error(`Unexpected code state: value ${value} had unexpected type`);

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,7 +86,6 @@ export const exec = async (
     }
   );
 
-
 export const throwAssertNever = (value: never) => {
   throw assertNever(value);
 };


### PR DESCRIPTION
Adds support for logging in with Ping Identity (Tested with PingOne)

The flow from Okta can be entirely reused.
The first commit shows the actual code changes by editing `src/plugins/okta/login.ts` in place.
The second commit is a pure code move to extract the shared functions + addition of a missed copyright header.
(Third commit is code formatting.)

