### PR TITLE
Add support for p0 allow

### DIFF
--- a/src/commands/allow.ts
+++ b/src/commands/allow.ts
@@ -1,0 +1,62 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { fetchCommand } from "../drivers/api";
+import { authenticate } from "../drivers/auth";
+import { guard } from "../drivers/firestore";
+import { print2 } from "../drivers/stdio";
+import { AllowResponse } from "../types/allow";
+import { Authn } from "../types/identity";
+import yargs from "yargs";
+
+const allowArgs = <T>(yargs: yargs.Argv<T>) =>
+  yargs
+    .parserConfiguration({ "unknown-options-as-args": true })
+    .help(false) // Turn off help in order to forward the --help command to the backend so P0 can provide the available requestable resources
+    .option("wait", {
+      alias: "w",
+      boolean: true,
+      default: false,
+      describe: "Block until the command is completed",
+    })
+    .option("arguments", {
+      array: true,
+      string: true,
+      default: [] as string[],
+    });
+
+export const allowCommand = (yargs: yargs.Argv) =>
+  yargs.command<{ arguments: string[] }>(
+    "allow [arguments..]",
+    "Create standing access for a resource",
+    allowArgs,
+    guard(allow)
+  );
+
+export const allow = async (
+  args: yargs.ArgumentsCamelCase<{
+    arguments: string[];
+    wait?: boolean;
+  }>,
+  authn?: Authn
+): Promise<AllowResponse | undefined> => {
+  const resolvedAuthn = authn ?? (await authenticate());
+  const data = await fetchCommand<AllowResponse>(resolvedAuthn, args, [
+    "allow",
+    ...args.arguments,
+  ]);
+
+  if (data && "ok" in data && "message" in data && data.ok) {
+    print2(data.message);
+    return data;
+  } else {
+    throw data;
+  }
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { print2 } from "../drivers/stdio";
 import { checkVersion } from "../middlewares/version";
+import { allowCommand } from "./allow";
 import { awsCommand } from "./aws";
 import { loginCommand } from "./login";
 import { lsCommand } from "./ls";
@@ -25,6 +26,7 @@ const commands = [
   loginCommand,
   lsCommand,
   requestCommand,
+  allowCommand,
   sshCommand,
   scpCommand,
 ];

--- a/src/types/allow.ts
+++ b/src/types/allow.ts
@@ -1,0 +1,14 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+export type AllowResponse = {
+  ok: true;
+  message: string;
+};


### PR DESCRIPTION
Adds a new command to the CLI which allows users to execute `p0 allow`. It inherits the options of the request we're attempting to grant standing access to.

<img width="497" alt="image" src="https://github.com/p0-security/p0cli/assets/12995427/4fae8c93-0100-446a-a23c-2393d2240cc0">

<img width="500" alt="image" src="https://github.com/p0-security/p0cli/assets/12995427/4015df56-8e67-439a-a7b8-e7c6e0693329">
