### PR TITLE
Release 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.6.2",
+  "version": "0.7.1",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {


### PR DESCRIPTION
This PR bumps the CLI version number to 0.7.1 which enables the use of StartSSM document, adds support for agent forwarding, and adds support for `p0 allow`