### PR TITLE
Remove generated ssm document

### DIFF
--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -58,9 +58,6 @@ describe("ssh", () => {
               },
             },
           },
-          generated: {
-            documentName: "documentName",
-          },
         },
       });
     });

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -32,7 +32,6 @@ import yargs from "yargs";
 const GRANT_TIMEOUT_MILLIS = 60e3;
 
 export type ExerciseGrantResponse = {
-  documentName: string;
   linuxUserName: string;
   ok: true;
   role: string;

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -59,7 +59,6 @@ type SsmArgs = {
   instance: string;
   region: string;
   requestId: string;
-  documentName: string;
   command?: string;
   forwardPortAddress?: string;
   noRemoteCommands?: boolean;

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -69,7 +69,4 @@ export type AwsSsh = {
     };
     type: "session";
   };
-  generated: {
-    documentName: string;
-  };
 };


### PR DESCRIPTION
This PR removes any mention of the generated ssm document, we're no longer relying on our custom generated documents for this.