### PR TITLE
Use persistent keys for granting ssh access

### DIFF
--- a/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
+++ b/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
@@ -1,57 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ssh ephemeral access should call p0 request with reason arg: args 1`] = `
-{
-  "_": [
-    "ssh",
-  ],
-  "arguments": [
-    "ssh",
-    "session",
-    "some-instance",
-    "--provider",
-    "aws",
-    "--reason",
-    "reason",
-  ],
-  "wait": true,
-}
-`;
-
-exports[`ssh ephemeral access should call sshOrScp with non-interactive command: stderr 1`] = `
-[
-  [
-    "a message",
-  ],
-  [
-    "Will wait up to 5 minutes for this request to complete...",
-  ],
-  [
-    "Your request was approved",
-  ],
-  [
-    "Waiting for access to be provisioned",
-  ],
-]
-`;
-
-exports[`ssh ephemeral access should call sshOrScp with interactive session: stderr 1`] = `
-[
-  [
-    "a message",
-  ],
-  [
-    "Will wait up to 5 minutes for this request to complete...",
-  ],
-  [
-    "Your request was approved",
-  ],
-  [
-    "Waiting for access to be provisioned",
-  ],
-]
-`;
-
 exports[`ssh persistent access should call p0 request with reason arg: args 1`] = `
 {
   "_": [
@@ -61,6 +9,8 @@ exports[`ssh persistent access should call p0 request with reason arg: args 1`] 
     "ssh",
     "session",
     "some-instance",
+    "--public-key",
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/LBEMei4SHUS36JPWdW6Ds0xiQvdcswbQajH+t64vJj+osTFky9dBjx8yuOi4ZJmFmfOfQIVoxlIITxaT8g/aYfkgSNEXUmjLAcRllpFT0hLUBZWj2xxBgt2ZoOi1fkNzQc+rYksPBCWd2vDhEqjEanJPNQxwQf8Gy0FKfABuJWZV/dyIiCWfwTIQMIm1XhgavC1xKKzYZa54TWK2CLBinSKeJifO0jEhhexK6y6La/Y4pMR1rDNc879CbHY2dZX8YYGAEC5+cfQrpwuTYfw4qvZyCeMdIvnS5YRe1Nh2sD0Q9wyBH0QoRCwY7WDJgSgxAtNgMdrSLstH279oKI3D ",
     "--provider",
     "aws",
     "--reason",
@@ -70,7 +20,7 @@ exports[`ssh persistent access should call p0 request with reason arg: args 1`] 
 }
 `;
 
-exports[`ssh persistent access should call sshOrScp with non-interactive command: stderr 1`] = `
+exports[`ssh persistent access should call sshOrScp with interactive session: stderr 1`] = `
 [
   [
     "Waiting for access to be provisioned",
@@ -78,7 +28,7 @@ exports[`ssh persistent access should call sshOrScp with non-interactive command
 ]
 `;
 
-exports[`ssh persistent access should call sshOrScp with interactive session: stderr 1`] = `
+exports[`ssh persistent access should call sshOrScp with non-interactive command: stderr 1`] = `
 [
   [
     "Waiting for access to be provisioned",

--- a/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
+++ b/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ssh ephemeral access should call p0 request with reason arg: args 1`] = `
+{
+  "_": [
+    "ssh",
+  ],
+  "arguments": [
+    "ssh",
+    "session",
+    "some-instance",
+    "--public-key",
+    "test-public-key",
+    "--provider",
+    "aws",
+    "--reason",
+    "reason",
+  ],
+  "wait": true,
+}
+`;
+
+exports[`ssh ephemeral access should call sshOrScp with interactive session: stderr 1`] = `
+[
+  [
+    "a message",
+  ],
+  [
+    "Will wait up to 5 minutes for this request to complete...",
+  ],
+  [
+    "Your request was approved",
+  ],
+  [
+    "Waiting for access to be provisioned",
+  ],
+]
+`;
+
+exports[`ssh ephemeral access should call sshOrScp with non-interactive command: stderr 1`] = `
+[
+  [
+    "a message",
+  ],
+  [
+    "Will wait up to 5 minutes for this request to complete...",
+  ],
+  [
+    "Your request was approved",
+  ],
+  [
+    "Waiting for access to be provisioned",
+  ],
+]
+`;
+
 exports[`ssh persistent access should call p0 request with reason arg: args 1`] = `
 {
   "_": [
@@ -10,7 +64,7 @@ exports[`ssh persistent access should call p0 request with reason arg: args 1`] 
     "session",
     "some-instance",
     "--public-key",
-    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/LBEMei4SHUS36JPWdW6Ds0xiQvdcswbQajH+t64vJj+osTFky9dBjx8yuOi4ZJmFmfOfQIVoxlIITxaT8g/aYfkgSNEXUmjLAcRllpFT0hLUBZWj2xxBgt2ZoOi1fkNzQc+rYksPBCWd2vDhEqjEanJPNQxwQf8Gy0FKfABuJWZV/dyIiCWfwTIQMIm1XhgavC1xKKzYZa54TWK2CLBinSKeJifO0jEhhexK6y6La/Y4pMR1rDNc879CbHY2dZX8YYGAEC5+cfQrpwuTYfw4qvZyCeMdIvnS5YRe1Nh2sD0Q9wyBH0QoRCwY7WDJgSgxAtNgMdrSLstH279oKI3D ",
+    "test-public-key",
     "--provider",
     "aws",
     "--reason",

--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { TEST_PUBLIC_KEY } from "../../common/__mocks__/keys";
 import { fetchCommand } from "../../drivers/api";
 import { print1, print2 } from "../../drivers/stdio";
 import { sshOrScp } from "../../plugins/aws/ssm";
@@ -35,6 +36,7 @@ const MOCK_REQUEST = {
     name: "name",
     ssh: {
       linuxUserName: "linuxUserName",
+      publicKey: TEST_PUBLIC_KEY,
     },
   },
   permission: {

--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -22,6 +22,7 @@ jest.mock("../../drivers/api");
 jest.mock("../../drivers/auth");
 jest.mock("../../drivers/stdio");
 jest.mock("../../plugins/aws/ssm");
+jest.mock("../../common/keys");
 
 const mockFetchCommand = fetchCommand as jest.Mock;
 const mockSshOrScp = sshOrScp as jest.Mock;
@@ -54,7 +55,10 @@ mockGetDoc({
 });
 
 describe("ssh", () => {
-  describe.each([["persistent", true]])("%s access", (_, isPersistent) => {
+  describe.each([
+    ["persistent", true],
+    ["ephemeral", false],
+  ])("%s access", (_, isPersistent) => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockFetchCommand.mockResolvedValue({

--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -28,6 +28,23 @@ const mockSshOrScp = sshOrScp as jest.Mock;
 const mockPrint1 = print1 as jest.Mock;
 const mockPrint2 = print2 as jest.Mock;
 
+const MOCK_REQUEST = {
+  status: "DONE",
+  generated: {
+    name: "name",
+    ssh: {
+      linuxUserName: "linuxUserName",
+    },
+  },
+  permission: {
+    spec: {
+      instanceId: "instanceId",
+      accountId: "accountId",
+      region: "region",
+    },
+  },
+};
+
 mockGetDoc({
   "iam-write": {
     ["aws:test-account"]: {
@@ -37,10 +54,7 @@ mockGetDoc({
 });
 
 describe("ssh", () => {
-  describe.each([
-    ["persistent", true],
-    ["ephemeral", false],
-  ])("%s access", (_, isPersistent) => {
+  describe.each([["persistent", true]])("%s access", (_, isPersistent) => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockFetchCommand.mockResolvedValue({
@@ -99,9 +113,7 @@ describe("ssh", () => {
         status: "APPROVED",
       });
       await sleep(100); // Need to wait for listen before trigger in tests
-      (onSnapshot as any).trigger({
-        status: "DONE",
-      });
+      (onSnapshot as any).trigger(MOCK_REQUEST);
       await expect(promise).resolves.toBeDefined();
       expect(mockPrint2.mock.calls).toMatchSnapshot("stderr");
       expect(mockPrint1).not.toHaveBeenCalled();
@@ -115,9 +127,7 @@ describe("ssh", () => {
         status: "APPROVED",
       });
       await sleep(100); // Need to wait for listen before trigger in tests
-      (onSnapshot as any).trigger({
-        status: "DONE",
-      });
+      (onSnapshot as any).trigger(MOCK_REQUEST);
       await expect(promise).resolves.toBeDefined();
       expect(mockPrint2.mock.calls).toMatchSnapshot("stderr");
       expect(mockPrint1).not.toHaveBeenCalled();

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -8,13 +8,13 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { createKeyPair } from "../common/keys";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
 import { sshOrScp } from "../plugins/aws/ssm";
 import {
   ScpCommandArgs,
   SshRequest,
-  createKeyPair,
   provisionRequest,
   requestToSsh,
 } from "./shared";

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -8,7 +8,6 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { createKeyPair } from "../common/keys";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
 import { sshOrScp } from "../plugins/aws/ssm";
@@ -75,13 +74,12 @@ const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
     throw "Could not determine host identifier from source or destination";
   }
 
-  const { publicKey, privateKey } = await createKeyPair();
+  const result = await provisionRequest(authn, args, host);
 
-  const request = await provisionRequest(authn, args, host, publicKey);
-
-  if (!request) {
+  if (!result) {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
+  const { request, privateKey } = result;
 
   const data = requestToSsh(request);
 

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -8,11 +8,15 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { fetchExerciseGrant } from "../drivers/api";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
 import { sshOrScp } from "../plugins/aws/ssm";
-import { createKeyPair, SshCommandArgs, provisionRequest } from "./shared";
+import {
+  createKeyPair,
+  SshCommandArgs,
+  provisionRequest,
+  requestToSsh,
+} from "./shared";
 import yargs from "yargs";
 
 export const sshCommand = (yargs: yargs.Argv) =>
@@ -85,22 +89,16 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
 
   const destination = args.destination;
 
-  const requestId = await provisionRequest(authn, args, destination);
-  if (!requestId) {
+  const { publicKey, privateKey } = await createKeyPair();
+
+  const request = await provisionRequest(authn, args, destination, publicKey);
+  if (!request) {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
 
-  const { publicKey, privateKey } = createKeyPair();
-
-  const result = await fetchExerciseGrant(authn, {
-    requestId,
-    destination,
-    publicKey,
-  });
-
   await sshOrScp(
     authn,
-    result,
+    requestToSsh(request),
     {
       ...args,
       destination,

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -8,7 +8,6 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { createKeyPair } from "../common/keys";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
 import { sshOrScp } from "../plugins/aws/ssm";
@@ -85,20 +84,18 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
 
   const destination = args.destination;
 
-  const { publicKey, privateKey } = await createKeyPair();
-
-  const request = await provisionRequest(authn, args, destination, publicKey);
-  if (!request) {
+  const result = await provisionRequest(authn, args, destination);
+  if (!result) {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
 
   await sshOrScp(
     authn,
-    requestToSsh(request),
+    requestToSsh(result.request),
     {
       ...args,
       destination,
     },
-    privateKey
+    result.privateKey
   );
 };

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -8,15 +8,11 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { createKeyPair } from "../common/keys";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
 import { sshOrScp } from "../plugins/aws/ssm";
-import {
-  createKeyPair,
-  SshCommandArgs,
-  provisionRequest,
-  requestToSsh,
-} from "./shared";
+import { SshCommandArgs, provisionRequest, requestToSsh } from "./shared";
 import yargs from "yargs";
 
 export const sshCommand = (yargs: yargs.Argv) =>

--- a/src/common/__mocks__/keys.ts
+++ b/src/common/__mocks__/keys.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+export const TEST_PUBLIC_KEY = "test-public-key";
 export const createKeyPair = jest.fn().mockImplementation(() => ({
   publicKey: "test-public-key",
   privateKey: "test-private-key",

--- a/src/common/__mocks__/keys.ts
+++ b/src/common/__mocks__/keys.ts
@@ -1,0 +1,14 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+export const createKeyPair = jest.fn().mockImplementation(() => ({
+  publicKey: "test-public-key",
+  privateKey: "test-private-key",
+}));

--- a/src/common/keys.ts
+++ b/src/common/keys.ts
@@ -1,0 +1,53 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { P0_PATH } from "../util";
+import * as fs from "fs/promises";
+import forge from "node-forge";
+import * as path from "path";
+
+export const PUBLIC_KEY_PATH = path.join(P0_PATH, "ssh", "id_rsa.pub");
+export const PRIVATE_KEY_PATH = path.join(P0_PATH, "ssh", "id_rsa");
+
+/**
+ * Search for a cached key pair, or create a new one if not found
+ */
+export const createKeyPair = async (): Promise<{
+  publicKey: string;
+  privateKey: string;
+}> => {
+  if (
+    (await fileExists(PUBLIC_KEY_PATH)) &&
+    (await fileExists(PRIVATE_KEY_PATH))
+  ) {
+    const publicKey = await fs.readFile(PUBLIC_KEY_PATH, "utf8");
+    const privateKey = await fs.readFile(PRIVATE_KEY_PATH, "utf8");
+
+    return { publicKey, privateKey };
+  } else {
+    const rsaKeyPair = forge.pki.rsa.generateKeyPair({ bits: 2048 });
+    const privateKey = forge.pki.privateKeyToPem(rsaKeyPair.privateKey);
+    const publicKey = forge.ssh.publicKeyToOpenSSH(rsaKeyPair.publicKey);
+
+    await fs.mkdir(path.dirname(PUBLIC_KEY_PATH), { recursive: true });
+    await fs.writeFile(PUBLIC_KEY_PATH, publicKey, { mode: 0o600 });
+    await fs.writeFile(PRIVATE_KEY_PATH, privateKey, { mode: 0o600 });
+    return { publicKey, privateKey };
+  }
+};
+
+const fileExists = async (path: string) => {
+  try {
+    await fs.access(path);
+    return true;
+  } catch (error) {
+    return false;
+  }
+};

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -8,7 +8,6 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { ExerciseGrantResponse } from "../commands/shared";
 import { config } from "../drivers/env";
 import { Authn } from "../types/identity";
 import * as path from "node:path";
@@ -17,9 +16,6 @@ import yargs from "yargs";
 const tenantUrl = (tenant: string) => `${config.appUrl}/o/${tenant}`;
 
 const commandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/`;
-
-const exerciseGrantUrl = (tenant: string) =>
-  `${tenantUrl(tenant)}/exercise-grant/`;
 
 export const fetchCommand = async <T>(
   authn: Authn,
@@ -34,21 +30,6 @@ export const fetchCommand = async <T>(
       argv,
       scriptName: path.basename(args.$0),
     })
-  );
-
-export const fetchExerciseGrant = async (
-  authn: Authn,
-  args: {
-    requestId: string;
-    destination: string;
-    publicKey?: string;
-  }
-) =>
-  baseFetch<ExerciseGrantResponse>(
-    authn,
-    exerciseGrantUrl(authn.identity.org.slug),
-    "POST",
-    JSON.stringify(args)
   );
 
 export const baseFetch = async <T>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,20 +10,6 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { cli } from "./commands";
 import { noop } from "lodash";
-import { constants } from "node:os";
-
-// Subscribing to this global abort controller allows handling process termination signals anywhere in the application
-export const TERMINATION_CONTROLLER = new AbortController();
-
-const terminationHandler = (code: number) => () => {
-  TERMINATION_CONTROLLER.abort(code);
-  process.exit(128 + code); // by convention the exit code is the signal code + 128
-};
-
-process.on("SIGHUP", terminationHandler(constants.signals.SIGHUP));
-process.on("SIGINT", terminationHandler(constants.signals.SIGINT));
-process.on("SIGQUIT", terminationHandler(constants.signals.SIGQUIT));
-process.on("SIGTERM", terminationHandler(constants.signals.SIGTERM));
 
 export const main = () => {
   // We can suppress output here, as .fail() already print1 errors

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -9,15 +9,15 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import {
-  ExerciseGrantResponse,
+  PRIVATE_KEY_PATH,
   ScpCommandArgs,
   SshCommandArgs,
+  SshRequest,
 } from "../../../commands/shared";
 import { print2 } from "../../../drivers/stdio";
 import { Authn } from "../../../types/identity";
 import { assumeRoleWithOktaSaml } from "../../okta/aws";
-import { sshAdd, sshAddList, withSshAgent } from "../../ssh-agent";
-import { SshAgentEnv } from "../../ssh-agent/types";
+import { withSshAgent } from "../../ssh-agent";
 import { AwsCredentials } from "../types";
 import { ensureSsmInstall } from "./install";
 import {
@@ -123,14 +123,12 @@ const spawnChildProcess = (
   credential: AwsCredentials,
   command: string,
   args: string[],
-  stdio: [StdioNull, StdioNull, StdioPipe],
-  sshAgentEnv: SshAgentEnv
+  stdio: [StdioNull, StdioNull, StdioPipe]
 ) =>
   spawn(command, args, {
     env: {
       ...process.env,
       ...credential,
-      ...(sshAgentEnv || {}),
     },
     stdio,
     shell: false,
@@ -138,7 +136,6 @@ const spawnChildProcess = (
 
 type SpawnSsmNodeOptions = {
   credential: AwsCredentials;
-  sshAgentEnv: SshAgentEnv;
   command: string;
   args: string[];
   attemptsRemaining?: number;
@@ -160,8 +157,7 @@ async function spawnSsmNode(
       options.credential,
       options.command,
       options.args,
-      options.stdio,
-      options.sshAgentEnv
+      options.stdio
     );
 
     const { isAccessPropagated } = accessPropagationGuard(child);
@@ -196,14 +192,13 @@ async function spawnSsmNode(
 }
 
 const createProxyCommands = (
-  data: ExerciseGrantResponse,
+  data: SshRequest,
   args: ScpCommandArgs | SshCommandArgs,
-  sshAuthSock: string,
   debug?: boolean
 ) => {
   const ssmCommand = [
     ...createBaseSsmCommand({
-      region: data.instance.region,
+      region: data.region,
       instance: "%h",
     }),
     "--document-name",
@@ -214,9 +209,6 @@ const createProxyCommands = (
 
   const commonArgs = [
     ...(debug ? ["-v"] : []),
-    // ignore any overrides in the user's config file, we only want to use the ssh-agent we've set up for the session
-    "-o",
-    `IdentityAgent=${sshAuthSock}`,
     "-o",
     `ProxyCommand=${ssmCommand.join(" ")}`,
   ];
@@ -246,7 +238,7 @@ const createProxyCommands = (
       ...(args.A ? ["-A"] : []),
       ...(args.L ? ["-L", args.L] : []),
       ...(args.N ? ["-N"] : []),
-      `${data.linuxUserName}@${data.instance.id}`,
+      `${data.linuxUserName}@${data.id}`,
       ...(args.command ? [args.command] : []),
       ...args.arguments.map(
         (argument) =>
@@ -272,7 +264,7 @@ const transformForShell = (args: string[]) => {
 
 export const sshOrScp = async (
   authn: Authn,
-  data: ExerciseGrantResponse,
+  data: SshRequest,
   cmdArgs: ScpCommandArgs | SshCommandArgs,
   privateKey: string
 ) => {
@@ -285,39 +277,27 @@ export const sshOrScp = async (
   }
 
   const credential = await assumeRoleWithOktaSaml(authn, {
-    account: data.instance.accountId,
+    account: data.accountId,
     role: data.role,
   });
 
-  return withSshAgent(cmdArgs, async (sshAgentEnv) => {
-    await sshAdd(cmdArgs, sshAgentEnv, privateKey);
-    if (cmdArgs.debug) {
-      print2("SSH Agent Keys:");
-      await sshAddList(cmdArgs, sshAgentEnv);
-    }
-
-    const { command, args } = createProxyCommands(
-      data,
-      cmdArgs,
-      sshAgentEnv.SSH_AUTH_SOCK,
-      cmdArgs.debug
-    );
+  return withSshAgent(cmdArgs, async () => {
+    const { command, args } = createProxyCommands(data, cmdArgs, cmdArgs.debug);
 
     if (cmdArgs.debug) {
       const reproCommands = [
-        `eval $(p0 aws role assume ${data.role} --account ${data.instance.accountId})`,
-        `export SSH_AUTH_SOCK=${sshAgentEnv.SSH_AUTH_SOCK}`,
-        `export SSH_AGENT_PID=${sshAgentEnv.SSH_AGENT_PID}`,
+        `eval $(ssh-agent)`,
+        `ssh-add "${PRIVATE_KEY_PATH}"`,
+        `eval $(p0 aws role assume ${data.role} --account ${data.accountId})`,
         `${command} ${transformForShell(args).join(" ")}`,
       ];
       print2(
-        `Execute the following commands to create a similar SSH/SCP session:\n*** COMMANDS BEGIN ***\n${reproCommands.join("\n")}\n*** COMMANDS END ***\n\nTHE SSH AGENT PROCESS WILL NOT BE KILLED AUTOMATICALLY IN DEBUG MODE\nYou can kill it with "sudo kill ${sshAgentEnv.SSH_AGENT_PID}"\n`
+        `Execute the following commands to create a similar SSH/SCP session:\n*** COMMANDS BEGIN ***\n${reproCommands.join("\n")}\n*** COMMANDS END ***"\n`
       );
     }
 
     return spawnSsmNode({
       credential,
-      sshAgentEnv,
       abortController: new AbortController(),
       command,
       args,

--- a/src/plugins/aws/ssm/index.ts
+++ b/src/plugins/aws/ssm/index.ts
@@ -9,11 +9,11 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import {
-  PRIVATE_KEY_PATH,
   ScpCommandArgs,
   SshCommandArgs,
   SshRequest,
 } from "../../../commands/shared";
+import { PRIVATE_KEY_PATH } from "../../../common/keys";
 import { print2 } from "../../../drivers/stdio";
 import { Authn } from "../../../types/identity";
 import { assumeRoleWithOktaSaml } from "../../okta/aws";

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -61,12 +61,16 @@ export type AwsConfig = {
 export type AwsSsh = {
   permission: {
     spec: {
-      awsResourcePermission: {
-        resource: {
-          arn: string;
-        };
-      };
+      instanceId: string;
+      accountId: string;
+      region: string;
     };
     type: "session";
+  };
+  generated: {
+    name: string;
+    ssh: {
+      linuxUserName: string;
+    };
   };
 };

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -71,6 +71,7 @@ export type AwsSsh = {
     name: string;
     ssh: {
       linuxUserName: string;
+      publicKey: string;
     };
   };
 };

--- a/src/plugins/ssh-agent/index.ts
+++ b/src/plugins/ssh-agent/index.ts
@@ -59,6 +59,8 @@ const asyncSpawn = async (
 const isSshAgentRunning = async (args: AgentArgs) => {
   try {
     if (args.debug) print2("Searching for active ssh-agents");
+    // TODO: There's a possible edge-case but unlikely that ssh-agent has an invalid process or PID.
+    // We can check to see if the active PID matches the current socket to mitigate this.
     await asyncSpawn(args, `pgrep`, ["-x", "ssh-agent"]);
     if (args.debug) print2("At least one SSH agent is running");
     return true;

--- a/src/plugins/ssh-agent/index.ts
+++ b/src/plugins/ssh-agent/index.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { PRIVATE_KEY_PATH } from "../../commands/shared";
+import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { print2 } from "../../drivers/stdio";
 import { AgentArgs } from "./types";
 import { SpawnOptionsWithoutStdio, spawn } from "node:child_process";

--- a/src/plugins/ssh-agent/types.ts
+++ b/src/plugins/ssh-agent/types.ts
@@ -11,8 +11,3 @@ You should have received a copy of the GNU General Public License along with @p0
 export type AgentArgs = {
   debug?: boolean;
 };
-
-export type SshAgentEnv = {
-  SSH_AUTH_SOCK: string;
-  SSH_AGENT_PID: string;
-};


### PR DESCRIPTION
This PR removes the ephemeral keys and exercise-grant endpoint. Instead a pair of keys will be generated and stored in the `.p0` folder. These keys will be used every time you access a node. These keys are automatically inserted into a users running agent. If an agent is not running, they will receive an error message telling them to start one.

![image](https://github.com/p0-security/p0cli/assets/12995427/ffa75425-55d4-494c-a672-52fa301be0b2)

New SSH debug commands:

![image](https://github.com/p0-security/p0cli/assets/12995427/e31e5dfb-e3ff-4ffd-af48-913187b9554f)

### Test Plan:
#### Sudo node access
1. Perform a regular ssh access request: `p0 ssh private-node --sudo`
#### SCP node access
1. Perform a request with SCP using: `p0 scp private-node:10mb.txt test.txt`
#### Agent Forwarding
1. Add a few keys to your agent using `ssh-add`.
2. Ssh into target machine with agent forwarding argument: `p0 ssh private-node -A`
3. Run `ssh-add -l` from target machine and verify that ssh-agent was forwarded.
#### Multiple Sockets
1. Run `pgrep -x ssh-agent` to find your ssh agents.
2. Run `eval $(ssh-agent)` to spawn an extra ssh agent.
3. Run `lsof -p $pid` to find the socket for an agent.
4. Set the socket using `SSH_AUTH_SOCK=$socket`
5. Execute `p0 ssh $instance --debug` with debug flag. 
    1. The new ssh agent should insert a key
    2. The old ssh agent should skip inserting a key.
6. Change the socket:
    1. SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.qDjtwp32tR/Listeners ./p0 ssh private-node --debug
##### Teardown
1. Connect to a node using `p0 ssh`.
2. Relinquish your connection.
3. Log into the node using SSM on the AWS GUI.
4. Verify that the user's authorized key file (/home/miguel-campos/.ssh/authorized_keys) is empty
#### Non-Ephemeral Access
1. Connect to a node using `p0 ssh`.
2. Verify that your authorized keys has 1 key.
3. Disconnect from the node.
4. Connect to the same node again.
5. Verify that your authorized keys still has 1 key.