### PR TITLE
Release v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {


### PR DESCRIPTION
Release v0.8.0 which moves away from ephemeral keys and exercise grants, it also fixes a bug where assuming roles with saml failed if too many roles were requested.