### PR TITLE
Basic gcloud ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { TEST_PUBLIC_KEY } from "../../common/__mocks__/keys";
 import { fetchCommand } from "../../drivers/api";
 import { print1, print2 } from "../../drivers/stdio";
-import { sshOrScp } from "../../plugins/aws/ssm";
+import { sshOrScp } from "../../plugins/ssh";
 import { mockGetDoc } from "../../testing/firestore";
 import { sleep } from "../../util";
 import { sshCommand } from "../ssh";
@@ -22,7 +22,7 @@ import yargs from "yargs";
 jest.mock("../../drivers/api");
 jest.mock("../../drivers/auth");
 jest.mock("../../drivers/stdio");
-jest.mock("../../plugins/aws/ssm");
+jest.mock("../../plugins/ssh");
 jest.mock("../../common/keys");
 
 const mockFetchCommand = fetchCommand as jest.Mock;
@@ -36,7 +36,6 @@ const MOCK_REQUEST = {
     name: "name",
     ssh: {
       linuxUserName: "linuxUserName",
-      publicKey: TEST_PUBLIC_KEY,
     },
   },
   permission: {
@@ -44,6 +43,8 @@ const MOCK_REQUEST = {
       instanceId: "instanceId",
       accountId: "accountId",
       region: "region",
+      publicKey: TEST_PUBLIC_KEY,
+      type: "aws",
     },
   },
 };
@@ -83,7 +84,9 @@ describe("ssh", () => {
     });
 
     it("should call p0 request with reason arg", async () => {
-      void sshCommand(yargs()).parse(`ssh some-instance --reason reason`);
+      void sshCommand(yargs()).parse(
+        `ssh some-instance --reason reason --provider aws`
+      );
       await sleep(100);
       const hiddenFilenameRequestArgs = omit(
         mockFetchCommand.mock.calls[0][1],

--- a/src/commands/request.ts
+++ b/src/commands/request.ts
@@ -13,7 +13,7 @@ import { authenticate } from "../drivers/auth";
 import { doc, guard } from "../drivers/firestore";
 import { print2 } from "../drivers/stdio";
 import { Authn } from "../types/identity";
-import { Request, RequestResponse } from "../types/request";
+import { PluginRequest, Request, RequestResponse } from "../types/request";
 import { onSnapshot } from "firebase/firestore";
 import { sys } from "typescript";
 import yargs from "yargs";
@@ -70,7 +70,7 @@ const waitForRequest = async (
     if (logMessage)
       print2("Will wait up to 5 minutes for this request to complete...");
     let cancel: NodeJS.Timeout | undefined = undefined;
-    const unsubscribe = onSnapshot<Request, object>(
+    const unsubscribe = onSnapshot<Request<PluginRequest>, object>(
       doc(`o/${tenantId}/permission-requests/${requestId}`),
       (snap) => {
         const data = snap.data();

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -10,7 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
-import { sshOrScp } from "../plugins/aws/ssm";
+import { sshOrScp } from "../plugins/ssh";
 import {
   ScpCommandArgs,
   provisionRequest,

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -84,9 +84,9 @@ const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
   if (!result) {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
-  const { request, privateKey } = result;
+  const { request, privateKey, linuxUserName } = result;
 
-  const data = requestToSsh(request);
+  const data = requestToSsh(request, { gcloud: { linuxUserName } });
 
   // replace the host with the linuxUserName@instanceId
   const { source, destination } = replaceHostWithInstance(data, args);

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -13,9 +13,9 @@ import { guard } from "../drivers/firestore";
 import { sshOrScp } from "../plugins/aws/ssm";
 import {
   ScpCommandArgs,
-  SshRequest,
   provisionRequest,
   requestToSsh,
+  SshRequest,
 } from "./shared";
 import yargs from "yargs";
 
@@ -48,6 +48,11 @@ export const scpCommand = (yargs: yargs.Argv) =>
         .option("account", {
           type: "string",
           describe: "The account on which the instance is located",
+        })
+        .option("provider", {
+          type: "string",
+          describe: "The cloud provider where the instance is hosted",
+          choices: ["aws", "gcloud"],
         })
         .option("sudo", {
           type: "boolean",

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -84,9 +84,9 @@ const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
   if (!result) {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
-  const { request, privateKey, linuxUserName } = result;
+  const { request, privateKey } = result;
 
-  const data = requestToSsh(request, { gcloud: { linuxUserName } });
+  const data = requestToSsh(request);
 
   // replace the host with the linuxUserName@instanceId
   const { source, destination } = replaceHostWithInstance(data, args);

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -16,6 +16,7 @@ import {
   provisionRequest,
   requestToSsh,
   SshRequest,
+  SUPPORTED_PROVIDERS,
 } from "./shared";
 import yargs from "yargs";
 
@@ -52,7 +53,7 @@ export const scpCommand = (yargs: yargs.Argv) =>
         .option("provider", {
           type: "string",
           describe: "The cloud provider where the instance is hosted",
-          choices: ["aws", "gcloud"],
+          choices: SUPPORTED_PROVIDERS,
         })
         .option("sudo", {
           type: "boolean",

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -147,13 +147,17 @@ const waitForProvisioning = async <P extends PluginRequest>(
 };
 
 const pluginToCliRequest = async (
-  request: Request<PluginRequest>
+  request: Request<PluginRequest>,
+  options?: { debug?: boolean }
 ): Promise<Request<CliRequest>> => {
   return request.permission.spec.type === "gcloud"
     ? ({
         ...request,
         cliLocalData: {
-          linuxUserName: await importSshKey(request.permission.spec.publicKey),
+          linuxUserName: await importSshKey(
+            request.permission.spec.publicKey,
+            options
+          ),
         },
       } as Request<GcpSsh>)
     : request.permission.spec.type === "aws"
@@ -205,7 +209,9 @@ export const provisionRequest = async (
     throw "Public key mismatch. Please revoke the request and try again.";
   }
 
-  const cliRequest = await pluginToCliRequest(provisionedRequest);
+  const cliRequest = await pluginToCliRequest(provisionedRequest, {
+    debug: args.debug,
+  });
 
   return { request: cliRequest, publicKey, privateKey };
 };

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -37,7 +37,7 @@ import yargs from "yargs";
  */
 const GRANT_TIMEOUT_MILLIS = 60e3;
 // The prefix of installed SSH accounts in P0 is the provider name
-const SUPPORTED_PROVIDERS = ["aws", "gcloud"];
+export const SUPPORTED_PROVIDERS = ["aws", "gcloud"];
 
 export type SshRequest = AwsSshRequest | GcpSshRequest;
 

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -94,15 +94,15 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
 
-  const { request } = result;
+  const { request, privateKey, linuxUserName } = result;
 
   await sshOrScp(
     authn,
-    requestToSsh(request),
+    requestToSsh(request, { gcloud: { linuxUserName } }),
     {
       ...args,
       destination,
     },
-    result.privateKey
+    privateKey
   );
 };

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -94,11 +94,11 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
 
-  const { request, privateKey, linuxUserName } = result;
+  const { request, privateKey } = result;
 
   await sshOrScp(
     authn,
-    requestToSsh(request, { gcloud: { linuxUserName } }),
+    requestToSsh(request),
     {
       ...args,
       destination,

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -63,6 +63,11 @@ export const sshCommand = (yargs: yargs.Argv) =>
           type: "string",
           describe: "The account on which the instance is located",
         })
+        .option("provider", {
+          type: "string",
+          describe: "The cloud provider where the instance is hosted",
+          choices: ["aws", "gcloud"],
+        })
         .option("debug", {
           type: "boolean",
           describe:
@@ -89,9 +94,11 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
   }
 
+  const { request } = result;
+
   await sshOrScp(
     authn,
-    requestToSsh(result.request),
+    requestToSsh(request),
     {
       ...args,
       destination,

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -10,7 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
-import { sshOrScp } from "../plugins/aws/ssm";
+import { sshOrScp } from "../plugins/ssh";
 import { SshCommandArgs, provisionRequest, requestToSsh } from "./shared";
 import yargs from "yargs";
 

--- a/src/common/subprocess.ts
+++ b/src/common/subprocess.ts
@@ -15,7 +15,10 @@ import { spawn, SpawnOptionsWithoutStdio } from "node:child_process";
 /** Spawns a subprocess with given command, args, and options.
  * May write content to its standard input.
  * Stdout and stderr of the subprocess is printed to stderr in debug mode.
- * The returned promise resolves with stdout or rejects with stderr of the subprocess. */
+ * The returned promise resolves with stdout or rejects with stderr of the subprocess.
+ *
+ * The captured output is expected to be relatively small.
+ * For larger outputs we should implement this with streams. */
 export const asyncSpawn = async (
   { debug }: AgentArgs,
   command: string,
@@ -26,6 +29,7 @@ export const asyncSpawn = async (
   new Promise<string>((resolve, reject) => {
     const child = spawn(command, args, options);
 
+    // Use streams for larger output
     let stdout = "";
     let stderr = "";
 

--- a/src/common/subprocess.ts
+++ b/src/common/subprocess.ts
@@ -1,0 +1,66 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { print2 } from "../drivers/stdio";
+import { AgentArgs } from "../plugins/ssh-agent/types";
+import { spawn, SpawnOptionsWithoutStdio } from "node:child_process";
+
+/** Spawns a subprocess with given command, args, and options.
+ * May write content to its standard input.
+ * Stdout and stderr of the subprocess is printed to stderr in debug mode.
+ * The returned promise resolves with stdout or rejects with stderr of the subprocess. */
+export const asyncSpawn = async (
+  { debug }: AgentArgs,
+  command: string,
+  args?: ReadonlyArray<string>,
+  options?: SpawnOptionsWithoutStdio,
+  writeStdin?: string
+) =>
+  new Promise<string>((resolve, reject) => {
+    const child = spawn(command, args, options);
+
+    let stdout = "";
+    let stderr = "";
+
+    if (writeStdin) {
+      if (!child.stdin) return reject("Child process has no stdin");
+      child.stdin.write(writeStdin);
+    }
+
+    child.stdout.on("data", (data) => {
+      const str = data.toString("utf-8");
+      stdout += str;
+      if (debug) {
+        print2(str);
+      }
+    });
+
+    child.stderr.on("data", (data) => {
+      const str = data.toString("utf-8");
+      stderr += str;
+      if (debug) {
+        print2(data.toString("utf-8"));
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (debug) {
+        print2("Process exited with code " + code);
+      }
+      if (code !== 0) {
+        return reject(stderr);
+      }
+      resolve(stdout);
+    });
+
+    if (writeStdin) {
+      child.stdin?.end();
+    }
+  });

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -8,16 +8,16 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-type SshItemConfig = {
-  label?: string;
-  state: string;
-};
+import { SshRequest } from "../../commands/shared";
+import { AwsSsh } from "./types";
 
-export type SshConfig = {
-  "iam-write": Record<string, SshItemConfig>;
-};
-
-export type CommonSshPermissionSpec = {
-  publicKey: string;
-  sudo?: boolean;
+export const awsRequestToSsh: (request: AwsSsh) => SshRequest = (request) => {
+  return {
+    id: request.permission.spec.instanceId,
+    accountId: request.permission.spec.accountId,
+    region: request.permission.spec.region,
+    role: request.generated.name,
+    linuxUserName: request.generated.ssh.linuxUserName,
+    type: "aws",
+  };
 };

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -8,8 +8,8 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { PermissionSpec } from "../../types/request";
-import { CommonSshGenerated, CommonSshPermissionSpec } from "../ssh/types";
+import { CliPermissionSpec, PermissionSpec } from "../../types/request";
+import { CommonSshPermissionSpec } from "../ssh/types";
 
 export type AwsCredentials = {
   AWS_ACCESS_KEY_ID: string;
@@ -71,8 +71,17 @@ export type AwsSshPermission = {
   type: "session";
 };
 
-export type AwsSshGenerated = CommonSshGenerated & {
+export type AwsSshGenerated = {
   name: string;
+  ssh: {
+    linuxUserName: string;
+  };
 };
 
-export type AwsSsh = PermissionSpec<"ssh", AwsSshPermission, AwsSshGenerated>;
+export type AwsPermissionSpec = PermissionSpec<
+  "ssh",
+  AwsSshPermission,
+  AwsSshGenerated
+>;
+
+export type AwsSsh = CliPermissionSpec<AwsPermissionSpec>;

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -8,6 +8,9 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { PermissionSpec } from "../../types/request";
+import { CommonSshGenerated, CommonSshPermissionSpec } from "../ssh/types";
+
 export type AwsCredentials = {
   AWS_ACCESS_KEY_ID: string;
   AWS_SECRET_ACCESS_KEY: string;
@@ -58,20 +61,18 @@ export type AwsConfig = {
 
 // -- Specific AWS permission types
 
-export type AwsSsh = {
-  permission: {
-    spec: {
-      instanceId: string;
-      accountId: string;
-      region: string;
-    };
-    type: "session";
+export type AwsSshPermission = {
+  spec: CommonSshPermissionSpec & {
+    instanceId: string;
+    accountId: string;
+    region: string;
+    type: "aws";
   };
-  generated: {
-    name: string;
-    ssh: {
-      linuxUserName: string;
-      publicKey: string;
-    };
-  };
+  type: "session";
 };
+
+export type AwsSshGenerated = CommonSshGenerated & {
+  name: string;
+};
+
+export type AwsSsh = PermissionSpec<"ssh", AwsSshPermission, AwsSshGenerated>;

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -45,7 +45,6 @@ export const importSshKey = async (
   const url = `https://oslogin.googleapis.com/v1/users/${account}:importSshPublicKey`;
   const response = await fetch(url, {
     method: "POST",
-    // nosemgrep
     body: JSON.stringify({
       key: publicKey,
     }),
@@ -64,6 +63,7 @@ export const importSshKey = async (
   // Find the primary POSIX account for the user, or the first in the array
   const posixAccount =
     loginProfile.posixAccounts.find((account) => account.primary) ||
+    // nosemgrep no-stringify-keys
     loginProfile.posixAccounts[0];
   if (debug) {
     print2(`Picked linux user name: ${posixAccount?.username}`);

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -1,0 +1,74 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { print2 } from "../../drivers/stdio";
+import { asyncSpawn } from "../ssh-agent";
+import { ImportSshPublicKeyResponse } from "./types";
+
+/**
+ * Adds an ssh public key to the user object's sshPublicKeys array in Google Workspace.
+ * GCP OS Login uses these public keys to authenticate the user.
+ * Importing the same public key multiple times is idempotent.
+ *
+ * The user account and the access token is retrieved from the gcloud CLI.
+ *
+ * Returns the posix account to use for SSH access.
+ *
+ * See https://cloud.google.com/compute/docs/oslogin/rest/v1/users/importSshPublicKey
+ */
+export const importSshKey = async (
+  publicKey: string,
+  options?: { debug?: boolean }
+) => {
+  const debug = options?.debug ?? false;
+  const accessToken = await asyncSpawn({ debug }, "gcloud", [
+    "auth",
+    "print-access-token",
+  ]);
+  const account = await asyncSpawn({ debug }, "gcloud", [
+    "config",
+    "get-value",
+    "account",
+  ]);
+  if (debug) {
+    print2(
+      `Retrieved access token ${accessToken.slice(0, 10)}... for account ${account}`
+    );
+  }
+  const url = `https://oslogin.googleapis.com/v1/users/${account}:importSshPublicKey`;
+  const response = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify({
+      key: publicKey,
+    }),
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+  const data: ImportSshPublicKeyResponse = await response.json();
+  if (debug) {
+    print2(
+      `Login profile for user after importing public key: ${JSON.stringify(data)}`
+    );
+  }
+  const { loginProfile } = data;
+  // Find the primary POSIX account for the user, or the first in the array
+  const posixAccount =
+    loginProfile.posixAccounts.find((account) => account.primary) ||
+    loginProfile.posixAccounts[0];
+  if (debug) {
+    print2(`Picked linux user name: ${posixAccount}`);
+  }
+  if (!posixAccount) {
+    throw "No POSIX accounts configured for the user. Ask your Google Workspace administrator to configure the user's POSIX account.";
+  }
+  return posixAccount;
+};

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -8,8 +8,8 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { asyncSpawn } from "../../common/subprocess";
 import { print2 } from "../../drivers/stdio";
-import { asyncSpawn } from "../ssh-agent";
 import { ImportSshPublicKeyResponse } from "./types";
 
 /**

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -45,7 +45,7 @@ export const importSshKey = async (
   const url = `https://oslogin.googleapis.com/v1/users/${account}:importSshPublicKey`;
   const response = await fetch(url, {
     method: "POST",
-    // nosemgrep: p0_security.no-stringify-keys
+    // nosemgrep
     body: JSON.stringify({
       key: publicKey,
     }),

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -12,6 +12,7 @@ import { print2 } from "../../drivers/stdio";
 import { asyncSpawn } from "../ssh-agent";
 import { ImportSshPublicKeyResponse } from "./types";
 
+
 /**
  * Adds an ssh public key to the user object's sshPublicKeys array in Google Workspace.
  * GCP OS Login uses these public keys to authenticate the user.
@@ -45,6 +46,7 @@ export const importSshKey = async (
   const url = `https://oslogin.googleapis.com/v1/users/${account}:importSshPublicKey`;
   const response = await fetch(url, {
     method: "POST",
+    // nosemgrep: p0_security.no-stringify-keys
     body: JSON.stringify({
       key: publicKey,
     }),
@@ -65,7 +67,7 @@ export const importSshKey = async (
     loginProfile.posixAccounts.find((account) => account.primary) ||
     loginProfile.posixAccounts[0];
   if (debug) {
-    print2(`Picked linux user name: ${posixAccount}`);
+    print2(`Picked linux user name: ${posixAccount?.username}`);
   }
   if (!posixAccount) {
     throw "No POSIX accounts configured for the user. Ask your Google Workspace administrator to configure the user's POSIX account.";

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -61,9 +61,11 @@ export const importSshKey = async (
   }
   const { loginProfile } = data;
   // Find the primary POSIX account for the user, or the first in the array
+  const linuxAccounts = loginProfile.posixAccounts.filter(
+    (account) => account.operatingSystemType === "LINUX"
+  );
   const posixAccount =
-    loginProfile.posixAccounts.find((account) => account.primary) ||
-    // nosemgrep no-stringify-keys
+    linuxAccounts.find((account) => account.primary) ||
     loginProfile.posixAccounts[0];
   if (debug) {
     print2(`Picked linux user name: ${posixAccount?.username}`);
@@ -71,5 +73,5 @@ export const importSshKey = async (
   if (!posixAccount) {
     throw "No POSIX accounts configured for the user. Ask your Google Workspace administrator to configure the user's POSIX account.";
   }
-  return posixAccount;
+  return posixAccount.username;
 };

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -28,7 +28,8 @@ export const importSshKey = async (
   options?: { debug?: boolean }
 ) => {
   const debug = options?.debug ?? false;
-  const accessToken = await asyncSpawn({ debug }, "gcloud", [
+  // Force debug=false otherwise it prints the access token
+  const accessToken = await asyncSpawn({ debug: false }, "gcloud", [
     "auth",
     "print-access-token",
   ]);

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -12,7 +12,6 @@ import { print2 } from "../../drivers/stdio";
 import { asyncSpawn } from "../ssh-agent";
 import { ImportSshPublicKeyResponse } from "./types";
 
-
 /**
  * Adds an ssh public key to the user object's sshPublicKeys array in Google Workspace.
  * GCP OS Login uses these public keys to authenticate the user.

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -8,16 +8,15 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-type SshItemConfig = {
-  label?: string;
-  state: string;
-};
+import { SshRequest } from "../../commands/shared";
+import { GcpSsh } from "./types";
 
-export type SshConfig = {
-  "iam-write": Record<string, SshItemConfig>;
-};
-
-export type CommonSshPermissionSpec = {
-  publicKey: string;
-  sudo?: boolean;
+export const gcpRequestToSsh: (request: GcpSsh) => SshRequest = (request) => {
+  return {
+    id: request.permission.spec.instanceName,
+    projectId: request.permission.spec.projectId,
+    zone: request.permission.spec.zone,
+    linuxUserName: request.cliLocalData.linuxUserName,
+    type: "gcloud",
+  };
 };

--- a/src/plugins/google/types.ts
+++ b/src/plugins/google/types.ts
@@ -8,8 +8,8 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { PermissionSpec } from "../../types/request";
-import { CommonSshGenerated, CommonSshPermissionSpec } from "../ssh/types";
+import { CliPermissionSpec, PermissionSpec } from "../../types/request";
+import { CommonSshPermissionSpec } from "../ssh/types";
 
 export type GcpSshPermission = {
   spec: CommonSshPermissionSpec & {
@@ -21,15 +21,22 @@ export type GcpSshPermission = {
   type: "session";
 };
 
-export type GcpSshGenerated = CommonSshGenerated;
+export type GcpPermissionSpec = PermissionSpec<"ssh", GcpSshPermission>;
 
-export type GcpSsh = PermissionSpec<"ssh", GcpSshPermission, GcpSshGenerated>;
+export type GcpSsh = CliPermissionSpec<
+  GcpPermissionSpec,
+  { linuxUserName: string }
+>;
 
 type PosixAccount = {
   username: string;
   uid: string;
   gid: string;
-  operatingSystemType: string;
+  // See https://cloud.google.com/compute/docs/oslogin/rest/Shared.Types/OperatingSystemType
+  operatingSystemType:
+    | "LINUX"
+    | "OPERATING_SYSTEM_TYPE_UNSPECIFIED"
+    | "WINDOWS";
   homeDirectory?: string;
   primary?: boolean;
 };

--- a/src/plugins/google/types.ts
+++ b/src/plugins/google/types.ts
@@ -8,22 +8,19 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-type SshItemConfig = {
-  label?: string;
-  state: string;
-};
+import { PermissionSpec } from "../../types/request";
+import { CommonSshGenerated, CommonSshPermissionSpec } from "../ssh/types";
 
-export type SshConfig = {
-  "iam-write": Record<string, SshItemConfig>;
-};
-
-export type CommonSshPermissionSpec = {
-  publicKey: string;
-  sudo?: boolean;
-};
-
-export type CommonSshGenerated = {
-  ssh: {
-    linuxUserName: string;
+export type GcpSshPermission = {
+  spec: CommonSshPermissionSpec & {
+    instanceName: string;
+    projectId: string;
+    zone: string;
+    type: "gcloud";
   };
+  type: "session";
 };
+
+export type GcpSshGenerated = CommonSshGenerated;
+
+export type GcpSsh = PermissionSpec<"ssh", GcpSshPermission, GcpSshGenerated>;

--- a/src/plugins/google/types.ts
+++ b/src/plugins/google/types.ts
@@ -24,3 +24,28 @@ export type GcpSshPermission = {
 export type GcpSshGenerated = CommonSshGenerated;
 
 export type GcpSsh = PermissionSpec<"ssh", GcpSshPermission, GcpSshGenerated>;
+
+type PosixAccount = {
+  username: string;
+  uid: string;
+  gid: string;
+  operatingSystemType: string;
+  homeDirectory?: string;
+  primary?: boolean;
+};
+
+type SshPublicKey = {
+  key: string;
+  fingerprint?: string; // only returned in response object
+  expirationTimeUsec?: number; // optional
+};
+
+type LoginProfile = {
+  name: string;
+  posixAccounts: PosixAccount[];
+  sshPublicKeys: { [fingerprint: string]: SshPublicKey };
+};
+
+export type ImportSshPublicKeyResponse = {
+  loginProfile: LoginProfile;
+};

--- a/src/plugins/ssh-agent/index.ts
+++ b/src/plugins/ssh-agent/index.ts
@@ -9,62 +9,9 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { PRIVATE_KEY_PATH } from "../../common/keys";
+import { asyncSpawn } from "../../common/subprocess";
 import { print2 } from "../../drivers/stdio";
 import { AgentArgs } from "./types";
-import { SpawnOptionsWithoutStdio, spawn } from "node:child_process";
-
-/** Spawns a subprocess with given command, args, and options.
- * May write content to its standard input.
- * Stdout and stderr of the subprocess is printed to stderr in debug mode.
- * The returned promise resolves with stdout or rejects with stderr of the subprocess. */
-export const asyncSpawn = async (
-  { debug }: AgentArgs,
-  command: string,
-  args?: ReadonlyArray<string>,
-  options?: SpawnOptionsWithoutStdio,
-  writeStdin?: string
-) =>
-  new Promise<string>((resolve, reject) => {
-    const child = spawn(command, args, options);
-
-    let stdout = "";
-    let stderr = "";
-
-    if (writeStdin) {
-      if (!child.stdin) return reject("Child process has no stdin");
-      child.stdin.write(writeStdin);
-    }
-
-    child.stdout.on("data", (data) => {
-      const str = data.toString("utf-8");
-      stdout += str;
-      if (debug) {
-        print2(str);
-      }
-    });
-
-    child.stderr.on("data", (data) => {
-      const str = data.toString("utf-8");
-      stderr += str;
-      if (debug) {
-        print2(data.toString("utf-8"));
-      }
-    });
-
-    child.on("exit", (code) => {
-      if (debug) {
-        print2("Process exited with code " + code);
-      }
-      if (code !== 0) {
-        return reject(stderr);
-      }
-      resolve(stdout);
-    });
-
-    if (writeStdin) {
-      child.stdin?.end();
-    }
-  });
 
 const isSshAgentRunning = async (args: AgentArgs) => {
   try {

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -62,7 +62,7 @@ const DEFAULT_VALIDATION_WINDOW_MS = 5e3;
  *
  * Note that each attempt consumes ~ 1 s.
  */
-const MAX_SSH_RETRIES = 30;
+const DEFAULT_MAX_SSH_RETRIES = 30;
 const GCP_MAX_SSH_RETRIES = 120; // GCP requires more time to propagate access
 
 /** The name of the SessionManager port forwarding document. This document is managed by AWS.  */
@@ -73,6 +73,7 @@ const START_SSH_SESSION_DOCUMENT_NAME = "AWS-StartSSHSession";
  * There are 2 cases of unprovisioned access in AWS
  * 1. SSM:StartSession action is missing either on the SSM document (AWS-StartSSHSession) or the EC2 instance
  * 2. Temporary error when issuing an SCP command
+ *
  * 1: results in UNAUTHORIZED_START_SESSION_MESSAGE
  * 2: results in CONNECTION_CLOSED_MESSAGE
  *
@@ -387,7 +388,7 @@ export const sshOrScp = async (
     }
 
     const maxRetries =
-      data.type === "gcloud" ? GCP_MAX_SSH_RETRIES : MAX_SSH_RETRIES;
+      data.type === "gcloud" ? GCP_MAX_SSH_RETRIES : DEFAULT_MAX_SSH_RETRIES;
 
     return spawnSshNode({
       credential,

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -8,8 +8,8 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { AwsSsh } from "../plugins/aws/types";
-import { GcpSsh } from "../plugins/google/types";
+import { AwsPermissionSpec, AwsSsh } from "../plugins/aws/types";
+import { GcpPermissionSpec, GcpSsh } from "../plugins/google/types";
 
 export const DONE_STATUSES = ["DONE", "DONE_NOTIFIED"] as const;
 export const DENIED_STATUSES = ["DENIED", "DENIED_NOTIFIED"] as const;
@@ -19,23 +19,28 @@ export const ERROR_STATUSES = [
   "ERRORED_NOTIFIED",
 ] as const;
 
-export type PluginRequest = AwsSsh | GcpSsh;
+export type CliRequest = AwsSsh | GcpSsh;
+export type PluginRequest = AwsPermissionSpec | GcpPermissionSpec;
+
+export type CliPermissionSpec<
+  P extends PluginRequest,
+  C extends object | undefined = undefined,
+> = P & {
+  cliLocalData: C;
+};
 
 export type PermissionSpec<
   K extends string,
   P extends { type: string },
-  G extends object,
+  G extends object | undefined = undefined,
 > = {
   type: K;
   permission: P;
   generated: G;
 };
 
-export type Request<P extends PluginRequest> = {
+export type Request<P extends PluginRequest> = P & {
   status: string;
-  type: P["type"];
-  generated: P["generated"];
-  permission: P["permission"];
   principal: string;
 };
 

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -8,6 +8,9 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { AwsSsh } from "../plugins/aws/types";
+import { GcpSsh } from "../plugins/google/types";
+
 export const DONE_STATUSES = ["DONE", "DONE_NOTIFIED"] as const;
 export const DENIED_STATUSES = ["DENIED", "DENIED_NOTIFIED"] as const;
 export const ERROR_STATUSES = [
@@ -16,16 +19,21 @@ export const ERROR_STATUSES = [
   "ERRORED_NOTIFIED",
 ] as const;
 
-export type PluginRequest = {
-  permission: object;
-  generated?: object;
+export type PluginRequest = AwsSsh | GcpSsh;
+
+export type PermissionSpec<
+  K extends string,
+  P extends { type: string },
+  G extends object,
+> = {
+  type: K;
+  permission: P;
+  generated: G;
 };
 
-export type Request<P extends PluginRequest = { permission: object }> = {
+export type Request<P extends PluginRequest> = {
   status: string;
-  generatedRoles: {
-    role: string;
-  }[];
+  type: P["type"];
   generated: P["generated"];
   permission: P["permission"];
   principal: string;


### PR DESCRIPTION
Support ssh with gcloud using native ssh with public key authentication and ProxyCommand - the same way as the existing AWS ssh works.

The underlying ProxyCommand in gcloud's case is `gcloud compute start-iap-tunnel`. The IAP tunnel is necessary for accessing VMs without an external IP.

All of the existing SSH functionality is supported: `-A`, `-N`, `-L`, `--sudo`, and `scp`.

However, login to Google Cloud is separate from `p0 login`. There is no support for automatic log in to Google Cloud with SAML (or other way). If we detect that the issue is gcloud login we print `Please login to Google Cloud CLI with 'gcloud auth login'`

- Rename variables and rewrite comments to apply to both AWS and GCP
- Rework types to more closely resemble backend types and share common fields
- Add detection gcloud-specific access propagation detection