### PR TITLE
grant: Add command

### DIFF
--- a/src/commands/__tests__/__snapshots__/grant.test.ts.snap
+++ b/src/commands/__tests__/__snapshots__/grant.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`grant when valid grant command should print request response 1`] = `
+[
+  [
+    "a message",
+  ],
+]
+`;

--- a/src/commands/__tests__/grant.test.ts
+++ b/src/commands/__tests__/grant.test.ts
@@ -1,0 +1,48 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { fetchCommand } from "../../drivers/api";
+import { print1, print2 } from "../../drivers/stdio";
+import { grantCommand } from "../grant";
+import yargs from "yargs";
+
+jest.mock("../../drivers/api");
+jest.mock("../../drivers/auth");
+jest.mock("../../drivers/stdio");
+
+const mockFetchCommand = fetchCommand as jest.Mock;
+const mockPrint1 = print1 as jest.Mock;
+const mockPrint2 = print2 as jest.Mock;
+
+describe("grant", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("when valid grant command", () => {
+    const command =
+      "grant gcloud role viewer --to someone@test.com --principal-type user";
+
+    function mockFetch() {
+      mockFetchCommand.mockResolvedValue({
+        ok: true,
+        message: "a message",
+        id: "abcefg",
+        isPreexisting: false,
+        isPersistent: false,
+      });
+    }
+
+    it(`should print request response`, async () => {
+      mockFetch();
+      await grantCommand(yargs()).parse(command);
+      expect(mockPrint2.mock.calls).toMatchSnapshot();
+      expect(mockPrint1).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/commands/grant.ts
+++ b/src/commands/grant.ts
@@ -12,10 +12,10 @@ import { guard } from "../drivers/firestore";
 import { request, requestArgs } from "./shared/request";
 import yargs from "yargs";
 
-export const requestCommand = (yargs: yargs.Argv) =>
+export const grantCommand = (yargs: yargs.Argv) =>
   yargs.command<{ arguments: string[] }>(
-    "request [arguments..]",
-    "Manually request permissions on a resource",
+    "grant [arguments..]",
+    "Grant access to another identity",
     requestArgs,
-    guard(request("request"))
+    guard(request("grant"))
   );

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,6 +12,7 @@ import { print2 } from "../drivers/stdio";
 import { checkVersion } from "../middlewares/version";
 import { allowCommand } from "./allow";
 import { awsCommand } from "./aws";
+import { grantCommand } from "./grant";
 import { loginCommand } from "./login";
 import { lsCommand } from "./ls";
 import { requestCommand } from "./request";
@@ -23,6 +24,7 @@ import { hideBin } from "yargs/helpers";
 
 const commands = [
   awsCommand,
+  grantCommand,
   loginCommand,
   lsCommand,
   requestCommand,

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -1,0 +1,131 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { fetchCommand } from "../../drivers/api";
+import { authenticate } from "../../drivers/auth";
+import { doc } from "../../drivers/firestore";
+import { print2 } from "../../drivers/stdio";
+import { Authn } from "../../types/identity";
+import { PluginRequest, Request, RequestResponse } from "../../types/request";
+import { onSnapshot } from "firebase/firestore";
+import { sys } from "typescript";
+import yargs from "yargs";
+
+const WAIT_TIMEOUT = 300e3;
+
+const APPROVED = { message: "Your request was approved", code: 0 };
+const DENIED = { message: "Your request was denied", code: 2 };
+const ERRORED = { message: "Your request encountered an error", code: 1 };
+
+const COMPLETED_REQUEST_STATUSES = {
+  APPROVED,
+  APPROVED_NOTIFIED: APPROVED,
+  DONE: APPROVED,
+  DONE_NOTIFIED: APPROVED,
+  DENIED,
+  ERRORED,
+};
+
+const isCompletedStatus = (
+  status: any
+): status is keyof typeof COMPLETED_REQUEST_STATUSES =>
+  status in COMPLETED_REQUEST_STATUSES;
+
+export const requestArgs = <T>(yargs: yargs.Argv<T>) =>
+  yargs
+    .parserConfiguration({ "unknown-options-as-args": true })
+    .help(false) // Turn off help in order to forward the --help command to the backend so P0 can provide the available requestable resources
+    .option("wait", {
+      alias: "w",
+      boolean: true,
+      default: false,
+      describe: "Block until the command is completed",
+    })
+    .option("arguments", {
+      array: true,
+      string: true,
+      default: [] as string[],
+    });
+
+const waitForRequest = async (
+  tenantId: string,
+  requestId: string,
+  logMessage: boolean
+) =>
+  await new Promise<number>((resolve) => {
+    if (logMessage)
+      print2("Will wait up to 5 minutes for this request to complete...");
+    let cancel: NodeJS.Timeout | undefined = undefined;
+    const unsubscribe = onSnapshot<Request<PluginRequest>, object>(
+      doc(`o/${tenantId}/permission-requests/${requestId}`),
+      (snap) => {
+        const data = snap.data();
+        if (!data) return;
+        const { status } = data;
+        if (isCompletedStatus(status)) {
+          if (cancel) clearTimeout(cancel);
+          unsubscribe?.();
+          const { message, code } = COMPLETED_REQUEST_STATUSES[status];
+          if (code !== 0 || logMessage) print2(message);
+          resolve(code);
+        }
+      }
+    );
+    cancel = setTimeout(() => {
+      unsubscribe?.();
+      print2("Your request did not complete within 5 minutes.");
+      resolve(4);
+    }, WAIT_TIMEOUT);
+  });
+
+export const request =
+  (command: "grant" | "request") =>
+  async <T>(
+    args: yargs.ArgumentsCamelCase<{
+      arguments: string[];
+      wait?: boolean;
+    }>,
+    authn?: Authn,
+    options?: {
+      message?: "all" | "approval-required" | "none";
+    }
+  ): Promise<RequestResponse<T> | undefined> => {
+    const resolvedAuthn = authn ?? (await authenticate());
+    const { userCredential } = resolvedAuthn;
+    const data = await fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
+      command,
+      ...args.arguments,
+    ]);
+
+    if (data && "ok" in data && "message" in data && data.ok) {
+      const logMessage =
+        !options?.message ||
+        options?.message === "all" ||
+        (options?.message === "approval-required" &&
+          !data.isPreexisting &&
+          !data.isPersistent);
+      if (logMessage) print2(data.message);
+      const { id } = data;
+      if (args.wait && id && userCredential.user.tenantId) {
+        const code = await waitForRequest(
+          userCredential.user.tenantId,
+          id,
+          logMessage
+        );
+        if (code) {
+          sys.exit(code);
+          return undefined;
+        }
+        return data;
+      } else return undefined;
+    } else {
+      throw data;
+    }
+  };

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -25,7 +25,7 @@ import {
   SupportedSshProvider,
   SupportedSshProviders,
 } from "../../types/ssh";
-import { request } from "../request";
+import { request } from "./request";
 import { getDoc } from "firebase/firestore";
 import { pick } from "lodash";
 import yargs from "yargs";
@@ -103,7 +103,7 @@ export const provisionRequest = async (
 
   const { publicKey, privateKey } = await createKeyPair();
 
-  const response = await request<PluginSshRequest>(
+  const response = await request("request")<PluginSshRequest>(
     {
       ...pick(args, "$0", "_"),
       arguments: [


### PR DESCRIPTION
The P0 backend supports `p0 grant`. Wire this up in the CLI.

I moved code shared between "grant" and "request" commands to `src/commands/shared/request`.