### PR TITLE
Pre-test for sudo in gcloud ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -54,9 +54,11 @@ export type SshCommandArgs = BaseSshCommandArgs & {
   command?: string;
 };
 
-const SSH_PROVIDERS: Record<
+export type CommandArgs = ScpCommandArgs | SshCommandArgs;
+
+export const SSH_PROVIDERS: Record<
   SupportedSshProvider,
-  SshProvider<any, any, any>
+  SshProvider<any, any, any, any>
 > = {
   aws: awsSshProvider,
   gcloud: gcpSshProvider,

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -96,6 +96,9 @@ const pluginToCliRequest = async (
     options
   );
 
+export const isSudoCommand = (args: { sudo?: boolean; command?: string }) =>
+  args.sudo || args.command === "sudo";
+
 export const provisionRequest = async (
   authn: Authn,
   args: yargs.ArgumentsCamelCase<BaseSshCommandArgs>,
@@ -115,7 +118,7 @@ export const provisionRequest = async (
         "--public-key",
         publicKey,
         ...(args.provider ? ["--provider", args.provider] : []),
-        ...(args.sudo || args.command === "sudo" ? ["--sudo"] : []),
+        ...(isSudoCommand(args) ? ["--sudo"] : []),
         ...(args.reason ? ["--reason", args.reason] : []),
         ...(args.account ? ["--account", args.account] : []),
       ],

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -86,8 +86,8 @@ export const awsSshProvider: SshProvider<
     ];
   },
   reproCommands: (request) => {
-    // TODO: Modify commands to add the ability to get permission set commands
-    if (request.type === "aws" && request.access !== "idc") {
+    // TODO: Add manual commands for IDC login
+    if (request.access !== "idc") {
       return [
         `eval $(p0 aws role assume ${request.role} --account ${request.accountId})`,
       ];

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -9,12 +9,33 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { SshProvider } from "../../types/ssh";
-import { AwsSshPermissionSpec, AwsSshRequest } from "./types";
+import { throwAssertNever } from "../../util";
+import { assumeRoleWithOktaSaml } from "../okta/aws";
+import { getAwsConfig } from "./config";
+import { assumeRoleWithIdc } from "./idc";
+import { ensureSsmInstall } from "./ssm/install";
+import {
+  AwsCredentials,
+  AwsSshIdcRequest,
+  AwsSshPermissionSpec,
+  AwsSshRequest,
+  AwsSshRoleRequest,
+} from "./types";
+
+/** Maximum number of attempts to start an SSH session
+ *
+ * Each attempt consumes ~ 1 s.
+ */
+const MAX_SSH_RETRIES = 30;
+
+/** The name of the SessionManager port forwarding document. This document is managed by AWS.  */
+const START_SSH_SESSION_DOCUMENT_NAME = "AWS-StartSSHSession";
 
 export const awsSshProvider: SshProvider<
   AwsSshPermissionSpec,
   undefined,
-  AwsSshRequest
+  AwsSshRequest,
+  AwsCredentials
 > = {
   requestToSsh: (request) => {
     const { permission, generated } = request;
@@ -33,4 +54,47 @@ export const awsSshProvider: SshProvider<
         };
   },
   toCliRequest: async (request) => ({ ...request, cliLocalData: undefined }),
+  cloudProviderLogin: async (authn, request) => {
+    if (!(await ensureSsmInstall())) {
+      throw "Please try again after installing the required AWS utilities";
+    }
+
+    const { config } = await getAwsConfig(authn, request.accountId);
+    if (!config.login?.type || config.login?.type === "iam") {
+      throw "This account is not configured for SSH access via the P0 CLI";
+    }
+
+    return config.login?.type === "idc"
+      ? await assumeRoleWithIdc(request as AwsSshIdcRequest)
+      : config.login?.type === "federated"
+        ? await assumeRoleWithOktaSaml(authn, request as AwsSshRoleRequest)
+        : throwAssertNever(config.login);
+  },
+  proxyCommand: (request) => {
+    return [
+      "aws",
+      "ssm",
+      "start-session",
+      "--region",
+      request.region,
+      "--target",
+      "%h",
+      "--document-name",
+      START_SSH_SESSION_DOCUMENT_NAME,
+      "--parameters",
+      '"portNumber=%p"',
+    ];
+  },
+  reproCommands: (request) => {
+    // TODO: Modify commands to add the ability to get permission set commands
+    if (request.type === "aws" && request.access !== "idc") {
+      return [
+        `eval $(p0 aws role assume ${request.role} --account ${request.accountId})`,
+      ];
+    }
+    return undefined;
+  },
+  preTestAccessPropagationArgs: () => undefined,
+  maxRetries: MAX_SSH_RETRIES,
+  friendlyName: "AWS",
 };

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { isSudoCommand } from "../../commands/shared/ssh";
 import { SshProvider } from "../../types/ssh";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
@@ -60,7 +61,7 @@ export const gcpSshProvider: SshProvider<
   },
   reproCommands: () => undefined, // TODO @ENG-2284 support login with Google Cloud
   preTestAccessPropagationArgs: (cmdArgs) => {
-    if (cmdArgs.sudo || ("command" in cmdArgs && cmdArgs.command === "sudo")) {
+    if (isSudoCommand(cmdArgs)) {
       return {
         ...cmdArgs,
         // `sudo -v` prints `Sorry, user <user> may not run sudo on <hostname>.` to stderr when user is not a sudoer.

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -12,6 +12,12 @@ import { SshProvider } from "../../types/ssh";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
 
+/** Maximum number of attempts to start an SSH session
+ *
+ * The length of each attempt varies based on the type of error from a few seconds to < 1s
+ */
+const MAX_SSH_RETRIES = 120;
+
 export const gcpSshProvider: SshProvider<
   GcpSshPermissionSpec,
   { linuxUserName: string },
@@ -35,4 +41,36 @@ export const gcpSshProvider: SshProvider<
       ),
     },
   }),
+  cloudProviderLogin: async () => undefined, // TODO @ENG-2284 support login with Google Cloud
+  proxyCommand: (request) => {
+    return [
+      "gcloud",
+      "compute",
+      "start-iap-tunnel",
+      request.id,
+      "%p",
+      // --listen-on-stdin flag is required for interactive SSH session.
+      // It is undocumented on page https://cloud.google.com/sdk/gcloud/reference/compute/start-iap-tunnel
+      // but mention on page https://cloud.google.com/iap/docs/tcp-by-host
+      // and also found in `gcloud ssh --dry-run` output
+      "--listen-on-stdin",
+      `--zone=${request.zone}`,
+      `--project=${request.projectId}`,
+    ];
+  },
+  reproCommands: () => undefined, // TODO @ENG-2284 support login with Google Cloud
+  preTestAccessPropagationArgs: (cmdArgs) => {
+    if (cmdArgs.sudo || ("command" in cmdArgs && cmdArgs.command === "sudo")) {
+      return {
+        ...cmdArgs,
+        // `sudo -v` prints `Sorry, user <user> may not run sudo on <hostname>.` to stderr when user is not a sudoer.
+        // It prints nothing to stdout when user is a sudoer - which is important because we don't want any output from the pre-test.
+        command: "sudo",
+        arguments: ["-v"],
+      };
+    }
+    return undefined;
+  },
+  maxRetries: MAX_SSH_RETRIES,
+  friendlyName: "Google Cloud",
 };

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -43,14 +43,19 @@ export type SshProvider<
   C extends object | undefined = undefined, // credentials object
 > = {
   requestToSsh: (request: CliPermissionSpec<PR, O>) => SR;
+  /** Converts a backend request to a CLI request */
   toCliRequest: (
     request: Request<PR>,
     options?: { debug?: boolean }
   ) => Promise<Request<CliSshRequest>>;
+  /** Logs in the user to the cloud provider */
   cloudProviderLogin: (authn: Authn, request: SR) => Promise<C>;
+  /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option */
   proxyCommand: (request: SR) => string[];
+  /** Each element in the returned array is a command that can be run to reproduce the
+   * steps of logging in the user to the ssh session. */
   reproCommands: (request: SR) => string[] | undefined;
-  /** Arguments for an pre-test command to verify access propagation prior
+  /** Arguments for a pre-test command to verify access propagation prior
    * to actually logging in the user to the ssh session.
    * This must return arguments for a non-interactive command - meaning the `command`
    * and potentially the `args` props must be specified in the returned scp/ssh command.

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { CommandArgs } from "../commands/shared/ssh";
 import {
   AwsSsh,
   AwsSshPermissionSpec,
@@ -18,6 +19,7 @@ import {
   GcpSshPermissionSpec,
   GcpSshRequest,
 } from "../plugins/google/types";
+import { Authn } from "./identity";
 import { Request } from "./request";
 
 export type CliSshRequest = AwsSsh | GcpSsh;
@@ -38,12 +40,28 @@ export type SshProvider<
   PR extends PluginSshRequest = PluginSshRequest,
   O extends object | undefined = undefined,
   SR extends SshRequest = SshRequest,
+  C extends object | undefined = undefined, // credentials object
 > = {
   requestToSsh: (request: CliPermissionSpec<PR, O>) => SR;
   toCliRequest: (
     request: Request<PR>,
     options?: { debug?: boolean }
   ) => Promise<Request<CliSshRequest>>;
+  cloudProviderLogin: (authn: Authn, request: SR) => Promise<C>;
+  proxyCommand: (request: SR) => string[];
+  reproCommands: (request: SR) => string[] | undefined;
+  /** Arguments for an pre-test command to verify access propagation prior
+   * to actually logging in the user to the ssh session.
+   * This must return arguments for a non-interactive command - meaning the `command`
+   * and potentially the `args` props must be specified in the returned scp/ssh command.
+   * If the return value is undefined then no pre-testing is done prior to executing
+   * the actual ssh/scp command.
+   */
+  preTestAccessPropagationArgs: (
+    cmdArgs: CommandArgs
+  ) => CommandArgs | undefined;
+  maxRetries: number;
+  friendlyName: string;
 };
 
 export type SshRequest = AwsSshRequest | GcpSshRequest;


### PR DESCRIPTION
Previously, we were not able to verify if sudo access has propagated to Google Cloud VMs, specifically in the case when the user already had regular access and then requested sudo access. This is because the IAM permissions for regular access already exist, so we successfully logged in the user to the VM. However, the new IAM permissions to allow sudo have not propagated yet, so the user was not able to successfully execute any sudo commands until later.

This PR addresses the issue by executing a pre-test ssh command that runs `sudo -v` in non-interactive mode to verify that the user _can_ sudo. Once the test completes we go on to log the user in.

Also refactors code to move aws and gcloud checks from `plugins/ssh/index.ts`.

Completes ENG-2292