### PR TITLE
Add command for automated access to EKS clusters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
   ],
   "dependencies": {
     "@rgrove/parse-xml": "^4.1.0",
+    "@types/ini": "^4.1.1",
     "dotenv": "^16.4.1",
     "express": "^4.18.2",
     "firebase": "^10.7.2",
+    "ini": "^4.1.3",
     "inquirer": "^9.2.15",
     "jsdom": "^24.1.1",
     "lodash": "^4.17.21",
@@ -32,6 +34,7 @@
     "pkce-challenge": "^4.1.0",
     "pluralize": "^8.0.0",
     "semver": "^7.6.0",
+    "tmp-promise": "^3.0.3",
     "typescript": "^4.8.4",
     "which": "^4.0.0",
     "yargs": "^17.6.0"

--- a/src/commands/aws/files.ts
+++ b/src/commands/aws/files.ts
@@ -9,9 +9,9 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { AwsCredentials } from "../../plugins/aws/types";
-import { EncodeOptions, parse, stringify } from "ini";
-import fs from "node:fs/promises";
-import os from "node:os";
+import * as ini from "ini";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import path from "node:path";
 import tmp from "tmp-promise";
 
@@ -29,11 +29,12 @@ export const AWS_CREDENTIALS_FILE = path.join(AWS_CONFIG_PATH, "credentials");
  * @returns Arbitrary object representing the contents of the file, or an empty
  * object if the file is empty or does not exist
  */
-export const readIniFile = async (path: string): Promise<any> => {
-  let data;
-
+export const readIniFile = async (
+  path: string
+): Promise<{ [key: string]: any }> => {
   try {
-    data = await fs.readFile(path, { encoding: "utf-8" });
+    const data = await fs.readFile(path, { encoding: "utf-8" });
+    return data ? ini.parse(data) : {};
   } catch (err: any) {
     if (err.code === "ENOENT") {
       return {};
@@ -41,12 +42,6 @@ export const readIniFile = async (path: string): Promise<any> => {
 
     throw err;
   }
-
-  if (!data) {
-    return {};
-  }
-
-  return parse(data);
 };
 
 /**
@@ -65,9 +60,9 @@ export const readIniFile = async (path: string): Promise<any> => {
 export const atomicWriteIniFile = async (
   path: string,
   obj: any,
-  iniEncodeOptions?: EncodeOptions
+  iniEncodeOptions?: ini.EncodeOptions
 ): Promise<void> => {
-  const data = stringify(obj, iniEncodeOptions);
+  const data = ini.stringify(obj, iniEncodeOptions);
 
   // Permissions will be moved along with the file
   const { path: tmpPath } = await tmp.file({ mode: 0o600, prefix: "p0cli-" });

--- a/src/commands/aws/files.ts
+++ b/src/commands/aws/files.ts
@@ -1,0 +1,106 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { AwsCredentials } from "../../plugins/aws/types";
+import { EncodeOptions, parse, stringify } from "ini";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import tmp from "tmp-promise";
+
+const AWS_CONFIG_PATH = path.join(os.homedir(), ".aws");
+export const AWS_CONFIG_FILE = path.join(AWS_CONFIG_PATH, "config");
+export const AWS_CREDENTIALS_FILE = path.join(AWS_CONFIG_PATH, "credentials");
+
+// Reference documentation: https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html
+
+/**
+ * Reads in an AWS CLI configuration file, which is formatted as INI text, and
+ * returns an arbitrary object representing the contents.
+ *
+ * @param path Path of the file to read
+ * @returns Arbitrary object representing the contents of the file, or an empty
+ * object if the file is empty or does not exist
+ */
+export const readIniFile = async (path: string): Promise<any> => {
+  let data;
+
+  try {
+    data = await fs.readFile(path, { encoding: "utf-8" });
+  } catch (err: any) {
+    if (err.code === "ENOENT") {
+      return {};
+    }
+
+    throw err;
+  }
+
+  if (!data) {
+    return {};
+  }
+
+  return parse(data);
+};
+
+/**
+ * This function writes an arbitrary object as INI-formatted text to a file
+ * atomically by first writing the data to a temporary file then moving the
+ * temporary file on top of the target file. This minimizes the chance that an
+ * exception, system crash, or other similar event will leave the file in a
+ * corrupted state; this is important since we're mucking around with the AWS
+ * CLI's configuration files.
+ *
+ * @param path Path of the (permanent) file to write to
+ * @param obj Arbitrary object to convert to INI-formatted text and write to the
+ * file
+ * @param iniEncodeOptions Options to pass to the INI encoding library
+ */
+export const atomicWriteIniFile = async (
+  path: string,
+  obj: any,
+  iniEncodeOptions?: EncodeOptions
+): Promise<void> => {
+  const data = stringify(obj, iniEncodeOptions);
+
+  // Permissions will be moved along with the file
+  const { path: tmpPath } = await tmp.file({ mode: 0o600, prefix: "p0cli-" });
+
+  await fs.writeFile(tmpPath, data, { encoding: "utf-8" });
+  await fs.rename(tmpPath, path);
+};
+
+export const writeAwsTempCredentials = async (
+  profileName: string,
+  awsCredentials: AwsCredentials
+) => {
+  const credentials = await readIniFile(AWS_CREDENTIALS_FILE);
+
+  credentials[profileName] = {
+    aws_access_key_id: awsCredentials.AWS_ACCESS_KEY_ID,
+    aws_secret_access_key: awsCredentials.AWS_SECRET_ACCESS_KEY,
+    aws_session_token: awsCredentials.AWS_SESSION_TOKEN,
+  };
+
+  // The credentials file is formatted with whitespace before and after the `=`
+  await atomicWriteIniFile(AWS_CREDENTIALS_FILE, credentials, {
+    whitespace: true,
+  });
+};
+
+export const writeAwsConfigProfile = async (
+  profileName: string,
+  profileConfig: any
+) => {
+  const config = await readIniFile(AWS_CONFIG_FILE);
+
+  config[`profile ${profileName}`] = profileConfig;
+
+  await atomicWriteIniFile(AWS_CONFIG_FILE, config);
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,7 @@ import { checkVersion } from "../middlewares/version";
 import { allowCommand } from "./allow";
 import { awsCommand } from "./aws";
 import { grantCommand } from "./grant";
+import { kubeconfigCommand } from "./kubeconfig";
 import { loginCommand } from "./login";
 import { lsCommand } from "./ls";
 import { requestCommand } from "./request";
@@ -31,6 +32,7 @@ const commands = [
   allowCommand,
   sshCommand,
   scpCommand,
+  kubeconfigCommand,
 ];
 
 export const cli = commands

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { retryWithSleep } from "../common/retry";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
-import { print2 } from "../drivers/stdio";
+import { Ansi, print2 } from "../drivers/stdio";
 import {
   awsCloudAuth,
   profileName,
@@ -150,6 +150,13 @@ const kubeconfigAction = async (
   print2(
     "Access granted and kubectl configured successfully. Re-run this command to refresh access if credentials expire."
   );
+
+  if (process.env.AWS_ACCESS_KEY_ID) {
+    print2(
+      `${Ansi.Yellow}Warning: AWS credentials were detected in your environment, which may cause kubectl errors. ` +
+        `To avoid issues, unset with \`unset AWS_ACCESS_KEY_ID\`.${Ansi.Reset}`
+    );
+  }
 };
 
 /**

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -1,0 +1,248 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { retryWithSleep } from "../common/retry";
+import { authenticate } from "../drivers/auth";
+import { guard } from "../drivers/firestore";
+import { print2 } from "../drivers/stdio";
+import { getAwsConfig } from "../plugins/aws/config";
+import {
+  awsCloudAuth,
+  profileName,
+  requestAccessToCluster,
+  getAndValidateK8sIntegration,
+} from "../plugins/kubeconfig";
+import { ensureEksInstall } from "../plugins/kubeconfig/install";
+import { exec, stricmp } from "../util";
+import { writeAwsConfigProfile, writeAwsTempCredentials } from "./aws/files";
+import yargs from "yargs";
+
+export type KubeconfigCommandArgs = {
+  cluster: string;
+  role: string;
+  resource?: string;
+  reason?: string;
+  requestedDuration?: string;
+};
+
+export const kubeconfigCommand = (yargs: yargs.Argv) =>
+  yargs.command<KubeconfigCommandArgs>(
+    "kubeconfig",
+    "Request access to and automatically configure kubectl for a k8s cluster hosted by a cloud provider. Currently supports AWS EKS only.",
+    (yargs) =>
+      yargs
+        .option("cluster", {
+          type: "string",
+          demandOption: true,
+          describe: "The ID of the k8s cluster as configured P0 Security",
+        })
+        .option("resource", {
+          type: "string",
+          describe:
+            'The resource or resource type (e.g., "Pod / *"), or omit for all',
+        })
+        .option("role", {
+          type: "string",
+          demandOption: true,
+          describe:
+            'The k8s role to request, e.g., "ClusterRole / cluster-admin"',
+        })
+        .option("reason", {
+          type: "string",
+          describe: "Reason access is needed",
+        })
+        .option("requested-duration", {
+          type: "string",
+          // Copied from the P0 backend
+          describe:
+            "Requested duration for access (format like '10 minutes', '2 hours', '5 days', or '1 week')",
+        }),
+    guard(kubeconfigAction)
+  );
+
+const kubeconfigAction = async (
+  args: yargs.ArgumentsCamelCase<KubeconfigCommandArgs>
+) => {
+  if (!(await ensureEksInstall())) {
+    throw "Required dependencies are missing; please try again after installing them, or check that they are available on the PATH.";
+  }
+
+  const role = normalizeRoleArg(args.role);
+
+  if (args.resource) {
+    validateResourceArg(args.resource);
+  }
+
+  const authn = await authenticate();
+
+  const clusterConfig = await getAndValidateK8sIntegration(authn, args.cluster);
+
+  const { clusterId, awsAccountId, awsClusterArn } = clusterConfig;
+  const { config } = await getAwsConfig(authn, awsAccountId);
+  const { login } = config;
+
+  // Verify that the AWS auth type is supported before issuing the requests
+  if (!login?.type || login?.type === "iam") {
+    throw "This AWS account is not configured for kubectl access via the P0 CLI.\nYou can request access to the cluster using the `p0 request k8s` command.";
+  }
+
+  const { type: loginType } = login;
+
+  const request = await requestAccessToCluster(authn, args, clusterId, role);
+
+  const awsAuth = await awsCloudAuth(
+    authn,
+    awsAccountId,
+    request.generated,
+    loginType
+  );
+
+  const profile = profileName(clusterId);
+
+  // The `aws eks update-kubeconfig` command can't handle the ARN of the EKS cluster.
+  // So we must, with great annoyance, parse it to extract the cluster name and region.
+  const clusterInfo = extractClusterNameAndRegion(awsClusterArn);
+  const { clusterRegion, clusterName } = clusterInfo;
+
+  await writeAwsTempCredentials(profile, awsAuth);
+  await writeAwsConfigProfile(profile, { region: clusterRegion });
+
+  const updateKubeconfigArgs = [
+    "eks",
+    "update-kubeconfig",
+    "--name",
+    clusterName,
+    "--region",
+    clusterRegion,
+    "--profile",
+    profile,
+  ];
+
+  try {
+    // Federated access especially sometimes takes some time to propagate, so
+    // retry for up to 20 seconds just in case it takes a while.
+    const awsResult = await retryWithSleep(
+      async () => await exec("aws", updateKubeconfigArgs, { check: true }),
+      () => true,
+      2,
+      10000
+    );
+    print2(awsResult.stdout);
+  } catch (error: any) {
+    print2("Failed to invoke `aws eks update-kubeconfig`");
+    throw error;
+  }
+
+  // `aws update-kubeconfig` will set the kubectl context if it made a change to the kubeconfig file.
+  // We'll set the context manually anyway, just in case. `aws update-kubeconfig` names the context
+  // with the EKS cluster's ARN.
+  try {
+    const kubectlResult = await exec(
+      "kubectl",
+      ["config", "use-context", awsClusterArn],
+      { check: true }
+    );
+    print2(kubectlResult.stdout);
+  } catch (error: any) {
+    print2("Failed to invoke `kubectl config use-context`");
+    throw error;
+  }
+
+  print2(
+    "Access granted and kubectl configured successfully. Re-run this command to refresh access if credentials expire."
+  );
+};
+
+/**
+ * Normalize the role argument to the format expected by the P0 backend,
+ * matching the way the Slack modal formats the role. Also validates that the
+ * role argument contains the components expected by the backend without having
+ * to make the API call.
+ *
+ * @param role The role argument to normalize
+ * @returns The normalized role value to pass to the backend
+ */
+const normalizeRoleArg = (role: string): string => {
+  const SEPARATOR = "/";
+  const SYNTAX_HINT =
+    "The role argument must be in one of the following formats:\n" +
+    "- ClusterRole/<roleName>\n" +
+    "- CuratedRole/<roleName>\n" +
+    "- Role/<namespace>/<roleName>";
+
+  const items = role.split(SEPARATOR).map((item) => item.trim());
+
+  if (items.length < 2 || items.length > 3) {
+    throw `Invalid format for role argument.\n${SYNTAX_HINT}`;
+  }
+
+  if (!items[0]) {
+    throw `Role kind must be specified.\n${SYNTAX_HINT}`;
+  }
+
+  if (stricmp(items[0], "ClusterRole")) {
+    return `ClusterRole ${SEPARATOR} ${items[1]}`;
+  } else if (stricmp(items[0], "CuratedRole")) {
+    return `CuratedRole ${SEPARATOR} ${items[1]}`;
+  } else if (stricmp(items[0], "Role")) {
+    if (items.length !== 3) {
+      throw `Invalid format for role argument.\n${SYNTAX_HINT}`;
+    }
+    return `Role ${SEPARATOR} ${items[1]} ${SEPARATOR} ${items[2]}`;
+  }
+
+  throw `Invalid role kind ${items[0]}.\n${SYNTAX_HINT}`;
+};
+
+/**
+ * Validate that the resource argument is of the format expected by the P0
+ * backend, again matching the way the Slack modal formats the resource.
+ *
+ * @param resource The resource argument to validate
+ */
+const validateResourceArg = (resource: string): void => {
+  const SEPARATOR = " / ";
+
+  const items = resource.split(SEPARATOR);
+
+  if (items.length < 2 || items.length > 3) {
+    throw (
+      "Invalid format for resource argument.\n" +
+      "The resource argument must be in one of the following formats (spaces required):\n" +
+      "- <kind> / <namespace> / <name>\n" +
+      "- <kind> / <name>"
+    );
+  }
+};
+
+const extractClusterNameAndRegion = (clusterArn: string) => {
+  const INVALID_ARN_MSG = `Invalid EKS cluster ARN: ${clusterArn}`;
+  // Example EKS cluster ARN: arn:aws:eks:us-west-2:123456789012:cluster/my-testing-cluster
+  const parts = clusterArn.split(":");
+
+  if (parts.length < 6 || !parts[3] || !parts[5]) {
+    throw INVALID_ARN_MSG;
+  }
+
+  const clusterRegion = parts[3];
+  const resource = parts[5].split("/");
+
+  if (resource[0] !== "cluster") {
+    throw INVALID_ARN_MSG;
+  }
+
+  const clusterName = resource[1];
+
+  if (!clusterName) {
+    throw INVALID_ARN_MSG;
+  }
+
+  return { clusterRegion, clusterName };
+};

--- a/src/commands/shared/index.ts
+++ b/src/commands/shared/index.ts
@@ -57,7 +57,7 @@ export const waitForProvisioning = async <P extends PluginRequest>(
     cancel = setTimeout(() => {
       if (!isResolved) {
         unsubscribe();
-        reject("Timeout awaiting SSH access grant");
+        reject("Timeout awaiting access grant. Please try again.");
       }
     }, GRANT_TIMEOUT_MILLIS);
   });

--- a/src/common/install.ts
+++ b/src/common/install.ts
@@ -1,0 +1,160 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { print1, print2 } from "../drivers/stdio";
+import { isa } from "../types";
+import { compact } from "lodash";
+import { spawn } from "node:child_process";
+import os from "node:os";
+import { sys } from "typescript";
+import which from "which";
+
+export const SupportedPlatforms = ["darwin"] as const;
+export type SupportedPlatform = (typeof SupportedPlatforms)[number];
+
+export const AwsItems = ["aws"] as const;
+export type AwsItem = (typeof AwsItems)[number];
+
+export type InstallMetadata = {
+  label: string;
+  commands: Record<SupportedPlatform, Readonly<string[]>>;
+};
+
+export const AwsInstall: Readonly<Record<AwsItem, InstallMetadata>> = {
+  aws: {
+    label: "AWS CLI v2",
+    commands: {
+      darwin: [
+        'curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"',
+        "sudo installer -pkg AWSCLIV2.pkg -target /",
+        'rm "AWSCLIV2.pkg"',
+      ],
+    },
+  },
+};
+
+const printToInstall = <
+  T extends string,
+  U extends Readonly<Record<T, InstallMetadata>>,
+>(
+  toInstall: readonly T[],
+  installMetadata: U
+) => {
+  print2("The following items must be installed on your system to continue:");
+  for (const item of toInstall) {
+    print2(`  - ${installMetadata[item].label} (${item})`);
+  }
+  print2("");
+};
+
+const queryInteractive = async () => {
+  const inquirer = (await import("inquirer")).default;
+  const { isGuided } = await inquirer.prompt([
+    {
+      type: "confirm",
+      name: "isGuided",
+      message:
+        "Do you want P0 to install these for you (sudo access required)?",
+    },
+  ]);
+  print2("");
+  return isGuided;
+};
+
+const requiredInstalls = async <T extends string>(installItems: readonly T[]) =>
+  compact(
+    await Promise.all(
+      installItems.map(async (item) =>
+        (await which(item, { nothrow: true })) === null ? item : undefined
+      )
+    )
+  );
+
+const printInstallCommands = <
+  T extends string,
+  U extends Readonly<Record<T, InstallMetadata>>,
+>(
+  platform: SupportedPlatform,
+  item: T,
+  installData: U
+) => {
+  const { label, commands } = installData[item];
+  print2(`To install ${label}, run the following commands:\n`);
+  for (const command of commands[platform]) {
+    print1(`  ${command}`);
+  }
+  print1(""); // Newline is useful for reading command output in a script, so send to /fd/1
+};
+
+export const guidedInstall = async <
+  T extends string,
+  U extends Readonly<Record<T, InstallMetadata>>,
+>(
+  platform: SupportedPlatform,
+  item: T,
+  installData: U
+) => {
+  const commands = installData[item].commands[platform];
+
+  const combined = commands.join(" && \\\n");
+
+  print2(`Executing:\n${combined}`);
+  print2("");
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("bash", ["-c", combined], { stdio: "inherit" });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(`Shell exited with code ${code}`);
+    });
+  });
+
+  print2("");
+};
+
+export const ensureInstall = async <
+  T extends string,
+  U extends Readonly<Record<T, InstallMetadata>>,
+>(
+  installItems: readonly T[],
+  installData: U
+): Promise<boolean> => {
+  const toInstall = await requiredInstalls(installItems);
+
+  if (toInstall.length === 0) {
+    return true;
+  }
+
+  const platform = os.platform();
+
+  printToInstall(toInstall, installData);
+
+  if (!isa(SupportedPlatforms)(platform)) {
+    throw (
+      `Guided dependency installation is not available on platform ${platform}\n` +
+      "Please install the above dependencies manually, or ensure they are on your PATH."
+    );
+  }
+
+  const interactive = !!sys.writeOutputIsTTY?.() && (await queryInteractive());
+
+  for (const item of toInstall) {
+    if (interactive) await guidedInstall(platform, item, installData);
+    else printInstallCommands(platform, item, installData);
+  }
+
+  const remaining = await requiredInstalls(installItems);
+
+  if (remaining.length === 0) {
+    print2("All packages successfully installed");
+    return true;
+  }
+  return false;
+};

--- a/src/drivers/stdio.ts
+++ b/src/drivers/stdio.ts
@@ -39,6 +39,7 @@ export function print2(message: any) {
 const AnsiCodes = {
   Reset: "00",
   Dim: "02",
+  Yellow: "33",
 } as const;
 
 export const Ansi = mapValues(AnsiCodes, (v) => `\u001b[${v}m`);

--- a/src/plugins/aws/ssm/install.ts
+++ b/src/plugins/aws/ssm/install.ts
@@ -8,36 +8,21 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { print1, print2 } from "../../../drivers/stdio";
+import {
+  AwsInstall,
+  AwsItems,
+  ensureInstall,
+  InstallMetadata,
+  SupportedPlatforms,
+} from "../../../common/install";
 import { isa } from "../../../types";
-import { compact } from "lodash";
-import { spawn } from "node:child_process";
 import os from "node:os";
-import { sys } from "typescript";
-import which from "which";
 
-const SupportedPlatforms = ["darwin"] as const;
-type SupportedPlatform = (typeof SupportedPlatforms)[number];
+const SsmItems = [...AwsItems, "session-manager-plugin"] as const;
+type SsmItem = (typeof SsmItems)[number];
 
-const AwsItems = ["aws", "session-manager-plugin"] as const;
-type AwsItem = (typeof AwsItems)[number];
-
-const AwsInstall: Readonly<
-  Record<
-    AwsItem,
-    { label: string; commands: Record<SupportedPlatform, Readonly<string[]>> }
-  >
-> = {
-  aws: {
-    label: "AWS CLI v2",
-    commands: {
-      darwin: [
-        'curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"',
-        "sudo installer -pkg AWSCLIV2.pkg -target /",
-        'rm "AWSCLIV2.pkg"',
-      ],
-    },
-  },
+const SsmInstall: Readonly<Record<SsmItem, InstallMetadata>> = {
+  ...AwsInstall,
   "session-manager-plugin": {
     label: "the AWS CLI Session Manager plugin",
     commands: {
@@ -51,65 +36,6 @@ const AwsInstall: Readonly<
   },
 };
 
-const printToInstall = (toInstall: AwsItem[]) => {
-  print2("The following items must be installed on your system to continue:");
-  for (const item of toInstall) {
-    print2(`  - ${AwsInstall[item].label}`);
-  }
-  print2("");
-};
-
-const queryInteractive = async () => {
-  const inquirer = (await import("inquirer")).default;
-  const { isGuided } = await inquirer.prompt([
-    {
-      type: "confirm",
-      name: "isGuided",
-      message:
-        "Do you want P0 to install these for you (sudo access required)?",
-    },
-  ]);
-  print2("");
-  return isGuided;
-};
-
-const requiredInstalls = async () =>
-  compact(
-    await Promise.all(
-      AwsItems.map(async (item) =>
-        (await which(item, { nothrow: true })) === null ? item : undefined
-      )
-    )
-  );
-
-const printInstallCommands = (platform: SupportedPlatform, item: AwsItem) => {
-  const { label, commands } = AwsInstall[item];
-  print2(`To install ${label}, run the following commands:\n`);
-  for (const command of commands[platform]) {
-    print1(`  ${command}`);
-  }
-  print1(""); // Newline is useful for reading command output in a script, so send to /fd/1
-};
-
-const guidedInstall = async (platform: SupportedPlatform, item: AwsItem) => {
-  const commands = AwsInstall[item].commands[platform];
-
-  const combined = commands.join(" && \\\n");
-
-  print2(`Executing:\n${combined}`);
-  print2("");
-
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn("bash", ["-c", combined], { stdio: "inherit" });
-    child.on("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(`Shell exited with code ${code}`);
-    });
-  });
-
-  print2("");
-};
-
 /** Ensures that AWS CLI and SSM plugin are installed on the user environment
  *
  * If they are not, and the session is a TTY, prompt the user to auto-install. If
@@ -119,26 +45,9 @@ const guidedInstall = async (platform: SupportedPlatform, item: AwsItem) => {
 export const ensureSsmInstall = async () => {
   const platform = os.platform();
 
+  // Preserve existing behavior of a hard error on unsupported platforms
   if (!isa(SupportedPlatforms)(platform))
     throw "SSH to AWS managed instances is only available on MacOS";
 
-  const toInstall = await requiredInstalls();
-  if (toInstall.length === 0) return true;
-
-  printToInstall(toInstall);
-
-  const interactive = !!sys.writeOutputIsTTY?.() && (await queryInteractive());
-
-  for (const item of toInstall) {
-    if (interactive) await guidedInstall(platform, item);
-    else printInstallCommands(platform, item);
-  }
-
-  const remaining = await requiredInstalls();
-
-  if (remaining.length === 0) {
-    print2("All packages successfully installed");
-    return true;
-  }
-  return false;
+  return await ensureInstall(SsmItems, SsmInstall);
 };

--- a/src/plugins/kubeconfig/index.ts
+++ b/src/plugins/kubeconfig/index.ts
@@ -1,0 +1,138 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { KubeconfigCommandArgs } from "../../commands/kubeconfig";
+import { waitForProvisioning } from "../../commands/shared";
+import { request } from "../../commands/shared/request";
+import { doc } from "../../drivers/firestore";
+import { print2 } from "../../drivers/stdio";
+import { Authn } from "../../types/identity";
+import { Request } from "../../types/request";
+import { assertNever } from "../../util";
+import { assumeRoleWithIdc } from "../aws/idc";
+import { AwsCredentials } from "../aws/types";
+import { assumeRoleWithOktaSaml } from "../okta/aws";
+import {
+  EksClusterConfig,
+  K8sConfig,
+  K8sGenerated,
+  K8sPermissionSpec,
+} from "./types";
+import { getDoc } from "firebase/firestore";
+import { pick } from "lodash";
+import yargs from "yargs";
+
+export const getAndValidateK8sIntegration = async (
+  authn: Authn,
+  clusterId: string
+): Promise<EksClusterConfig> => {
+  const configDoc = await getDoc<K8sConfig, object>(
+    doc(`o/${authn.identity.org.tenantId}/integrations/k8s`)
+  );
+
+  const clusterConfig = configDoc
+    .data()
+    ?.workflows.items.find(
+      (c) => c.clusterId === clusterId && c.state === "installed"
+    );
+
+  if (!clusterConfig) {
+    throw `Cluster with ID ${clusterId} not found`;
+  }
+
+  const { awsAccountId, awsClusterArn } = clusterConfig;
+
+  if (!awsAccountId || !awsClusterArn) {
+    throw (
+      `This command currently only supports AWS EKS clusters, and ${clusterId} is not configured as one.\n` +
+      "You can request access to the cluster using the `p0 request k8s` command."
+    );
+  }
+
+  return {
+    ...clusterConfig,
+    awsAccountId,
+    awsClusterArn,
+  };
+};
+
+export const requestAccessToCluster = async (
+  authn: Authn,
+  args: yargs.ArgumentsCamelCase<KubeconfigCommandArgs>,
+  clusterId: string,
+  role: string
+): Promise<Request<K8sPermissionSpec>> => {
+  const response = await request("request")(
+    {
+      ...pick(args, "$0", "_"),
+      arguments: [
+        "k8s",
+        "resource",
+        "--cluster",
+        clusterId,
+        "--role",
+        role,
+        ...(args.resource ? ["--locator", args.resource] : []),
+        ...(args.reason ? ["--reason", args.reason] : []),
+        ...(args.requestedDuration
+          ? ["--requested-duration", args.requestedDuration]
+          : []),
+      ],
+      wait: true,
+    },
+    authn,
+    { message: "approval-required" }
+  );
+
+  if (!response) {
+    throw "Did not receive access ID from server";
+  }
+  const { id, isPreexisting } = response;
+  if (!isPreexisting) {
+    print2(
+      "Waiting for access to be provisioned. This may take up to a minute."
+    );
+  }
+
+  return await waitForProvisioning<K8sPermissionSpec>(authn, id);
+};
+
+export const profileName = (eksCluterName: string): string =>
+  `p0cli-managed-eks-${eksCluterName}`;
+
+export const awsCloudAuth = async (
+  authn: Authn,
+  awsAccountId: string,
+  generated: K8sGenerated,
+  loginType: "federated" | "idc"
+): Promise<AwsCredentials> => {
+  const { eksGenerated } = generated;
+  const { name, idc } = eksGenerated;
+
+  switch (loginType) {
+    case "idc":
+      if (!idc) {
+        throw "AWS is configured to use Identity Center, but IDC information wasn't received in the request.";
+      }
+
+      return await assumeRoleWithIdc({
+        accountId: awsAccountId,
+        permissionSet: name,
+        idc,
+      });
+    case "federated":
+      return await assumeRoleWithOktaSaml(authn, {
+        accountId: awsAccountId,
+        role: name,
+      });
+    default:
+      throw assertNever(loginType);
+  }
+};

--- a/src/plugins/kubeconfig/install.ts
+++ b/src/plugins/kubeconfig/install.ts
@@ -65,6 +65,5 @@ const EksInstall: Readonly<Record<EksItem, InstallMetadata>> = {
   },
 };
 
-export const ensureEksInstall = async () => {
-  return await ensureInstall(EksItems, EksInstall);
-};
+export const ensureEksInstall = async () =>
+  await ensureInstall(EksItems, EksInstall);

--- a/src/plugins/kubeconfig/install.ts
+++ b/src/plugins/kubeconfig/install.ts
@@ -1,0 +1,70 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import {
+  AwsInstall,
+  AwsItems,
+  ensureInstall,
+  InstallMetadata,
+} from "../../common/install";
+
+const EksItems = [...AwsItems, "kubectl"] as const;
+type EksItem = (typeof EksItems)[number];
+
+/**
+ * Converts the current system architecture, as represented in TypeScript, to
+ * the value used in the kubectl download URL, or throw an exception if the
+ * current architecture is not one kubectl has an official build for.
+ */
+const kubectlDownloadArch = (): string => {
+  const arch = process.arch;
+
+  switch (arch) {
+    case "x64": // macOS, Linux, and Windows
+      return "amd64";
+    case "arm64": // macOS and Linux only
+      return arch;
+    default:
+      throw `Unsupported system architecture for kubectl: ${arch}. Please install kubectl manually, or check that it is available in your PATH.`;
+  }
+};
+
+const kubectlInstallCommandsDarwin = (): Readonly<string[]> => {
+  const arch = kubectlDownloadArch();
+
+  // The download is the kubectl binary itself
+  return [
+    `curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/darwin/${arch}/kubectl"`,
+    "chmod +x kubectl",
+    "sudo mkdir -p /usr/local/bin",
+    "sudo mv -i ./kubectl /usr/local/bin/kubectl",
+    "sudo chown root: /usr/local/bin/kubectl",
+  ];
+};
+
+const EksInstall: Readonly<Record<EksItem, InstallMetadata>> = {
+  ...AwsInstall,
+  kubectl: {
+    label: "Kubernetes command-line tool",
+    commands: {
+      get darwin() {
+        // Use a getter so that we only invoke kubectlInstallCommandsDarwin() if and when we
+        // need to generate the installation commands so that we only check the architecture as
+        // needed; if kubectl is already installed, doesn't really matter how it was installed
+        // or whether it's an officially-supported architecture.
+        return kubectlInstallCommandsDarwin();
+      },
+    },
+  },
+};
+
+export const ensureEksInstall = async () => {
+  return await ensureInstall(EksItems, EksInstall);
+};

--- a/src/plugins/kubeconfig/types.ts
+++ b/src/plugins/kubeconfig/types.ts
@@ -1,0 +1,74 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { PermissionSpec } from "../../types/request";
+
+export type K8sConfig = {
+  workflows: {
+    items: K8sClusterConfig[];
+  };
+};
+
+export type BaseK8sClusterConfig = {
+  clusterId: string;
+
+  clusterServer: string;
+  clusterCertificate: string;
+  state: string;
+} & (KubernetesProxyComponentConfig | KubernetesPublicComponentConfig);
+
+// k8s clusters that are not EKS clusters will not have these set...
+export type K8sClusterConfig = BaseK8sClusterConfig & {
+  awsAccountId?: string;
+  awsClusterArn?: string;
+};
+
+// ...But all EKS clusters must have both set
+export type EksClusterConfig = BaseK8sClusterConfig & {
+  awsAccountId: string;
+  awsClusterArn: string;
+};
+
+type KubernetesProxyComponentConfig = {
+  isProxy: true;
+  publicJwk: string;
+};
+
+export type KubernetesPublicComponentConfig = {
+  isProxy: false;
+};
+
+export type K8sPermissionSpec = PermissionSpec<
+  "k8s",
+  K8sResourcePermission,
+  K8sGenerated
+>;
+
+export type K8sResourcePermission = {
+  resource: {
+    name: string;
+    namespace: string;
+    kind: string;
+  };
+  role: string;
+  clusterId: string;
+  type: "resource";
+};
+
+export type K8sGenerated = {
+  eksGenerated: {
+    // For IDC, the name of the permission set. For Federated, the name of the assumed role
+    name: string;
+
+    // Only present for IDC; the ID and region of the IDC installation
+    idc?: { id: string; region: string };
+  };
+  role: string; // The name of the generated role in k8s itself
+};

--- a/src/plugins/kubeconfig/types.ts
+++ b/src/plugins/kubeconfig/types.ts
@@ -16,21 +16,17 @@ export type K8sConfig = {
   };
 };
 
-export type BaseK8sClusterConfig = {
+export type K8sClusterConfig = {
   clusterId: string;
   clusterServer: string;
   clusterCertificate: string;
   state: string;
-} & (KubernetesProxyComponentConfig | KubernetesPublicComponentConfig);
-
-// k8s clusters that are not EKS clusters will not have these set...
-export type K8sClusterConfig = BaseK8sClusterConfig & {
   awsAccountId?: string;
   awsClusterArn?: string;
-};
+} & (KubernetesProxyComponentConfig | KubernetesPublicComponentConfig);
 
-// ...But all EKS clusters must have both set
-export type EksClusterConfig = BaseK8sClusterConfig & {
+// These are optional in general for k8s clusters, but required for EKS
+export type EksClusterConfig = K8sClusterConfig & {
   awsAccountId: string;
   awsClusterArn: string;
 };

--- a/src/plugins/kubeconfig/types.ts
+++ b/src/plugins/kubeconfig/types.ts
@@ -18,7 +18,6 @@ export type K8sConfig = {
 
 export type BaseK8sClusterConfig = {
   clusterId: string;
-
   clusterServer: string;
   clusterCertificate: string;
   state: string;

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { K8sPermissionSpec } from "../plugins/kubeconfig/types";
 import { PluginSshRequest } from "./ssh";
 
 export const DONE_STATUSES = ["DONE", "DONE_NOTIFIED"] as const;
@@ -28,7 +29,7 @@ export type PermissionSpec<
   generated: G;
 };
 
-export type PluginRequest = PluginSshRequest;
+export type PluginRequest = K8sPermissionSpec | PluginSshRequest;
 
 export type Request<P extends PluginRequest> = P & {
   status: string;

--- a/src/util.ts
+++ b/src/util.ts
@@ -97,5 +97,15 @@ export const assertNever = (value: never) => {
 export const unexpectedValueError = (value: any) =>
   new Error(`Unexpected code state: value ${value} had unexpected type`);
 
-export const stricmp = (a: string, b: string) =>
+/**
+ * Performs a case-insensitive comparison of two strings. This uses
+ * `localeCompare()`, which is safer than `toLowerCase()` or `toUpperCase()` for
+ * non-ASCII characters and is the generally-accepted best practice. See:
+ * https://stackoverflow.com/a/2140723
+ *
+ * @param a The first string to compare
+ * @param b The second string to compare
+ * @returns true if the strings are equal, ignoring case
+ */
+export const ciEquals = (a: string, b: string) =>
   a.localeCompare(b, undefined, { sensitivity: "accent" }) === 0;

--- a/src/util.ts
+++ b/src/util.ts
@@ -96,3 +96,6 @@ export const assertNever = (value: never) => {
 
 export const unexpectedValueError = (value: any) =>
   new Error(`Unexpected code state: value ${value} had unexpected type`);
+
+export const stricmp = (a: string, b: string) =>
+  a.localeCompare(b, undefined, { sensitivity: "accent" }) === 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1219,6 +1219,11 @@
   resolved "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz"
   integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
 
+"@types/ini@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/ini/-/ini-4.1.1.tgz#6984664a8cc74c3348f4049d0bf2b1ab2d061ca3"
+  integrity sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==
+
 "@types/inquirer@^9.0.7":
   version "9.0.7"
   resolved "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.7.tgz"
@@ -3106,6 +3111,11 @@ inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ini@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-4.1.3.tgz#4c359675a6071a46985eb39b14e4a2c0ec98a795"
+  integrity sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==
+
 inquirer@^9.2.15:
   version "9.2.15"
   resolved "https://registry.npmjs.org/inquirer/-/inquirer-9.2.15.tgz"
@@ -4836,12 +4846,24 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+tmp-promise@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This PR implements support for fully automated access to an AWS EKS cluster for AWS accounts configured to use IAM Identity Center or federated access via Okta SAML. The command, `p0 kubeconifig` will:

- Confirm that required tooling, specifically the AWS CLI and `kubectl`, are installed, and provide installation assistance if not
- Make a P0 request to the given cluster and wait for access to be granted
- If using IDC, perform an SSO login to IDC
- For both IDC and federated, write the temporary AWS credentials to a profile in the `~/.aws/credentials` file, using a unique but stable profile for each EKS cluster to allow for re-running the command to refresh credentials
    - Makes use of an INI parser and atomic file writes to guard against corruption issues and prevent stomping on other credentials
- Call `aws eks update-kubeconfig` to automatically generate or update the `kubectl` configuration
- Call `kubectl config use-context` to activate the configuration

Once done, the user can simply run `kubectl` commands to interact seamlessly with the cluster.

Tested locally against my testing EKS cluster, in both AWS IDC and AWS Federated (Okta SAML) modes. Also tested behavior when `kubectl` command is missing.

Standard flow from no access to able to access:
![Standard flow](https://github.com/user-attachments/assets/e1b00a71-091b-4621-b12e-5486222b01de)

Example flow when `kubectl` not detected. Note that the `kubectl` download URL correctly reflects the system processor architecture:
![Missing kubectl](https://github.com/user-attachments/assets/ad6ccc60-947f-4b2f-b764-cded587c3134)