### PR TITLE
Automatic gcloud CLI installation

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -143,8 +143,28 @@ export const provisionRequest = async (
     throw "Public key mismatch. Please revoke the request and try again.";
   }
 
-  return { request: provisionedRequest, publicKey, privateKey };
+  return { provisionedRequest, publicKey, privateKey };
 };
 
-export const requestToSsh = (request: Request<PluginSshRequest>): SshRequest =>
-  SSH_PROVIDERS[request.permission.spec.type].requestToSsh(request as any);
+export const prepareRequest = async (
+  authn: Authn,
+  args: yargs.ArgumentsCamelCase<BaseSshCommandArgs>,
+  destination: string
+) => {
+  const result = await provisionRequest(authn, args, destination);
+  if (!result) {
+    throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
+  }
+
+  const { provisionedRequest } = result;
+
+  const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.spec.type];
+  await sshProvider.ensureInstall();
+
+  const cliRequest = await pluginToCliRequest(provisionedRequest, {
+    debug: args.debug,
+  });
+  const request = sshProvider.requestToSsh(cliRequest);
+
+  return { ...result, request, sshProvider };
+};

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -21,7 +21,6 @@ import {
   CliSshRequest,
   PluginSshRequest,
   SshProvider,
-  SshRequest,
   SupportedSshProvider,
   SupportedSshProviders,
 } from "../../types/ssh";

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -87,7 +87,7 @@ const validateSshInstall = async (
   }
 };
 
-export const pluginToCliRequest = async (
+const pluginToCliRequest = async (
   request: Request<PluginSshRequest>,
   options?: { debug?: boolean }
 ): Promise<Request<CliSshRequest>> =>

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -87,7 +87,7 @@ const validateSshInstall = async (
   }
 };
 
-const pluginToCliRequest = async (
+export const pluginToCliRequest = async (
   request: Request<PluginSshRequest>,
   options?: { debug?: boolean }
 ): Promise<Request<CliSshRequest>> =>
@@ -143,12 +143,8 @@ export const provisionRequest = async (
     throw "Public key mismatch. Please revoke the request and try again.";
   }
 
-  const cliRequest = await pluginToCliRequest(provisionedRequest, {
-    debug: args.debug,
-  });
-
-  return { request: cliRequest, publicKey, privateKey };
+  return { request: provisionedRequest, publicKey, privateKey };
 };
 
-export const requestToSsh = (request: Request<CliSshRequest>): SshRequest =>
+export const requestToSsh = (request: Request<PluginSshRequest>): SshRequest =>
   SSH_PROVIDERS[request.permission.spec.type].requestToSsh(request as any);

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
+import { print1, print2 } from "../drivers/stdio";
 import { sshOrScp } from "../plugins/ssh";
 import { SshCommandArgs, provisionRequest, requestToSsh } from "./shared/ssh";
 import yargs from "yargs";
@@ -88,7 +89,7 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
   const authn = await authenticate();
 
   const destination = args.destination;
-
+  print2("temp - provisionRequest");
   const result = await provisionRequest(authn, args, destination);
   if (!result) {
     throw "Server did not return a request id. Please contact support@p0.dev for assistance.";
@@ -96,9 +97,10 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
 
   const { request, privateKey } = result;
 
+  print2("temp - sshOrScp");
   await sshOrScp(
     authn,
-    requestToSsh(request),
+    request,
     {
       ...args,
       destination,

--- a/src/common/install.ts
+++ b/src/common/install.ts
@@ -126,10 +126,8 @@ export const ensureInstall = async <
   installItems: readonly T[],
   installData: U
 ): Promise<boolean> => {
-  print2("temp - ensureInstall");
   const toInstall = await requiredInstalls(installItems);
 
-  print2("temp - requiredInstalls");
   if (toInstall.length === 0) {
     return true;
   }

--- a/src/common/install.ts
+++ b/src/common/install.ts
@@ -126,8 +126,10 @@ export const ensureInstall = async <
   installItems: readonly T[],
   installData: U
 ): Promise<boolean> => {
+  print2("temp - ensureInstall");
   const toInstall = await requiredInstalls(installItems);
 
+  print2("temp - requiredInstalls");
   if (toInstall.length === 0) {
     return true;
   }

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -54,11 +54,12 @@ export const awsSshProvider: SshProvider<
         };
   },
   toCliRequest: async (request) => ({ ...request, cliLocalData: undefined }),
-  cloudProviderLogin: async (authn, request) => {
+  ensureInstall: async () => {
     if (!(await ensureSsmInstall())) {
       throw "Please try again after installing the required AWS utilities";
     }
-
+  },
+  cloudProviderLogin: async (authn, request) => {
     const { config } = await getAwsConfig(authn, request.accountId);
     if (!config.login?.type || config.login?.type === "iam") {
       throw "This account is not configured for SSH access via the P0 CLI";

--- a/src/plugins/aws/ssm/install.ts
+++ b/src/plugins/aws/ssm/install.ts
@@ -13,10 +13,7 @@ import {
   AwsItems,
   ensureInstall,
   InstallMetadata,
-  SupportedPlatforms,
 } from "../../../common/install";
-import { isa } from "../../../types";
-import os from "node:os";
 
 const SsmItems = [...AwsItems, "session-manager-plugin"] as const;
 type SsmItem = (typeof SsmItems)[number];

--- a/src/plugins/aws/ssm/install.ts
+++ b/src/plugins/aws/ssm/install.ts
@@ -42,12 +42,4 @@ const SsmInstall: Readonly<Record<SsmItem, InstallMetadata>> = {
  * the user declines, or if not a TTY, the installation commands are printed to
  * stdout.
  */
-export const ensureSsmInstall = async () => {
-  const platform = os.platform();
-
-  // Preserve existing behavior of a hard error on unsupported platforms
-  if (!isa(SupportedPlatforms)(platform))
-    throw "SSH to AWS managed instances is only available on MacOS";
-
-  return await ensureInstall(SsmItems, SsmInstall);
-};
+export const ensureSsmInstall = () => ensureInstall(SsmItems, SsmInstall);

--- a/src/plugins/google/install.ts
+++ b/src/plugins/google/install.ts
@@ -23,10 +23,14 @@ const GcpSshInstall: Readonly<Record<GcpSshItem, InstallMetadata>> = {
         // See https://cloud.google.com/sdk/docs/install-sdk
         "architecture=$(arch)",
         'package=$([ $architecture = "arm64" ] && echo "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-arm.tar.gz" || "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-x86_64.tar.gz" )',
-        "wget -O google-cloud-cli.tar.gz $package",
-        "tar -xzf google-cloud-cli.tar.gz",
-        "./google-cloud-sdk/install.sh",
-        "rm -rf google-cloud-cli.tar.gz",
+        "wget -O ~/google-cloud-cli.tar.gz $package",
+        "tar -xzf ~/google-cloud-cli.tar.gz -C ~", // Extract to home directory
+        "~/google-cloud-sdk/install.sh",
+        "rm -rf ~/google-cloud-cli.tar.gz",
+        // Symlink gcloud to /usr/local/bin - assumes /usr/local/bin is already in $PATH so next time `gcloud` is run it will be found
+        "sudo mkdir -p /usr/local/bin",
+        "sudo ln -s ~/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud",
+        "sudo chown root: /usr/local/bin/gcloud",
       ],
     },
   },

--- a/src/plugins/google/install.ts
+++ b/src/plugins/google/install.ts
@@ -1,0 +1,36 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { ensureInstall, InstallMetadata } from "../../common/install";
+
+export const SupportedPlatforms = ["darwin"] as const;
+
+const GcpSshItems = ["gcloud"] as const;
+type GcpSshItem = (typeof GcpSshItems)[number];
+
+const GcpSshInstall: Readonly<Record<GcpSshItem, InstallMetadata>> = {
+  gcloud: {
+    label: "GCloud CLI",
+    commands: {
+      darwin: [
+        // See https://cloud.google.com/sdk/docs/install-sdk
+        "architecture=$(arch)",
+        'package=$([ $architecture = "arm64" ] && echo "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-arm.tar.gz" || "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-x86_64.tar.gz" )',
+        "wget -O google-cloud-cli.tar.gz $package",
+        "tar -xzf google-cloud-cli.tar.gz",
+        "./google-cloud-sdk/install.sh",
+        "rm -rf google-cloud-cli.tar.gz",
+      ],
+    },
+  },
+};
+
+export const ensureGcpSshInstall = () =>
+  ensureInstall(GcpSshItems, GcpSshInstall);

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { isSudoCommand } from "../../commands/shared/ssh";
 import { SshProvider } from "../../types/ssh";
+import { ensureGcpSshInstall } from "./install";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
 
@@ -42,6 +43,11 @@ export const gcpSshProvider: SshProvider<
       ),
     },
   }),
+  ensureInstall: async () => {
+    if (!(await ensureGcpSshInstall())) {
+      throw "Please try again after installing the required GCP utilities";
+    }
+  },
   cloudProviderLogin: async () => undefined, // TODO @ENG-2284 support login with Google Cloud
   proxyCommand: (request) => {
     return [

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -8,22 +8,11 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import {
-  CommandArgs,
-  pluginToCliRequest,
-  requestToSsh,
-  SSH_PROVIDERS,
-} from "../../commands/shared/ssh";
+import { CommandArgs, SSH_PROVIDERS } from "../../commands/shared/ssh";
 import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { print2 } from "../../drivers/stdio";
 import { Authn } from "../../types/identity";
-import { Request } from "../../types/request";
-import {
-  PluginSshRequest,
-  SshProvider,
-  SshRequest,
-  SupportedSshProvider,
-} from "../../types/ssh";
+import { SshProvider, SshRequest, SupportedSshProvider } from "../../types/ssh";
 import { AwsCredentials } from "../aws/types";
 import { withSshAgent } from "../ssh-agent";
 import {
@@ -339,26 +328,17 @@ const preTestAccessPropagationIfNeeded = async <
   return null;
 };
 
-export const sshOrScp = async (
-  authn: Authn,
-  pluginRequest: Request<PluginSshRequest>,
-  cmdArgs: CommandArgs,
-  privateKey: string
-) => {
+export const sshOrScp = async (args: {
+  authn: Authn;
+  request: SshRequest;
+  cmdArgs: CommandArgs;
+  privateKey: string;
+  sshProvider: SshProvider<any, any, any, any>;
+}) => {
+  const { authn, request, cmdArgs, privateKey, sshProvider } = args;
   if (!privateKey) {
     throw "Failed to load a private key for this request. Please contact support@p0.dev for assistance.";
   }
-
-  const type = pluginRequest.permission.spec.type;
-  const sshProvider = SSH_PROVIDERS[type];
-
-  print2("temp - ensureInstall");
-  await sshProvider.ensureInstall();
-
-  const cliRequest = await pluginToCliRequest(pluginRequest, {
-    debug: cmdArgs.debug,
-  });
-  const request = requestToSsh(cliRequest);
 
   const credential: AwsCredentials | undefined =
     await sshProvider.cloudProviderLogin(authn, request);

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -48,6 +48,7 @@ export type SshProvider<
     request: Request<PR>,
     options?: { debug?: boolean }
   ) => Promise<Request<CliSshRequest>>;
+  ensureInstall: () => Promise<void>;
   /** Logs in the user to the cloud provider */
   cloudProviderLogin: (authn: Authn, request: SR) => Promise<C>;
   /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option */


### PR DESCRIPTION
Add a new `ensureInstall` method to the SSH provider type. Move the AWS SSM installation to this function, and add a new implementation for GCP that installs the gcloud CLI.

The `ensureInstall` method must be called before any other functions on the SSH provider because those functions may already use the required dependencies. In the case of GCP, the `toCliRequest` function calls `gcloud auth print-access-token`.  Add a new `prepareRequest` function is to establish the correct ordering of calls.

https://github.com/user-attachments/assets/ed96f7f4-cc34-4563-9683-c43cb21900c1

Also: logging improvement in access propagation guard: log first attempt, and log whether it's a pre-test (used only by gcp) or actual ssh session login.