### PR TITLE
ENG-2493 Add SSH -o and -R options

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -48,8 +48,10 @@ export type SshCommandArgs = BaseSshCommandArgs & {
   sudo?: boolean;
   destination: string;
   L?: string; // Port forwarding option
+  R?: string; // Reverse port forwarding option
   N?: boolean; // No remote command
   A?: boolean; // Agent forwarding
+  o?: string; // Configuration options
   arguments: string[];
   command?: string;
 };

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -63,7 +63,7 @@ export const sshCommand = (yargs: yargs.Argv) =>
         .option("o", {
           type: "string",
           describe:
-            "Can be used to give options in the format used in the configuration file.",
+            "Can be used to give options in the format used in the SSH configuration file.",
         })
         // Match `p0 request --reason`
         .option("reason", {

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -24,10 +24,6 @@ export const sshCommand = (yargs: yargs.Argv) =>
           type: "string",
           demandOption: true,
         })
-        .option("sudo", {
-          type: "boolean",
-          describe: "Add user to sudoers file",
-        })
         .positional("command", {
           type: "string",
           describe: "Pass command to the shell",
@@ -38,11 +34,21 @@ export const sshCommand = (yargs: yargs.Argv) =>
           string: true,
           default: [] as string[],
         })
+        .option("sudo", {
+          type: "boolean",
+          describe: "Add user to sudoers file",
+        })
         .option("L", {
           type: "string",
           // Copied from `man ssh`
           describe:
             "Specifies that connections to the given TCP port or Unix socket on the local (client) host are to be forwarded to the given host and port, or Unix socket, on the remote side.",
+        })
+        .option("R", {
+          type: "string",
+          // Copied from `man ssh`
+          describe:
+            "Specifies that connections to the given TCP port or Unix socket on the remote (server) host are to be forwarded to the local side.",
         })
         .option("N", {
           type: "boolean",
@@ -53,6 +59,11 @@ export const sshCommand = (yargs: yargs.Argv) =>
           type: "boolean",
           describe:
             "Enables forwarding of connections from an authentication agent such as ssh-agent",
+        })
+        .option("o", {
+          type: "string",
+          describe:
+            "Can be used to give options in the format used in the configuration file.",
         })
         // Match `p0 request --reason`
         .option("reason", {

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -265,7 +265,9 @@ const createCommand = (
       ...commonArgs,
       ...(args.A ? ["-A"] : []),
       ...(args.L ? ["-L", args.L] : []),
+      ...(args.R ? ["-R", args.R] : []),
       ...(args.N ? ["-N"] : []),
+      ...(args.o ? ["-o", args.o] : []),
       `${data.linuxUserName}@${data.id}`,
       ...(args.command ? [args.command] : []),
       ...args.arguments.map(


### PR DESCRIPTION
Update P0 CLI to include SSH -o (options) and -R (remote port forwarding) options

Manually verified that P0 SSH now works to enable remote port forwarding for dev instance on both AWS and GCP.