### PR TITLE
ENG-2319 Specify the path to the keyfile when invoking ssh and scp.

### DIFF
--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -243,8 +243,10 @@ const createCommand = (
 ) => {
   const commonArgs = [
     ...(args.debug ? ["-v"] : []),
+    // Explicitly specify which private key to use to avoid "Too many authentication failures"
+    // error caused by SSH trying every available key
     "-i",
-    PRIVATE_KEY_PATH, // ENG-2319 Explicitly specify which private key to use
+    PRIVATE_KEY_PATH,
     "-o",
     `ProxyCommand=${proxyCommand.join(" ")}`,
   ];

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -52,9 +52,6 @@ const SUDO_MESSAGE = /Sorry, user .+ may not run sudo on .+/; // The output of `
  */
 const DEFAULT_VALIDATION_WINDOW_MS = 5e3;
 
-/** Delay between retries */
-const RETRY_DELAY_MS = 2000;
-
 /**
  * AWS
  * There are 2 cases of unprovisioned access in AWS
@@ -219,16 +216,12 @@ async function spawnSshNode(
           return;
         }
 
-        new Promise<void>((resolve) =>
-          setTimeout(resolve, RETRY_DELAY_MS)
-        ).then(() =>
-          spawnSshNode({
-            ...options,
-            attemptsRemaining: attemptsRemaining - 1,
-          })
-            .then((code) => resolve(code))
-            .catch(reject)
-        );
+        spawnSshNode({
+          ...options,
+          attemptsRemaining: attemptsRemaining - 1,
+        })
+          .then((code) => resolve(code))
+          .catch(reject);
 
         return;
       } else if (isGoogleLoginException()) {


### PR DESCRIPTION
Specify the path to the keyfile when invoking ssh and scp.

This is to avoid the "Too many authentication failures" that may happen when SSH has to iterate over too many keys before finding a match when attempting to connect.

See the ticket for additional details.