### PR TITLE
Fix ls help

### DIFF
--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -32,6 +32,7 @@ type LsResponse = {
 const lsArgs = <T>(yargs: yargs.Argv<T>) =>
   yargs
     .parserConfiguration({ "unknown-options-as-args": true })
+    .help(false)
     .option("arguments", {
       array: true,
       string: true,


### PR DESCRIPTION
Set yargs help to false in order to forward --help argument to P0 backend to correctly display ls help

Before:

```
komal@Komals-MacBook-Pro p0cli % ./p0 ls ssh --help
p0 ls [arguments..]

List request-command arguments

Options:
  --help       Show help                                               [boolean]
  --version    Show version number                                     [boolean]
  --arguments                                              [array] [default: []]
```

After
```
komal@Komals-MacBook-Pro p0cli % ./p0 ls ssh --help
p0 ls ssh

Secure Shell (SSH)

Commands:
  p0 ls ssh session <destination>  Secure Shell (SSH) session
  p0 ls ssh all                    Secure Shell (SSH) all
  p0 ls ssh group [name]           Secure Shell (SSH) Group

Options:
  --help  Show help                                                    [boolean]
  --size  Maximum number of items to list                 [number] [default: 15]
```
