### PR TITLE
ENG-2490 Support any SSH option via --

### DIFF
--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -57,6 +57,10 @@ export const scpCommand = (yargs: yargs.Argv) =>
         .option("debug", {
           type: "boolean",
           describe: "Print debug information.",
+        })
+        // Enable populate-- to capture SSH-specific options after `--`
+        .parserConfiguration({
+          "populate--": true,
         }),
     guard(scpAction)
   );

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -68,6 +68,9 @@ export const scpCommand = (yargs: yargs.Argv) =>
 const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
   const authn = await authenticate();
 
+  const sshOptions = (args["--"] ?? []) as string[];
+  args.sshOptions = sshOptions;
+
   const host = getHostIdentifier(args.source, args.destination);
 
   if (!host) {

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -35,6 +35,7 @@ export type BaseSshCommandArgs = {
   account?: string;
   provider?: SupportedSshProvider;
   debug?: boolean;
+  sshOptions?: string[];
 };
 
 export type ScpCommandArgs = BaseSshCommandArgs & {
@@ -46,11 +47,6 @@ export type ScpCommandArgs = BaseSshCommandArgs & {
 export type SshCommandArgs = BaseSshCommandArgs & {
   sudo?: boolean;
   destination: string;
-  L?: string; // Port forwarding option
-  R?: string; // Reverse port forwarding option
-  N?: boolean; // No remote command
-  A?: boolean; // Agent forwarding
-  o?: string; // Configuration options
   arguments: string[];
   command?: string;
 };

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -38,33 +38,6 @@ export const sshCommand = (yargs: yargs.Argv) =>
           type: "boolean",
           describe: "Add user to sudoers file",
         })
-        .option("L", {
-          type: "string",
-          // Copied from `man ssh`
-          describe:
-            "Specifies that connections to the given TCP port or Unix socket on the local (client) host are to be forwarded to the given host and port, or Unix socket, on the remote side.",
-        })
-        .option("R", {
-          type: "string",
-          // Copied from `man ssh`
-          describe:
-            "Specifies that connections to the given TCP port or Unix socket on the remote (server) host are to be forwarded to the local side.",
-        })
-        .option("N", {
-          type: "boolean",
-          describe:
-            "Do not execute a remote command. Useful for forwarding ports.",
-        })
-        .option("A", {
-          type: "boolean",
-          describe:
-            "Enables forwarding of connections from an authentication agent such as ssh-agent",
-        })
-        .option("o", {
-          type: "string",
-          describe:
-            "Can be used to give options in the format used in the SSH configuration file.",
-        })
         // Match `p0 request --reason`
         .option("reason", {
           describe: "Reason access is needed",
@@ -82,6 +55,10 @@ export const sshCommand = (yargs: yargs.Argv) =>
         .option("debug", {
           type: "boolean",
           describe: "Print debug information.",
+        })
+        // Enable populate-- to capture SSH-specific options after `--`
+        .parserConfiguration({
+          "populate--": true,
         }),
     guard(sshAction)
   );
@@ -96,6 +73,9 @@ export const sshCommand = (yargs: yargs.Argv) =>
 const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
   // Prefix is required because the backend uses it to determine that this is an AWS request
   const authn = await authenticate();
+
+  const sshOptions = (args["--"] ?? []) as string[];
+  args.sshOptions = sshOptions;
 
   const { request, privateKey, sshProvider } = await prepareRequest(
     authn,

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -243,17 +243,12 @@ const createCommand = (
   addCommonArgs(args, proxyCommand);
 
   if ("source" in args) {
+    addScpArgs(args);
+
     return {
       command: "scp",
       args: [
         ...(args.sshOptions ? args.sshOptions : []),
-        // if a response is not received after three 5 minute attempts,
-        // the connection will be closed.
-        "-o",
-        "ServerAliveCountMax=3",
-        `-o`,
-        "ServerAliveInterval=300",
-        ...(args.recursive ? ["-r"] : []),
         args.source,
         args.destination,
       ],
@@ -316,6 +311,35 @@ const addCommonArgs = (args: CommandArgs, proxyCommand: string[]) => {
   const verboseOptionExists = sshOptions.some((opt) => opt === "-v");
   if (!verboseOptionExists) {
     sshOptions.push("-v");
+  }
+};
+
+const addScpArgs = (args: CommandArgs) => {
+  const sshOptions = args.sshOptions ? args.sshOptions : [];
+
+  // if a response is not received after three 5 minute attempts,
+  // the connection will be closed.
+  const serverAliveCountMaxOptionExists = sshOptions.some(
+    (opt, idx) =>
+      opt === "-o" && sshOptions[idx + 1]?.startsWith("ServerAliveCountMax")
+  );
+
+  if (!serverAliveCountMaxOptionExists) {
+    sshOptions.push("-o", "ServerAliveCountMax=3");
+  }
+
+  const serverAliveIntervalOptionExists = sshOptions.some(
+    (opt, idx) =>
+      opt === "-o" && sshOptions[idx + 1]?.startsWith("ServerAliveInterval")
+  );
+
+  if (!serverAliveIntervalOptionExists) {
+    sshOptions.push("-o", "ServerAliveInterval=300");
+  }
+
+  const recursiveOptionExists = sshOptions.some((opt) => opt === "-r");
+  if (!recursiveOptionExists) {
+    sshOptions.push("-r");
   }
 };
 


### PR DESCRIPTION
Support specifying any SSH option via --, e.g.:

p0 ssh dev-instance-fabian-joya --provider gcloud -- -NR '*:8080:localhost:8088' -o 'GatewayPorts yes'

Verified that both SSH and SCP work as expected, with and without --.