### PR TITLE
Segregate P0 CLI local files by environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/drivers/env.ts
+++ b/src/drivers/env.ts
@@ -34,4 +34,5 @@ export const config = {
       env.P0_GOOGLE_OIDC_CLIENT_SECRET ?? "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",
   },
   appUrl: env.P0_APP_URL ?? "https://api.p0.app",
+  ENV: env.P0_ENV ?? "production",
 };

--- a/src/drivers/env.ts
+++ b/src/drivers/env.ts
@@ -34,5 +34,5 @@ export const config = {
       env.P0_GOOGLE_OIDC_CLIENT_SECRET ?? "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",
   },
   appUrl: env.P0_APP_URL ?? "https://api.p0.app",
-  ENV: env.P0_ENV ?? "production",
+  environment: env.P0_ENV ?? "production",
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,11 +8,15 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { config } from "./drivers/env";
 import child_process from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 
-export const P0_PATH = path.join(os.homedir(), ".p0");
+export const P0_PATH = path.join(
+  os.homedir(),
+  config.ENV === "dev" ? ".p0-dev" : ".p0"
+);
 
 /** Waits the specified delay (in ms)
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 
 export const P0_PATH = path.join(
   os.homedir(),
-  config.environment === "development" ? ".p0-dev" : ".p0"
+  config.environment === "production" ? ".p0" : `.p0-${config.environment}`
 );
 
 /** Waits the specified delay (in ms)

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 
 export const P0_PATH = path.join(
   os.homedir(),
-  config.ENV === "dev" ? ".p0-dev" : ".p0"
+  config.environment === "dev" ? ".p0-dev" : ".p0"
 );
 
 /** Waits the specified delay (in ms)

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 
 export const P0_PATH = path.join(
   os.homedir(),
-  config.environment === "dev" ? ".p0-dev" : ".p0"
+  config.environment === "development" ? ".p0-dev" : ".p0"
 );
 
 /** Waits the specified delay (in ms)


### PR DESCRIPTION
Addresses: ENG-2527

Adds a way to segregate development and production environments based on .env configuration.

add the below line in .env file
```
P0_ENV=development
```

Folder used for environments:
production --> ./p0

example:
development -->./p0-development
stage-> ./p0-stage





