### PR TITLE
ENG-2677 Better error-handling of expired token

### DIFF
--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -59,7 +59,15 @@ export const importSshKey = async (
   });
 
   if (!response.ok) {
-    throw `Import of SSH public key failed. HTTP error ${response.status}: ${await response.text()}`;
+    if (debug) {
+      print2(`HTTP error ${response.status}: ${await response.text()}`);
+    }
+
+    if (response.status === 401) {
+      throw `Authentication failed. Please login to Google Cloud CLI with 'gcloud auth login'`;
+    } else {
+      throw `Import of SSH public key failed.`;
+    }
   }
 
   const data: ImportSshPublicKeyResponse = await response.json();


### PR DESCRIPTION
Improved the error-handling if 'gcloud auth print-access-token' does not return a valid access token.