### PR TITLE
ENG-2660: Print selected SSH output to stderr

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -26,7 +26,7 @@ import {
  *
  * Each attempt consumes ~ 1 s.
  */
-const MAX_SSH_RETRIES = 30;
+const MAX_SSH_RETRIES = 6;
 
 /** The name of the SessionManager port forwarding document. This document is managed by AWS.  */
 const START_SSH_SESSION_DOCUMENT_NAME = "AWS-StartSSHSession";

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -73,7 +73,7 @@ export const gcpSshProvider: SshProvider<
         // `sudo -v` prints `Sorry, user <user> may not run sudo on <hostname>.` to stderr when user is not a sudoer.
         // It prints nothing to stdout when user is a sudoer - which is important because we don't want any output from the pre-test.
         command: "sudo",
-        arguments: ["-v"],
+        arguments: ["--", "-v"],
       };
     }
     return undefined;

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -18,7 +18,7 @@ import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
  *
  * The length of each attempt varies based on the type of error from a few seconds to < 1s
  */
-const MAX_SSH_RETRIES = 120;
+const MAX_SSH_RETRIES = 24;
 
 export const gcpSshProvider: SshProvider<
   GcpSshPermissionSpec,
@@ -73,7 +73,7 @@ export const gcpSshProvider: SshProvider<
         // `sudo -v` prints `Sorry, user <user> may not run sudo on <hostname>.` to stderr when user is not a sudoer.
         // It prints nothing to stdout when user is a sudoer - which is important because we don't want any output from the pre-test.
         command: "sudo",
-        arguments: ["--", "-v"],
+        arguments: ["-v"],
       };
     }
     return undefined;

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -92,6 +92,10 @@ const UNPROVISIONED_ACCESS_MESSAGES = [
   { pattern: DESTINATION_READ_ERROR },
 ];
 
+// Flags to ensure we only print each message once
+let authMessagePrinted = false;
+let portForwardingMessagePrinted = false;
+
 /** Checks if access has propagated through AWS to the SSM agent
  *
  * AWS takes about 8 minutes, GCP takes under 1 minute
@@ -114,11 +118,28 @@ const accessPropagationGuard = (
 ) => {
   let isEphemeralAccessDeniedException = false;
   let isGoogleLoginException = false;
-  const beforeStart = Date.now();
 
+  const beforeStart = Date.now();
   child.stderr.on("data", (chunk) => {
     const chunkString: string = chunk.toString("utf-8");
-    parseAndPrintSshOutputToStderr(chunkString, debug);
+    const lines = chunkString.split("\n");
+
+    for (const line of lines) {
+      if (debug) {
+        print2(line);
+      } else if (line.includes("Authenticated to") && !authMessagePrinted) {
+        // We want to let the user know that they successfully authenticated
+        print2(line);
+        authMessagePrinted = true;
+      } else if (
+        // We also want to let the user know if port forwarding failed
+        line.includes("port forwarding failed") &&
+        !portForwardingMessagePrinted
+      ) {
+        print2(line);
+        portForwardingMessagePrinted = true;
+      }
+    }
 
     const match = UNPROVISIONED_ACCESS_MESSAGES.find((message) =>
       chunkString.match(message.pattern)
@@ -143,36 +164,6 @@ const accessPropagationGuard = (
     isAccessPropagated: () => !isEphemeralAccessDeniedException,
     isGoogleLoginException: () => isGoogleLoginException,
   };
-};
-
-/**
- * Parses and prints a chunk of SSH output to stderr.
- *
- * If debug is enabled, all output is printed. Otherwise, only selected messages are printed.
- *
- * @param chunkString the chunk to print
- * @param debug true if debug output is enabled
- */
-const parseAndPrintSshOutputToStderr = (
-  chunkString: string,
-  debug?: boolean
-) => {
-  const lines = chunkString.split("\n");
-
-  // SSH only prints the "Authenticated to" message if the verbose option (-v) is enabled
-  for (const line of lines) {
-    if (debug) {
-      print2(line);
-    } else {
-      if (line.includes("Authenticated to")) {
-        print2(line);
-      }
-
-      if (line.includes("port forwarding failed")) {
-        print2(line);
-      }
-    }
-  }
 };
 
 const spawnChildProcess = (
@@ -343,6 +334,7 @@ const addCommonArgs = (args: CommandArgs, proxyCommand: string[]) => {
     sshOptions.push("-o", `ProxyCommand=${proxyCommand.join(" ")}`);
   }
 
+  // Force verbose output from SSH so we can parse the output
   const verboseOptionExists = sshOptions.some((opt) => opt === "-v");
   if (!verboseOptionExists) {
     sshOptions.push("-v");

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -59,8 +59,6 @@ const accessPropagationGuard = (
     const chunkString: string = chunk.toString("utf-8");
     parseAndPrintSshOutputToStderr(chunkString, options);
 
-    if (debug) print2(chunkString);
-
     const match = provider.unprovisionedAccessPatterns.find((message) =>
       chunkString.match(message.pattern)
     );
@@ -87,36 +85,6 @@ const accessPropagationGuard = (
     isAccessPropagated: () => !isEphemeralAccessDeniedException,
     isLoginException: () => isLoginException,
   };
-};
-
-/**
- * Parses and prints a chunk of SSH output to stderr.
- *
- * If debug is enabled, all output is printed. Otherwise, only selected messages are printed.
- *
- * @param chunkString the chunk to print
- * @param options SSH spawn options
- */
-const parseAndPrintSshOutputToStderr = (
-  chunkString: string,
-  options: SpawnSshNodeOptions
-) => {
-  const lines = chunkString.split("\n");
-  const isPreTest = options.isAccessPropagationPreTest;
-
-  for (const line of lines) {
-    if (options.debug) {
-      print2(line);
-    } else {
-      if (!isPreTest && line.includes("Authenticated to")) {
-        // We want to let the user know that they successfully authenticated
-        print2(line);
-      } else if (!isPreTest && line.includes("port forwarding failed")) {
-        // We also want to let the user know if port forwarding failed
-        print2(line);
-      }
-    }
-  }
 };
 
 /**

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -472,7 +472,9 @@ export const sshOrScp = async (args: {
     credential
   );
   if (exitCode && exitCode !== 0) {
-    print2(`SSH session terminated`);
+    print2(
+      `Failed to establish an SSH session.${!cmdArgs.debug ? " Use the --debug option to see additional details." : ""}`
+    );
     return exitCode; // Only exit if there was an error when pre-testing
   }
 

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -164,10 +164,7 @@ const parseAndPrintSshOutputToStderr = (
     if (options.debug) {
       print2(line);
     } else {
-      if (isPreTest && line.match(SUDO_MESSAGE)) {
-        // On pre-test, print the sudo error message if present
-        print2(line);
-      } else if (!isPreTest && line.includes("Authenticated to")) {
+      if (!isPreTest && line.includes("Authenticated to")) {
         // We want to let the user know that they successfully authenticated
         print2(line);
       } else if (!isPreTest && line.includes("port forwarding failed")) {


### PR DESCRIPTION
* If debug is not enabled, it will now still print selected SSH output to stderr:
  - "Authenticated to" ... message
  - "port forwarding failed" messages
  - "Sorry, user {user} may not run sudo..." messages (on pre-test only)
* Print an error message when SSH pre-test fails.

Examples:

./p0 ssh dev-instance-fabian-joya --provider gcloud -- -NR '*:8080:localhost:8088' -o 'GatewayPorts yes'
Authenticated to dev-instance-fabian-joya (via proxy) using "publickey".
Warning: remote port forwarding failed for listen port 8080

./p0 ssh dev-instance-fabian-joya --sudo        
Failed to establish an SSH session. Use the --debug option to see additional details.