### PR TITLE
Throw error message if user has no email from firebase

### DIFF
--- a/src/drivers/auth.ts
+++ b/src/drivers/auth.ts
@@ -108,6 +108,9 @@ export const authenticate = async (options?: {
   });
   auth.tenantId = identity.org.tenantId;
   const userCredential = await signInWithCredential(auth, firebaseCredential);
+  if (!userCredential?.user?.email) {
+    throw "Can not sign in: this user has previously signed in with a different identity provider.\nPlease contact support@p0.dev to enable this user.";
+  }
 
   return { userCredential, identity };
 };


### PR DESCRIPTION
If there are multiple users with the same email in Identity Platform for a particular tenant, an authentication attempt to firebase will return a user with an empty email.

On the frontend we display an error message when that happens:
https://github.com/p0-security/app/blob/5237e1a54597dc63258e56566353ad09ecd3e187/frontend/src/components/Login/hook.ts#L301-L306

But on the CLI we had no such check.  This PR adds the same check as on the frontend.  Now when a user logs in, if they have multiple identities in Identity Platform they will see the message `Can not sign in: this user has previously signed in with a different identity provider.\nPlease contact support@p0.dev to enable this user.`

https://github.com/user-attachments/assets/7d5f94f5-199f-4ec1-96d2-ef73d1802787

