### PR TITLE
Print spinners during backend interaction

### DIFF
--- a/src/commands/__tests__/ls.test.ts
+++ b/src/commands/__tests__/ls.test.ts
@@ -17,6 +17,7 @@ import yargs from "yargs";
 jest.mock("../../drivers/api");
 jest.mock("../../drivers/auth");
 jest.mock("../../drivers/stdio");
+jest.spyOn(process, "exit");
 
 const mockFetchCommand = fetchCommand as jest.Mock;
 const mockPrint1 = print1 as jest.Mock;
@@ -41,14 +42,14 @@ describe("ls", () => {
         { key: "instance-1", group: "Group", value: "Resource 1" },
         { key: "instance-2", value: "Resource 2" },
       ]);
-      await lsCommand(yargs()).parse(command);
+      await lsCommand(yargs()).exitProcess(false).parse(command);
       expect(mockPrint1.mock.calls).toMatchSnapshot("stdout");
       expect(mockPrint2.mock.calls).toMatchSnapshot("stderr");
     });
 
     it("should print friendly message if no items", async () => {
       mockItems([]);
-      await lsCommand(yargs()).parse(command);
+      await lsCommand(yargs()).exitProcess(false).parse(command);
       expect(mockPrint1.mock.calls).toMatchSnapshot("stdout");
       expect(mockPrint2.mock.calls).toMatchSnapshot("stderr");
     });
@@ -74,7 +75,10 @@ Unknown argument: foo`,
     });
 
     it("should print error message", async () => {
-      const error = await failure(lsCommand(yargs()), command);
+      const error = await failure(
+        lsCommand(yargs().exitProcess(false)),
+        command
+      );
       expect(error).toMatchSnapshot();
     });
   });

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { retryWithSleep } from "../common/retry";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
-import { Ansi, print2 } from "../drivers/stdio";
+import { AnsiSgr, print2 } from "../drivers/stdio";
 import {
   awsCloudAuth,
   profileName,
@@ -153,8 +153,8 @@ const kubeconfigAction = async (
 
   if (process.env.AWS_ACCESS_KEY_ID) {
     print2(
-      `${Ansi.Yellow}Warning: AWS credentials were detected in your environment, which may cause kubectl errors. ` +
-        `To avoid issues, unset with \`unset AWS_ACCESS_KEY_ID\`.${Ansi.Reset}`
+      `${AnsiSgr.Yellow}Warning: AWS credentials were detected in your environment, which may cause kubectl errors. ` +
+        `To avoid issues, unset with \`unset AWS_ACCESS_KEY_ID\`.${AnsiSgr.Reset}`
     );
   }
 };

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -9,9 +9,10 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { retryWithSleep } from "../common/retry";
+import { AnsiSgr } from "../drivers/ansi";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
-import { AnsiSgr, print2 } from "../drivers/stdio";
+import { print2 } from "../drivers/stdio";
 import {
   awsCloudAuth,
   profileName,

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { fetchCommand } from "../drivers/api";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
-import { print2, print1, Ansi } from "../drivers/stdio";
+import { print2, print1, AnsiSgr, spinUntil } from "../drivers/stdio";
 import { max, orderBy } from "lodash";
 import pluralize from "pluralize";
 import yargs from "yargs";
@@ -53,10 +53,10 @@ const ls = async (
   }>
 ) => {
   const authn = await authenticate();
-  const data = await fetchCommand<LsResponse>(authn, args, [
-    "ls",
-    ...args.arguments,
-  ]);
+  const data = await spinUntil(
+    "Listing accessible resources",
+    fetchCommand<LsResponse>(authn, args, ["ls", ...args.arguments])
+  );
   const allArguments = [...args._, ...args.arguments];
 
   if (data && "ok" in data && data.ok) {
@@ -89,8 +89,8 @@ const ls = async (
           isSameValue
             ? item.key
             : maxLength > 30
-              ? `${item.key}\n  ${Ansi.Dim}${tagPart}${Ansi.Reset}`
-              : `${item.key.padEnd(maxLength)}${Ansi.Dim} - ${tagPart}${Ansi.Reset}`
+              ? `${item.key}\n  ${AnsiSgr.Dim}${tagPart}${AnsiSgr.Reset}`
+              : `${item.key.padEnd(maxLength)}${AnsiSgr.Dim} - ${tagPart}${AnsiSgr.Reset}`
         }`
       );
     }

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -8,10 +8,11 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { AnsiSgr } from "../drivers/ansi";
 import { fetchCommand } from "../drivers/api";
 import { authenticate } from "../drivers/auth";
 import { guard } from "../drivers/firestore";
-import { print2, print1, AnsiSgr, spinUntil } from "../drivers/stdio";
+import { print2, print1, spinUntil } from "../drivers/stdio";
 import { max, orderBy } from "lodash";
 import pluralize from "pluralize";
 import yargs from "yargs";

--- a/src/drivers/__mocks__/stdio.ts
+++ b/src/drivers/__mocks__/stdio.ts
@@ -1,0 +1,17 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+
+export const print1 = jest.fn();
+export const print2 = jest.fn();
+
+export const spinUntil = jest.fn(
+  async <T>(_message: string, promise: Promise<T>) => await promise
+);

--- a/src/drivers/ansi.ts
+++ b/src/drivers/ansi.ts
@@ -1,0 +1,23 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { mapValues } from "lodash";
+
+const AnsiCodes = {
+  Reset: "00",
+  Dim: "02",
+  Green: "32",
+  Yellow: "33",
+} as const;
+
+export const Ansi = (value: string) => `\u001b[${value}`;
+
+/** Creates an ANSI Select Graphic Rendition code */
+export const AnsiSgr = mapValues(AnsiCodes, (v) => Ansi(v + "m"));

--- a/src/drivers/stdio.ts
+++ b/src/drivers/stdio.ts
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License along with @p0
  * - Later redirection / duplication
  */
 import { sleep } from "../util";
-import { mapValues } from "lodash";
+import { Ansi, AnsiSgr } from "./ansi";
 
 /** Used to output machine-readable text to stdout
  *
@@ -36,18 +36,6 @@ export function print2(message: any) {
   // eslint-disable-next-line no-console
   console.error(message);
 }
-
-const AnsiCodes = {
-  Reset: "00",
-  Dim: "02",
-  Green: "32",
-  Yellow: "33",
-} as const;
-
-const Ansi = (value: string) => `\u001b[${value}`;
-
-/** Creates an ANSI Select Graphic Rendition code */
-export const AnsiSgr = mapValues(AnsiCodes, (v) => Ansi(v + "m"));
 
 /** Resets the terminal cursor to the beginning of the line */
 export function reset2() {
@@ -70,6 +58,8 @@ const Spin = {
 export const spinUntil = async <T>(message: string, promise: Promise<T>) => {
   let isDone = false;
   let ix = 0;
+  // 'catch' here just prevents UncaughtExceptionError; errors are sent to caller
+  // on function return
   void promise.finally(() => (isDone = true)).catch(() => {});
   while (!isDone) {
     await sleep(Spin.delayMs);


### PR DESCRIPTION
Currently, we provide no user feedback whilst we contact the P0 backend. This makes it difficult for the user to distinguish between waiting on a backend response and a hung process.

Use a yarn-style Unicode spinner to indicate that the process is still live.

https://github.com/user-attachments/assets/bd58acc0-7d1a-4058-a41a-d95c3c13a929

