### PR TITLE
SSH: Update to work with newest IDC request format

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.7.0",
     "prettier": "^3.2.4",
-    "ts-node": "^10.9.2",
-    "ts-jest": "^29.1.2"
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2"
   },
   "scripts": {
     "build": "tsc && cp -r public dist/",

--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -16,7 +16,7 @@ import { mockGetDoc } from "../../testing/firestore";
 import { sleep } from "../../util";
 import { sshCommand } from "../ssh";
 import { onSnapshot } from "firebase/firestore";
-import { omit } from "lodash";
+import { noop, omit } from "lodash";
 import yargs from "yargs";
 
 jest.mock("../../drivers/api");
@@ -40,6 +40,7 @@ const MOCK_REQUEST = {
   },
   permission: {
     spec: {
+      awsResourcePermission: { permission: {} },
       instanceId: "instanceId",
       accountId: "accountId",
       region: "region",
@@ -84,9 +85,9 @@ describe("ssh", () => {
     });
 
     it("should call p0 request with reason arg", async () => {
-      void sshCommand(yargs()).parse(
-        `ssh some-instance --reason reason --provider aws`
-      );
+      void sshCommand(yargs())
+        .fail(noop)
+        .parse(`ssh some-instance --reason reason --provider aws`);
       await sleep(100);
       const hiddenFilenameRequestArgs = omit(
         mockFetchCommand.mock.calls[0][1],
@@ -96,14 +97,14 @@ describe("ssh", () => {
     });
 
     it("should wait for access grant", async () => {
-      const promise = sshCommand(yargs()).parse(`ssh some-instance`);
+      const promise = sshCommand(yargs()).fail(noop).parse(`ssh some-instance`);
       const wait = sleep(100);
       await Promise.race([wait, promise]);
       await expect(wait).resolves.toBeUndefined();
     });
 
     it("should wait for provisioning", async () => {
-      const promise = sshCommand(yargs()).parse(`ssh some-instance`);
+      const promise = sshCommand(yargs()).fail(noop).parse(`ssh some-instance`);
       await sleep(100); // Need to wait for listen before trigger in tests
       (onSnapshot as any).trigger({
         status: "APPROVED",
@@ -114,9 +115,9 @@ describe("ssh", () => {
     });
 
     it("should call sshOrScp with non-interactive command", async () => {
-      const promise = sshCommand(yargs()).parse(
-        `ssh some-instance do something`
-      );
+      const promise = sshCommand(yargs())
+        .fail(noop)
+        .parse(`ssh some-instance do something`);
       await sleep(100); // Need to wait for listen before trigger in tests
       (onSnapshot as any).trigger({
         status: "APPROVED",
@@ -130,7 +131,7 @@ describe("ssh", () => {
     });
 
     it("should call sshOrScp with interactive session", async () => {
-      const promise = sshCommand(yargs()).parse(`ssh some-instance`);
+      const promise = sshCommand(yargs()).fail(noop).parse(`ssh some-instance`);
       await sleep(100); // Need to wait for listen before trigger in tests
       (onSnapshot as any).trigger({
         status: "APPROVED",

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -116,15 +116,17 @@ export const awsSshProvider: SshProvider<
 
   requestToSsh: (request) => {
     const { permission, generated } = request;
-    const { instanceId, accountId, region } = permission.spec;
-    const { idc, ssh, name } = generated;
+    const { awsResourcePermission, instanceId, accountId, region } =
+      permission.spec;
+    const { idcId, idcRegion } = awsResourcePermission.permission;
+    const { ssh, name } = generated;
     const { linuxUserName } = ssh;
     const common = { linuxUserName, accountId, region, id: instanceId };
-    return !idc
+    return !idcId || !idcRegion
       ? { ...common, role: name, type: "aws", access: "role" }
       : {
           ...common,
-          idc,
+          idc: { id: idcId, region: idcRegion },
           permissionSet: name,
           type: "aws",
           access: "idc",

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -68,6 +68,12 @@ export type AwsSshPermission = {
     accountId: string;
     region: string;
     type: "aws";
+    awsResourcePermission: {
+      permission: {
+        idcId?: string;
+        idcRegion?: string;
+      };
+    };
   };
   type: "session";
 };
@@ -76,10 +82,6 @@ export type AwsSshGenerated = {
   name: string;
   ssh: {
     linuxUserName: string;
-  };
-  idc?: {
-    region: string;
-    id: string;
   };
 };
 


### PR DESCRIPTION
The P0 backend moved IDC data from the `generated` field on the request object to the `permission` field.

Update CLI to match this format.