### PR TITLE
always clear identity cache when logging in

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -12,7 +12,6 @@ import {
   IDENTITY_CACHE_PATH,
   IDENTITY_FILE_PATH,
   authenticate,
-  loadCredentials,
 } from "../drivers/auth";
 import { doc, guard } from "../drivers/firestore";
 import { print2 } from "../drivers/stdio";
@@ -45,12 +44,8 @@ export const login = async (
   if (!loginFn) throw "Unsupported login for your organization";
 
   const tokenResponse = await loginFn(orgWithSlug);
-  // if the user changed their org, clear any cached identities this prevents
-  // commands like `aws assume role` from using the old identities
-  const currentIdentity = await loadCredentials().catch(() => undefined);
-  if (currentIdentity?.org.slug !== args.org) {
-    await clearIdentityCache();
-  }
+
+  await clearIdentityCache();
   await writeIdentity(orgWithSlug, tokenResponse);
 
   // validate auth


### PR DESCRIPTION
This PR removes a minor optimization which was causing an endless recursive loop, every time a user logs in we'll reset their identity cache.