### PR TITLE
[ENG-2790] Fix broken p0 kubeconfig command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -240,15 +240,9 @@ const extractClusterNameAndRegion = (clusterArn: string) => {
   // Example EKS cluster ARN: arn:aws:eks:us-west-2:123456789012:cluster/my-testing-cluster
   const arn = parseArn(clusterArn);
   const { region: clusterRegion, resource: resourceStr } = arn;
-  const resource = resourceStr.split("/");
+  const [resourceType, clusterName] = resourceStr.split("/");
 
-  if (resource[0] !== "cluster") {
-    throw INVALID_ARN_MSG;
-  }
-
-  const clusterName = resource[1];
-
-  if (!clusterName || !clusterRegion) {
+  if (resourceType !== "cluster" || !clusterName || !clusterRegion) {
     throw INVALID_ARN_MSG;
   }
 

--- a/src/plugins/aws/__tests__/utils.test.ts
+++ b/src/plugins/aws/__tests__/utils.test.ts
@@ -1,0 +1,95 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { parseArn } from "../utils";
+
+describe("parseArn() function", () => {
+  it.each([
+    "badarn:aws:ec2:us-east-1:123456789012:vpc/vpc-0e9801d129EXAMPLE", // Bad prefix
+    ":aws:ec2:us-east-1:123456789012:vpc/vpc-0e9801d129EXAMPLE", // Missing prefix
+    "arn:aws:ec2:us-east-1:123456789012", // Too few elements
+  ])('Raises an "Invalid ARN" error', (arn) => {
+    expect(() => parseArn(arn)).toThrow("Invalid AWS ARN");
+  });
+
+  it("Parses a valid ARN with all fields correctly", () => {
+    const arn = "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0e9801d129EXAMPLE";
+
+    const parsed = parseArn(arn);
+
+    expect(parsed).toEqual({
+      partition: "aws",
+      service: "ec2",
+      region: "us-east-1",
+      accountId: "123456789012",
+      resource: "vpc/vpc-0e9801d129EXAMPLE",
+    });
+  });
+
+  it("Parses a valid ARN with colons in the resource correctly", () => {
+    // Note: This is not the format we would expect an EKS ARN to actually be in (it should
+    // use a / instead of a : in the resource); this is just for unit testing purposes.
+    const arn = "arn:aws:eks:us-west-2:123456789012:cluster:my-testing-cluster";
+
+    const parsed = parseArn(arn);
+
+    expect(parsed).toEqual({
+      partition: "aws",
+      service: "eks",
+      region: "us-west-2",
+      accountId: "123456789012",
+      resource: "cluster:my-testing-cluster",
+    });
+  });
+
+  it("Parses a valid ARN with no region correctly", () => {
+    const arn = "arn:aws:iam::123456789012:user/johndoe";
+
+    const parsed = parseArn(arn);
+
+    expect(parsed).toEqual({
+      partition: "aws",
+      service: "iam",
+      region: "",
+      accountId: "123456789012",
+      resource: "user/johndoe",
+    });
+  });
+
+  it("Parses a valid ARN with no account ID correctly", () => {
+    // Note: This is not a valid SNS ARN; they would ordinarily have an account ID. This is
+    // just for unit testing purposes.
+    const arn = "arn:aws-us-gov:sns:us-east-1::example-sns-topic-name";
+
+    const parsed = parseArn(arn);
+
+    expect(parsed).toEqual({
+      partition: "aws-us-gov",
+      service: "sns",
+      region: "us-east-1",
+      accountId: "",
+      resource: "example-sns-topic-name",
+    });
+  });
+
+  it("Parses a valid ARN with no region or account ID correctly", () => {
+    const arn = "arn:aws-cn:s3:::my-corporate-bucket";
+
+    const parsed = parseArn(arn);
+
+    expect(parsed).toEqual({
+      partition: "aws-cn",
+      service: "s3",
+      region: "",
+      accountId: "",
+      resource: "my-corporate-bucket",
+    });
+  });
+});

--- a/src/plugins/aws/utils.ts
+++ b/src/plugins/aws/utils.ts
@@ -1,0 +1,69 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+
+/**
+ * Parses out Amazon Resource Names (ARNs) from AWS into their components. Note
+ * that not all components are present in all ARNs (depending on the service;
+ * for example, S3 ARNs don't have a region or account ID), and the final
+ * component of the ARN (`resource`) may contain its own internal structure that
+ * is also service-dependent and which may also include colons. In particular,
+ * quoting the Amazon docs: "Be aware that the ARNs for some resources omit the
+ * Region, the account ID, or both the Region and the account ID."
+ *
+ * @param arn The ARN to parse as a string.
+ * @return A structure representing the components of the ARN. All fields will
+ * be defined, but some may be empty strings if they are not present in the ARN.
+ */
+export const parseArn = (
+  arn: string
+): {
+  partition: string;
+  service: string;
+  region: string;
+  accountId: string;
+  resource: string;
+} => {
+  // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
+  const INVALID_ARN_MSG = `Invalid AWS ARN: ${arn}`;
+
+  const parts = arn.split(":");
+
+  if (parts.length < 6) {
+    throw INVALID_ARN_MSG;
+  }
+
+  const [arnPrefix, partition, service, region, accountId, ...remainder] =
+    parts;
+  const resource = remainder.join(":");
+
+  if (arnPrefix !== "arn") {
+    throw `Invalid AWS ARN prefix "${arnPrefix}" in ARN: ${arn}`;
+  }
+
+  // We know these are all defined thanks to the parts.length check above, but
+  // TypeScript doesn't, so....
+  if (
+    partition === undefined ||
+    service === undefined ||
+    accountId === undefined ||
+    region === undefined
+  ) {
+    throw INVALID_ARN_MSG;
+  }
+
+  return {
+    partition,
+    service,
+    region,
+    accountId,
+    resource,
+  };
+};

--- a/src/plugins/kubeconfig/types.ts
+++ b/src/plugins/kubeconfig/types.ts
@@ -17,9 +17,7 @@ export type K8sClusterConfig = {
   isProxy: boolean;
   token: string;
   publicJwk?: string; // only present for proxy installs
-  provider:
-    | { type: "aws"; clusterArn: string; accountId: string }
-    | { type: "email" };
+  hosting: { type: "aws"; arn: string } | { type: "azure" } | { type: "gcp" };
   state: string;
 };
 
@@ -42,15 +40,16 @@ export type K8sResourcePermission = {
   role: string;
   clusterId: string;
   type: "resource";
+  awsResourcePermission?: {
+    idcRegion?: string;
+    idcId?: string;
+  };
 };
 
 export type K8sGenerated = {
   eksGenerated: {
     // For IDC, the name of the permission set. For Federated, the name of the assumed role
     name: string;
-
-    // Only present for IDC; the ID and region of the IDC installation
-    idc?: { id: string; region: string };
   };
   role: string; // The name of the generated role in k8s itself
 };


### PR DESCRIPTION
This PR unbreaks the `p0 kubeconfig` command. Some values and structures got changed around in the k8s integration config and responses from the backend:
- Required AWS IDC metadata is no longer found in the `eksGenerated` object; it's now in `awsResourcePermission`
- AWS account ID is no longer stored separately in the k8s integration configuration, and now is extracted from the EKS cluster ARN
- `provider` was renamed `hosting` in the k8s integration configuration

It also adds some minor quality-of-live improvements to the `p0 kubeconfig` command, such as utilizing `spinUntil()` for some of the longer `await`s, and adds a more robust and reusable simple AWS ARN parser.

Added a unit test for the ARN parser, and tested everything locally in both AWS IDC and AWS Federated (Okta SAML) configurations.