### PR TITLE
ENG-2931 Fix error when no identity file is present

### DIFF
--- a/src/drivers/auth.ts
+++ b/src/drivers/auth.ts
@@ -11,8 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { login } from "../commands/login";
 import { Authn, Identity } from "../types/identity";
 import { P0_PATH } from "../util";
-import { loadConfig } from "./config";
-import { authenticateToFirebase, initializeFirebase } from "./firestore";
+import { authenticateToFirebase } from "./firestore";
 import { print2 } from "./stdio";
 import * as fs from "fs/promises";
 import * as path from "path";
@@ -66,7 +65,7 @@ export const cached = async <T>(
   }
 };
 
-export const loadCredentials = async (options?: {
+const loadCredentialsWithAutoLogin = async (options?: {
   noRefresh?: boolean;
 }): Promise<Identity> => {
   try {
@@ -78,7 +77,7 @@ export const loadCredentials = async (options?: {
     ) {
       await login({ org: identity.org.slug }, { skipAuthenticate: true });
       print2("\u200B"); // Force a new line
-      return loadCredentials({ noRefresh: true });
+      return loadCredentialsWithAutoLogin({ noRefresh: true });
     }
     return identity;
   } catch (error: any) {
@@ -92,10 +91,7 @@ export const loadCredentials = async (options?: {
 export const authenticate = async (options?: {
   noRefresh?: boolean;
 }): Promise<Authn> => {
-  await loadConfig();
-  initializeFirebase();
-
-  const identity = await loadCredentials(options);
+  const identity = await loadCredentialsWithAutoLogin(options);
   const userCredential = await authenticateToFirebase(identity);
 
   return { userCredential, identity };

--- a/src/drivers/config.ts
+++ b/src/drivers/config.ts
@@ -30,7 +30,8 @@ export async function saveConfig(config: Config) {
   tenantConfig = config;
 }
 
-export async function loadConfig() {
+export async function loadConfig(): Promise<Config> {
   const buffer = await fs.readFile(CONFIG_FILE_PATH);
   tenantConfig = JSON.parse(buffer.toString());
+  return tenantConfig;
 }

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { Identity } from "../types/identity";
-import { getTenantConfig } from "./config";
+import { loadConfig } from "./config";
 import { bootstrapConfig } from "./env";
 import { FirebaseApp, initializeApp } from "firebase/app";
 import {
@@ -17,6 +17,7 @@ import {
   OAuthProvider,
   SignInMethod,
   signInWithCredential,
+  UserCredential,
 } from "firebase/auth";
 import {
   collection as fsCollection,
@@ -34,15 +35,19 @@ const bootstrapFirestore = getFirestore(bootstrapApp);
 let app: FirebaseApp;
 let firestore: Firestore;
 
-export function initializeFirebase() {
-  const tenantConfig = getTenantConfig();
+async function initializeFirebase() {
+  const tenantConfig = await loadConfig();
   app = initializeApp(tenantConfig.fs, "authFirebase");
   firestore = getFirestore(app);
 }
 
-export async function authenticateToFirebase(identity: Identity) {
+export async function authenticateToFirebase(
+  identity: Identity
+): Promise<UserCredential> {
   const { credential } = identity;
   const tenantId = identity.org.tenantId;
+
+  await initializeFirebase();
 
   // TODO: Move to map lookup
   const provider = new OAuthProvider(


### PR DESCRIPTION
Fixes the error that is shown when no identity file is present.

The CLI now again shows a message asking the user to login:

./p0 ls gcloud role oauth
Please run `p0 login <organization>` to use the P0 CLI.

Added unit test.