### PR TITLE
ENG-2960 Read ssoProvider from config host, not p0-prod

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -14,8 +14,8 @@ import {
   IDENTITY_FILE_PATH,
 } from "../drivers/auth";
 import { saveConfig } from "../drivers/config";
-import { bootstrapConfig } from "../drivers/env";
-import { fsShutdownGuard, publicDoc } from "../drivers/firestore";
+import { fsShutdownGuard, initializeFirebase } from "../drivers/firestore";
+import { doc } from "../drivers/firestore";
 import { print2 } from "../drivers/stdio";
 import { pluginLoginMap } from "../plugins/login";
 import { TokenResponse } from "../types/oidc";
@@ -34,13 +34,13 @@ export const login = async (
   args: { org: string },
   options?: { skipAuthenticate?: boolean }
 ) => {
-  const orgDoc = await getDoc<RawOrgData, object>(
-    publicDoc(`orgs/${args.org}`)
-  );
-  const orgData = orgDoc.data();
-  if (!orgData) throw "Could not find organization";
+  await saveConfig(args.org);
+  await initializeFirebase();
 
-  await saveConfig(orgData.config ?? bootstrapConfig);
+  const orgDoc = await getDoc<RawOrgData, object>(doc(`orgs/${args.org}`));
+  const orgData = orgDoc.data();
+
+  if (!orgData) throw "Could not find organization";
 
   const orgWithSlug: OrgData = { ...orgData, slug: args.org };
 

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -35,10 +35,12 @@ const bootstrapFirestore = getFirestore(bootstrapApp);
 let app: FirebaseApp;
 let firestore: Firestore;
 
-async function initializeFirebase() {
-  const tenantConfig = await loadConfig();
-  app = initializeApp(tenantConfig.fs, "authFirebase");
-  firestore = getFirestore(app);
+export async function initializeFirebase() {
+  if (!firestore) {
+    const tenantConfig = await loadConfig();
+    app = initializeApp(tenantConfig.fs, "authFirebase");
+    firestore = getFirestore(app);
+  }
 }
 
 export async function authenticateToFirebase(
@@ -85,7 +87,7 @@ export const doc = <T>(path: string) => {
   return fsDoc(firestore, path) as DocumentReference<T>;
 };
 
-export const publicDoc = <T>(path: string) => {
+export const bootstrapDoc = <T>(path: string) => {
   return fsDoc(bootstrapFirestore, path) as DocumentReference<T>;
 };
 


### PR DESCRIPTION
Reads the ssoProvider for login from the host specified in the config, instead of defaulting to p0-prod.