### PR TITLE
ls: Fix listing help formatting.

### DIFF
--- a/src/commands/__tests__/__snapshots__/ls.test.ts.snap
+++ b/src/commands/__tests__/__snapshots__/ls.test.ts.snap
@@ -29,7 +29,8 @@ exports[`ls when valid ls command should print friendly message if no items: std
 exports[`ls when valid ls command should print list response: stderr 1`] = `
 [
   [
-    "Showing destinations. Resources labeled with * are already accessible to you:",
+    "Showing destinations.
+Resources labeled with * are already accessible to you:",
   ],
 ]
 `;

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -72,12 +72,11 @@ const ls = async (
     const postfixPart = data.term
       ? ` matching '${data.term}'`
       : data.isTruncated
-        ? ` (use \`p0
-         ${allArguments.join(" ")} <like>\` to narrow results)`
+        ? ` (use \`p0 ${allArguments.join(" ")} <like>\` to narrow results)`
         : "";
 
     print2(
-      `Showing${truncationPart} ${label}${postfixPart}. Resources labeled with * are already accessible to you:`
+      `Showing${truncationPart} ${label}${postfixPart}.\nResources labeled with * are already accessible to you:`
     );
     const sortedItems = orderBy(data.items, "isPreexisting", "desc");
     const isSameValue = sortedItems.every((i) => !i.group && i.key === i.value);


### PR DESCRIPTION
I'd broken this in #42. Fix whitespace.

Before:

```
Showing the first 15 destinations (use `p0
       ls ssh session destination <like>` to narrow results). Resources labeled with * are already accessible to you:
```

After:

```
Showing the first 15 destinations (use `p0 ls ssh session destination <like>` to narrow results).
Resources labeled with * are already accessible to you:
```