### PR TITLE
ls: display number of items that were truncated 

### DIFF
--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -102,11 +102,8 @@ const ls = async (
     print2(
       `Showing${truncationPart} ${label}${postfixPart}.\nResources labeled with * are already accessible to you:`
     );
-    const sortedItems = orderBy(
-      slice(data.items, 0, requestedSize),
-      "isPreexisting",
-      "desc"
-    );
+    const truncated = slice(data.items, 0, requestedSize);
+    const sortedItems = orderBy(truncated, "isPreexisting", "desc");
     const isSameValue = sortedItems.every((i) => !i.group && i.key === i.value);
     const maxLength = max(sortedItems.map((i) => i.key.length)) || 0;
     for (const item of sortedItems) {


### PR DESCRIPTION
Addresses ENG-2998. Improves CLI usability when there are a large number of results by giving the user an idea of the total number of results for their query. We request twice the requested size, and if the total number of results is within the amount, we display the number of remaining results. If not, we just display 'of many'

<img width="737" alt="image" src="https://github.com/user-attachments/assets/8ecf9774-0b83-4599-b398-00f6f9191759">
<img width="826" alt="image" src="https://github.com/user-attachments/assets/74225400-ba74-4d53-b737-d16b4b3dcd03">
