### PR TITLE
update ssh command arguments to use shared properties

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -33,7 +33,7 @@ import yargs from "yargs";
 export type BaseSshCommandArgs = {
   sudo?: boolean;
   reason?: string;
-  account?: string;
+  parent?: string;
   provider?: SupportedSshProvider;
   debug?: boolean;
   sshOptions?: string[];
@@ -119,7 +119,7 @@ export const provisionRequest = async (
         ...(args.provider ? ["--provider", args.provider] : []),
         ...(isSudoCommand(args) ? ["--sudo"] : []),
         ...(args.reason ? ["--reason", args.reason] : []),
-        ...(args.account ? ["--account", args.account] : []),
+        ...(args.parent ? ["--parent", args.parent] : []),
       ],
       wait: true,
     },

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -43,9 +43,9 @@ export const sshCommand = (yargs: yargs.Argv) =>
           describe: "Reason access is needed",
           type: "string",
         })
-        .option("account", {
+        .option("parent", {
           type: "string",
-          describe: "The account on which the instance is located",
+          describe: "The parent resource on which the instance is located",
         })
         .option("provider", {
           type: "string",

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -45,7 +45,8 @@ export const sshCommand = (yargs: yargs.Argv) =>
         })
         .option("parent", {
           type: "string",
-          describe: "The parent resource on which the instance is located",
+          describe:
+            "The containing parent resource which the instance belongs to (account, project, subscription, etc.)",
         })
         .option("provider", {
           type: "string",


### PR DESCRIPTION
This PR updates the ssh command argument `account` to use the new shared name: `parent`. The parent argument unifies inputs of `accountId` for AWS, `projectId` for Google Cloud, and `subscriptionId` for Azure.

![image](https://github.com/user-attachments/assets/79d8cfd7-516f-4b6b-b07a-c708aea1d4c8)
