### PR TITLE
Implement reproCommands for Azure SSH

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -58,6 +58,9 @@ export type SshAdditionalSetup = {
   /** A list of SSH configuration options, as would be used after '-o' in an SSH command */
   sshOptions: string[];
 
+  /** The path to the private key file to use for the SSH connection, instead of the default P0 CLI managed key */
+  identityFile: string;
+
   /** The port to connect to, overriding the default */
   port: string;
 

--- a/src/plugins/azure/auth.ts
+++ b/src/plugins/azure/auth.ts
@@ -10,9 +10,21 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { exec } from "../../util";
 
+export const azLoginCommand = () => ({
+  command: "az",
+  args: ["login"],
+});
+
+export const azAccountSetCommand = (subscriptionId: string) => ({
+  command: "az",
+  args: ["account", "set", "--subscription", subscriptionId],
+});
+
 export const azLogin = async (subscriptionId: string) => {
-  await exec("az", ["login"], { check: true });
-  await exec("az", ["account", "set", "--subscription", subscriptionId], {
-    check: true,
-  });
+  const { command: azLoginExe, args: azLoginArgs } = azLoginCommand();
+  await exec(azLoginExe, azLoginArgs, { check: true });
+
+  const { command: azAccountSetExe, args: azAccountSetArgs } =
+    azAccountSetCommand(subscriptionId);
+  await exec(azAccountSetExe, azAccountSetArgs, { check: true });
 };

--- a/src/plugins/azure/keygen.ts
+++ b/src/plugins/azure/keygen.ts
@@ -19,6 +19,11 @@ export const AD_CERT_FILENAME = "p0cli-azure-ad-ssh-cert.pub";
 // The `az ssh cert` command manages key generation, and generates SSH RSA keys with the standard names
 export const AD_SSH_KEY_PRIVATE = "id_rsa";
 
+export const azSshCertCommand = (keyPath: string) => ({
+  command: "az",
+  args: ["ssh", "cert", "--file", path.join(keyPath, AD_CERT_FILENAME)],
+});
+
 export const createTempDirectoryForKeys = async (): Promise<{
   path: string;
   cleanup: () => Promise<void>;
@@ -36,11 +41,8 @@ export const createTempDirectoryForKeys = async (): Promise<{
 
 export const generateSshKeyAndAzureAdCert = async (keyPath: string) => {
   try {
-    await exec(
-      "az",
-      ["ssh", "cert", "--file", path.join(keyPath, AD_CERT_FILENAME)],
-      { check: true }
-    );
+    const { command, args } = azSshCertCommand(keyPath);
+    await exec(command, args, { check: true });
   } catch (error: any) {
     print2(error.stdout);
     print2(error.stderr);

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -279,11 +279,7 @@ const addCommonArgs = (
   // Explicitly specify which private key to use to avoid "Too many authentication failures"
   // error caused by SSH trying every available key
   if (!identityFileOptionExists) {
-    if (setupData?.identityFile) {
-      sshOptions.push("-i", setupData.identityFile);
-    } else {
-      sshOptions.push("-i", PRIVATE_KEY_PATH);
-    }
+    sshOptions.push("-i", setupData?.identityFile ?? PRIVATE_KEY_PATH);
 
     // Only use the authentication identity specified by -i above
     if (!identitiesOnlyOptionExists) {

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -91,7 +91,10 @@ export type SshProvider<
 
   /** Each element in the returned array is a command that can be run to reproduce the
    * steps of logging in the user to the ssh session. */
-  reproCommands: (request: SR) => string[] | undefined;
+  reproCommands: (
+    request: SR,
+    additionalData?: SshAdditionalSetup
+  ) => string[] | undefined;
 
   /** Unwraps this provider's types */
   requestToSsh: (request: CliPermissionSpec<PR, O>) => SR;


### PR DESCRIPTION
This PR improves the Azure SSH debugging experience by adding reproduction commands for Azure SSH, which are displayed when invoking `p0 ssh` with the `--debug` option. It outputs all the `az` commands, as used by the P0 CLI, that are needed to manually reproduce the SSH connection process, as well as the final `ssh`/`scp` command too. I also included some minor refactoring which both made the implementation easier, as well as removed some redundancy from the `ssh` options we end up passing for Azure SSH (e.g., previously, we technically specified two separate private keys to `ssh`, the usual P0 CLI-managed key as well as the ephemeral SSH certificate private key generated by `az ssh cert`).

The first commit also includes removing a TODO for ENG 3129, which is no longer required and replaces it with a describe comment, as a tiny "while I'm here" change.

## Testing
Tested locally. Repro commands were tested against my local P0 instance connecting to my Azure test VM (to confirm that the repro commands I added in this PR work as expected) and against an AWS EC2 instance in Federated auth mode (to confirm that I didn't break any existing repro commands with my changes).

## Screenshots
Example repro commands for `p0 ssh` for Azure SSH (note: redaction of sensitive values by my terminal, not part of the P0 CLI output):
![Repro commands ssh](https://github.com/user-attachments/assets/27a677ba-da98-491f-a205-e9bca4c4ad5d)

Example repro commands for `p0 scp` for Azure SSH:
![Repro commands scp](https://github.com/user-attachments/assets/8ec3a125-69d9-4bb8-8552-1c572b85e81b)