### PR TITLE
Add debugging output for Azure SSH provider

### DIFF
--- a/src/plugins/azure/auth.ts
+++ b/src/plugins/azure/auth.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { print2 } from "../../drivers/stdio";
 import { exec } from "../../util";
 
 export const azLoginCommand = () => ({
@@ -20,11 +21,31 @@ export const azAccountSetCommand = (subscriptionId: string) => ({
   args: ["account", "set", "--subscription", subscriptionId],
 });
 
-export const azLogin = async (subscriptionId: string) => {
+export const azLogin = async (
+  subscriptionId: string,
+  options: { debug?: boolean } = {}
+) => {
+  const { debug } = options;
+
+  if (debug) print2("Logging in to Azure...");
+
   const { command: azLoginExe, args: azLoginArgs } = azLoginCommand();
-  await exec(azLoginExe, azLoginArgs, { check: true });
+  const loginResult = await exec(azLoginExe, azLoginArgs, { check: true });
+
+  if (debug) {
+    print2(loginResult.stdout);
+    print2(loginResult.stderr);
+    print2(`Setting active Azure subscription to ${subscriptionId}...`);
+  }
 
   const { command: azAccountSetExe, args: azAccountSetArgs } =
     azAccountSetCommand(subscriptionId);
-  await exec(azAccountSetExe, azAccountSetArgs, { check: true });
+  const accountSetResult = await exec(azAccountSetExe, azAccountSetArgs, {
+    check: true,
+  });
+
+  if (debug) {
+    print2(accountSetResult.stdout);
+    print2(accountSetResult.stderr);
+  }
 };

--- a/src/plugins/azure/keygen.ts
+++ b/src/plugins/azure/keygen.ts
@@ -39,10 +39,22 @@ export const createTempDirectoryForKeys = async (): Promise<{
   return { path, cleanup };
 };
 
-export const generateSshKeyAndAzureAdCert = async (keyPath: string) => {
+export const generateSshKeyAndAzureAdCert = async (
+  keyPath: string,
+  options: { debug?: boolean } = {}
+) => {
+  const { debug } = options;
+
+  if (debug) print2("Generating Azure AD SSH certificate...");
+
   try {
     const { command, args } = azSshCertCommand(keyPath);
-    await exec(command, args, { check: true });
+    const { stdout, stderr } = await exec(command, args, { check: true });
+
+    if (debug) {
+      print2(stdout);
+      print2(stderr);
+    }
   } catch (error: any) {
     print2(error.stdout);
     print2(error.stderr);

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -392,6 +392,7 @@ export const sshOrScp = async (args: {
   sshProvider: SshProvider<any, any, any, any>;
 }) => {
   const { authn, request, cmdArgs, privateKey, sshProvider } = args;
+  const { debug } = cmdArgs;
 
   if (!privateKey) {
     throw "Failed to load a private key for this request. Please contact support@p0.dev for assistance.";
@@ -402,7 +403,7 @@ export const sshOrScp = async (args: {
 
   const proxyCommand = sshProvider.proxyCommand(request);
 
-  const setupData = await sshProvider.setup?.(request);
+  const setupData = await sshProvider.setup?.(request, { debug });
 
   const { command, args: commandArgs } = createCommand(
     request,
@@ -411,7 +412,7 @@ export const sshOrScp = async (args: {
     proxyCommand
   );
 
-  if (cmdArgs.debug) {
+  if (debug) {
     const reproCommands = sshProvider.reproCommands(request, setupData);
     if (reproCommands) {
       const repro = [
@@ -447,7 +448,7 @@ export const sshOrScp = async (args: {
       command,
       args: commandArgs,
       stdio: ["inherit", "inherit", "pipe"],
-      debug: cmdArgs.debug,
+      debug,
       provider: request.type,
       endTime: endTime,
     });

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -84,7 +84,10 @@ export type SshProvider<
 
   /** Perform any setup required before running the SSH command. Returns a list of additional arguments to pass to the
    * SSH command. */
-  setup?: (request: SR) => Promise<SshAdditionalSetup>;
+  setup?: (
+    request: SR,
+    options?: { debug?: boolean }
+  ) => Promise<SshAdditionalSetup>;
 
   /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option */
   proxyCommand: (request: SR) => string[];


### PR DESCRIPTION
This PR improves the Azure SSH debugging experience by adding debug output for the various `az` commands being run before opening the `ssh`/`scp` session. Specifically, when the `--debug` flag is set, the CLI will output the stdout and stderr for all the `az` commands it runs. Note though that it _won't_ set the `--debug` flag for the `az` commands themselves as this outputs far too much information, with the exception of the `az network bastion tunnel` command; while it still outputs far too much information in debug mode, it has an unfortunate tendency to hide certain errors unless you pass it the `--debug` flag, so I did add it there.

Some additional information is also logged by the CLI itself now when the `--debug` flag is set.

## Testing
Tested locally against my Azure VM in our test tenant, both with and without the `--debug` flag.

## Screenshots
Example output when _not_ using `--debug`; matches output from before this PR (as before, sensitive redaction value by my terminal, not the CLI):
![Output without debug](https://github.com/user-attachments/assets/45478acd-9893-4acc-b782-0d34b0a3235c)

Examples of output when using `--debug`:
Initial startup:
![Output with debug 1](https://github.com/user-attachments/assets/d0f5da8f-a6a5-40f7-bbe1-fe7a9510244a)

Generating Azure AD SSH certificate:
![Output with debug 2](https://github.com/user-attachments/assets/fe94abdb-214f-445d-8d34-41ed02d10553)

Starting tunnel (and showing repro commands added in previous PR):
![Output with debug 3](https://github.com/user-attachments/assets/67077615-7e13-4aa5-9214-5e401cc06851)

Closing SSH session and shutting down tunnel:
![Output with debug 4](https://github.com/user-attachments/assets/c6c145b1-968a-4d13-a886-e5d1eb2c30cb)