### PR TITLE
Bump P0 CLI version number in prep for new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {


### PR DESCRIPTION
Bump P0 CLI version number from `0.12.0` to `0.13.0` in prep for new release