### PR TITLE
Add sudo propagation check for azure

### DIFF
--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -34,7 +34,7 @@ const unprovisionedAccessPatterns = [
   },
 ] as const;
 
-const validPreTestAccessPatterns = [
+const provisionedAccessPatterns = [
   {
     pattern: /sudo: a password is required/,
   },
@@ -186,7 +186,7 @@ export const azureSshProvider: SshProvider<
   }),
 
   unprovisionedAccessPatterns,
-  validPreTestAccessPatterns,
+  provisionedAccessPatterns,
 
   toCliRequest: async (request) => {
     return {

--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { isSudoCommand } from "../../commands/shared/ssh";
 import { SshProvider } from "../../types/ssh";
 import { azAccountSetCommand, azLogin, azLoginCommand } from "./auth";
 import { ensureAzInstall } from "./install";
@@ -25,6 +26,19 @@ import {
   AzureSshRequest,
 } from "./types";
 import path from "node:path";
+
+const unprovisionedAccessPatterns = [
+  {
+    // The output of `sudo -v` when the user is not allowed to run sudo
+    pattern: /Sorry, user .+ may not run sudo on .+/,
+  },
+] as const;
+
+const validPreTestAccessPatterns = [
+  {
+    pattern: /sudo: a password is required/,
+  },
+] as const;
 
 // TODO: Determine what this value should be for Azure
 const PROPAGATION_TIMEOUT_LIMIT_MS = 2 * 60 * 1000;
@@ -55,8 +69,18 @@ export const azureSshProvider: SshProvider<
 
   propagationTimeoutMs: PROPAGATION_TIMEOUT_LIMIT_MS,
 
-  // TODO(ENG-3149): Implement sudo access checks here
-  preTestAccessPropagationArgs: () => undefined,
+  preTestAccessPropagationArgs: (cmdArgs) => {
+    if (isSudoCommand(cmdArgs)) {
+      return {
+        ...cmdArgs,
+        // `sudo -v` prints `Sorry, user <user> may not run sudo on <hostname>.` to stderr when user is not a sudoer.
+        // we have to use `-n` flag to avoid the oauth prompt on azure cli.
+        command: "sudo",
+        arguments: ["-nv"],
+      };
+    }
+    return undefined;
+  },
 
   // Azure doesn't support ProxyCommand, as nice as that would be. Yet.
   proxyCommand: () => [],
@@ -161,8 +185,8 @@ export const azureSshProvider: SshProvider<
     bastionId: request.permission.bastionHostId,
   }),
 
-  // TODO: Implement
-  unprovisionedAccessPatterns: [],
+  unprovisionedAccessPatterns,
+  validPreTestAccessPatterns,
 
   toCliRequest: async (request) => {
     return {

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -44,6 +44,13 @@ export type CliPermissionSpec<
 export const SupportedSshProviders = ["aws", "azure", "gcloud"] as const;
 export type SupportedSshProvider = (typeof SupportedSshProviders)[number];
 
+export type AccessPattern = {
+  /** If the error matches this string, indicates that access is not provisioned */
+  readonly pattern: RegExp;
+  /** Maximum amount of time to wait for provisioning after encountering this error */
+  readonly validationWindowMs?: number;
+};
+
 export type SshProvider<
   PR extends PluginSshRequest = PluginSshRequest,
   O extends object | undefined = undefined,
@@ -102,13 +109,15 @@ export type SshProvider<
   /** Unwraps this provider's types */
   requestToSsh: (request: CliPermissionSpec<PR, O>) => SR;
 
-  /** Regex matches for error strings indicating that the provider has not yet fully provisioned node acces */
-  unprovisionedAccessPatterns: readonly {
-    /** If the error matches this string, indicates that access is not provisioned */
-    readonly pattern: RegExp;
-    /** Maximum amount of time to wait for provisioning after encountering this error */
-    readonly validationWindowMs?: number;
-  }[];
+  /** Regex matches for error strings indicating that the provider has not yet fully provisioned node access */
+  unprovisionedAccessPatterns: readonly AccessPattern[];
+
+  /** Regex matches for error strings indicating that the provider is ready for node access.
+   * Used to override error codes during access propagation testing.
+   */
+  validPreTestAccessPatterns?: readonly AccessPattern[];
+
+  /** Regex matches for error strings indicating that the provider has fully provisioned */
 
   /** Converts a backend request to a CLI request */
   toCliRequest: (

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -115,7 +115,7 @@ export type SshProvider<
   /** Regex matches for error strings indicating that the provider is ready for node access.
    * Used to override error codes during access propagation testing.
    */
-  validPreTestAccessPatterns?: readonly AccessPattern[];
+  provisionedAccessPatterns?: readonly AccessPattern[];
 
   /** Regex matches for error strings indicating that the provider has fully provisioned */
 


### PR DESCRIPTION
This PR implements Azure's `preTestAccessPropagationArgs` and adds a new parameter to the `SSHProvider` type to support valid access errors. 

Sudo access to an azure node can sometimes take an unexpectedly long time to propagate fully and if a user connects before sudo access propagates then they'll need to restart their session in order to pick up the sudo access. Therefore it is necessary to validate sudo access before letting a user complete their connection. 

We get an error code of 1 instead of an error code 0 after sudo access is granted when performing the pretest for an Azure instance. This means that we needed to extend the `SSHProvider` interface a little to include potentially valid error messages and override the error code of 1.

> In the case a user doesn't have sudo access, sudo -nv will exit with code 1 and print Sorry, user ${username} may not run sudo on ${host}. to stderr. 
>
> If the user does have sudo access, sudo -nv will exit with code 1 (so, the same as the no access case) but print sudo: a password is required to stderr.