### PR TITLE
Azure SSH: clear current identity before logging in again

### DIFF
--- a/src/plugins/azure/auth.ts
+++ b/src/plugins/azure/auth.ts
@@ -16,6 +16,11 @@ export const azLoginCommand = () => ({
   args: ["login"],
 });
 
+export const azLogoutCommand = () => ({
+  command: "az",
+  args: ["logout"],
+});
+
 export const azAccountSetCommand = (subscriptionId: string) => ({
   command: "az",
   args: ["account", "set", "--subscription", subscriptionId],
@@ -28,6 +33,23 @@ export const azLogin = async (
   const { debug } = options;
 
   if (debug) print2("Logging in to Azure...");
+
+  // Logging out first ensures that any cached credentials are cleared.
+  // https://github.com/Azure/azure-cli/issues/29161
+  try {
+    const { command: azLogoutExe, args: azLogOutArgs } = azLogoutCommand();
+    const logoutResult = await exec(azLogoutExe, azLogOutArgs, { check: true });
+
+    if (debug) {
+      print2(logoutResult.stdout);
+      print2(logoutResult.stderr);
+    }
+  } catch (error: any) {
+    if (debug) {
+      // ignore the error if the user is not logged in.
+      print2(`Skipping logout: ${error.stderr}`);
+    }
+  }
 
   const { command: azLoginExe, args: azLoginArgs } = azLoginCommand();
   const loginResult = await exec(azLoginExe, azLoginArgs, { check: true });

--- a/src/plugins/azure/auth.ts
+++ b/src/plugins/azure/auth.ts
@@ -37,8 +37,8 @@ export const azLogin = async (
   // Logging out first ensures that any cached credentials are cleared.
   // https://github.com/Azure/azure-cli/issues/29161
   try {
-    const { command: azLogoutExe, args: azLogOutArgs } = azLogoutCommand();
-    const logoutResult = await exec(azLogoutExe, azLogOutArgs, { check: true });
+    const { command: azLogoutExe, args: azLogoutArgs } = azLogoutCommand();
+    const logoutResult = await exec(azLogoutExe, azLogoutArgs, { check: true });
 
     if (debug) {
       print2(logoutResult.stdout);

--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -10,7 +10,12 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { isSudoCommand } from "../../commands/shared/ssh";
 import { SshProvider } from "../../types/ssh";
-import { azAccountSetCommand, azLogin, azLoginCommand } from "./auth";
+import {
+  azAccountSetCommand,
+  azLogin,
+  azLoginCommand,
+  azLogoutCommand,
+} from "./auth";
 import { ensureAzInstall } from "./install";
 import {
   AD_CERT_FILENAME,
@@ -86,6 +91,7 @@ export const azureSshProvider: SshProvider<
   proxyCommand: () => [],
 
   reproCommands: (request, additionalData) => {
+    const { command: azLogoutExe, args: azLogoutArgs } = azLogoutCommand();
     const { command: azLoginExe, args: azLoginArgs } = azLoginCommand();
     const { command: azAccountSetExe, args: azAccountSetArgs } =
       azAccountSetCommand(request.subscriptionId);
@@ -117,6 +123,7 @@ export const azureSshProvider: SshProvider<
     );
 
     return [
+      `${azLogoutExe} ${azLogoutArgs.join(" ")}`,
       `${azLoginExe} ${azLoginArgs.join(" ")}`,
       `${azAccountSetExe} ${azAccountSetArgs.join(" ")}`,
       `mkdir ${keyPath}`,


### PR DESCRIPTION
This PR adds runs the `az logout` before logging in so that we wipe any currently connected identities. This resolves a handful of issues we're seeing for example: 

1. granting a user access, relinquishing access, and then granting again will use an old cached identity which will have a temporary block on access.
2. granting sudo access, and regular user access and relinquishing one temporarily blocks access to the account.
3. if someone runs `az login` and uses a different identity that has the same subscription id.