### PR TITLE
Allow ctrl+d to exit terminal when valid access patterns exist

### DIFF
--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -95,7 +95,7 @@ const accessPropagationGuard = (
     isAccessPropagated: () => {
       return (
         !isEphemeralAccessDeniedException &&
-        (!validAccessPatterns?.length || isValidError)
+        (!validAccessPatterns || isValidError)
       );
     },
     isLoginException: () => isLoginException,

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -59,7 +59,7 @@ const accessPropagationGuard = (
 ) => {
   let isEphemeralAccessDeniedException = false;
   let isLoginException = false;
-  let isValidError = false;
+  let isValidError = true;
 
   child.stderr.on("data", (chunk) => {
     const chunkString: string = chunk.toString("utf-8");
@@ -75,6 +75,7 @@ const accessPropagationGuard = (
 
     if (matchUnprovisionedPattern) {
       isEphemeralAccessDeniedException = true;
+      isValidError = false;
     }
 
     if (matchPreTestPattern && !matchUnprovisionedPattern) {
@@ -95,9 +96,7 @@ const accessPropagationGuard = (
     isAccessPropagated: () => {
       return (
         !isEphemeralAccessDeniedException &&
-        (!options.isAccessPropagationPreTest ||
-          !validAccessPatterns?.length ||
-          isValidError)
+        (!validAccessPatterns?.length || isValidError)
       );
     },
     isLoginException: () => isLoginException,

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -59,7 +59,7 @@ const accessPropagationGuard = (
 ) => {
   let isEphemeralAccessDeniedException = false;
   let isLoginException = false;
-  let isValidError = true;
+  let isValidError = false;
 
   child.stderr.on("data", (chunk) => {
     const chunkString: string = chunk.toString("utf-8");
@@ -69,16 +69,15 @@ const accessPropagationGuard = (
       chunkString.match(message.pattern)
     );
 
-    const matchPreTestPattern = validAccessPatterns?.find((message) =>
+    const matchValidAccessPattern = validAccessPatterns?.find((message) =>
       chunkString.match(message.pattern)
     );
 
     if (matchUnprovisionedPattern) {
       isEphemeralAccessDeniedException = true;
-      isValidError = false;
     }
 
-    if (matchPreTestPattern && !matchUnprovisionedPattern) {
+    if (matchValidAccessPattern && !matchUnprovisionedPattern) {
       isValidError = true;
     }
 
@@ -96,7 +95,9 @@ const accessPropagationGuard = (
     isAccessPropagated: () => {
       return (
         !isEphemeralAccessDeniedException &&
-        (!validAccessPatterns?.length || isValidError)
+        (!options.isAccessPropagationPreTest ||
+          !validAccessPatterns?.length ||
+          isValidError)
       );
     },
     isLoginException: () => isLoginException,

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -92,12 +92,9 @@ const accessPropagationGuard = (
   });
 
   return {
-    isAccessPropagated: () => {
-      return (
-        !isEphemeralAccessDeniedException &&
-        (!validAccessPatterns || isValidError)
-      );
-    },
+    isAccessPropagated: () =>
+      !isEphemeralAccessDeniedException &&
+      (!validAccessPatterns || isValidError),
     isLoginException: () => isLoginException,
   };
 };

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -95,9 +95,7 @@ const accessPropagationGuard = (
     isAccessPropagated: () => {
       return (
         !isEphemeralAccessDeniedException &&
-        (!options.isAccessPropagationPreTest ||
-          !validAccessPatterns?.length ||
-          isValidError)
+        (!validAccessPatterns?.length || isValidError)
       );
     },
     isLoginException: () => isLoginException,
@@ -190,7 +188,9 @@ async function spawnSshNode(
     // TODO ENG-2284 support login with Google Cloud: currently return a boolean to indicate if the exception was a Google login error.
     const { isAccessPropagated, isLoginException } = accessPropagationGuard(
       provider.unprovisionedAccessPatterns,
-      provider.provisionedAccessPatterns,
+      options.isAccessPropagationPreTest
+        ? provider.provisionedAccessPatterns
+        : undefined,
       provider.loginRequiredPattern,
       child,
       options

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -32,11 +32,6 @@ import {
 } from "node:child_process";
 import { Readable } from "node:stream";
 
-/** Maximum amount of time after SSH subprocess starts to check for {@link UNPROVISIONED_ACCESS_MESSAGES}
- *  in the process's stderr
- */
-const DEFAULT_VALIDATION_WINDOW_MS = 5e3;
-
 const RETRY_DELAY_MS = 5000;
 
 /** Checks if access has propagated through AWS to the SSM agent
@@ -97,9 +92,14 @@ const accessPropagationGuard = (
   });
 
   return {
-    isAccessPropagated: () =>
-      !isEphemeralAccessDeniedException &&
-      (!validAccessPatterns || isValidError),
+    isAccessPropagated: () => {
+      return (
+        !isEphemeralAccessDeniedException &&
+        (!options.isAccessPropagationPreTest ||
+          !validAccessPatterns?.length ||
+          isValidError)
+      );
+    },
     isLoginException: () => isLoginException,
   };
 };


### PR DESCRIPTION
We recently introduced `validAccessPatterns` in #147 which checks to make sure a certain termination string exists when performing propagation checks. Consequentially for Azure, when we exit the terminal we're now always attempting to verify that an ephemeral access message is valid and failing the check.

Two fixes were possible, 1) we either only check `isValidError` if we're in a propagation check or 2) we default `isValidError` to true and we only set it to false if we encounter an error.

We didn't go with the first option in #147 because we want to remove the concept of `isAccessPropagationPreTest` from the `accessPropagationGuard`, but checking for valid error messages should only apply during the pretest phase. This PR instead only passes `validAccessPatterns` if we're performing a pre-test to the propagation guard.