### PR TITLE
Azure SSH: provide user friendly error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/plugins/azure/auth.ts
+++ b/src/plugins/azure/auth.ts
@@ -27,10 +27,7 @@ const knownAccountSetErrors: KnownError[] = [
   },
 ];
 
-export const normalizeAzureCliError = (
-  error: any,
-  normalizedErrors: KnownError[]
-) => {
+const normalizeAzureCliError = (error: any, normalizedErrors: KnownError[]) => {
   for (const { pattern, message } of normalizedErrors) {
     if (pattern.test(error.stderr)) {
       throw message;

--- a/src/plugins/azure/types.ts
+++ b/src/plugins/azure/types.ts
@@ -12,6 +12,11 @@ import { PermissionSpec } from "../../types/request";
 import { CliPermissionSpec } from "../../types/ssh";
 import { CommonSshPermissionSpec } from "../ssh/types";
 
+export type KnownError = {
+  pattern: RegExp;
+  message: string;
+};
+
 export type AzureSshPermissionSpec = PermissionSpec<"ssh", AzureSshPermission>;
 
 export type AzureSsh = CliPermissionSpec<


### PR DESCRIPTION
This PR applies a small refactor that improves the error handling of during auth steps for the Azure SSH plugin. When a user cancels their login attempt or if we fail to set the users active Azure subscription. The refactor introduces a knew `KnownError` type and a utility method `normalizeAzureCliError` that should make it easy to extend and capture new errors as we discover them.