### PR TITLE
Make Google OAuth client parameters optional

### DIFF
--- a/src/drivers/config.ts
+++ b/src/drivers/config.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { Config, GoogleConfig, RawOrgData } from "../types/org";
+import { Config, RawOrgData } from "../types/org";
 import { P0_PATH } from "../util";
 import { bootstrapConfig } from "./env";
 import { bootstrapDoc } from "./firestore";
@@ -21,19 +21,17 @@ export const CONFIG_FILE_PATH = path.join(P0_PATH, "config.json");
 
 let tenantConfig: Config;
 
-export function getTenantConfig(): Config {
-  return tenantConfig;
-}
+export const getTenantConfig = () => tenantConfig;
 
 /** Use only if the organization is configured with Google login to P0 */
-export function getGoogleTenantConfig(): GoogleConfig {
+export const getGoogleTenantConfig = () => {
   if ("google" in tenantConfig) {
     return tenantConfig;
   }
   throw "Login failed!\nThis organization is configured to use Google login but the required OAuth client parameters are missing.\nPlease contact support@p0.dev to properly configure your organization login.";
-}
+};
 
-export async function saveConfig(orgId: string) {
+export const saveConfig = async (orgId: string) => {
   const orgDoc = await getDoc<RawOrgData, object>(
     bootstrapDoc(`orgs/${orgId}`)
   );
@@ -50,10 +48,10 @@ export async function saveConfig(orgId: string) {
   await fs.writeFile(CONFIG_FILE_PATH, JSON.stringify(config), { mode: "600" });
 
   tenantConfig = config;
-}
+};
 
-export async function loadConfig(): Promise<Config> {
+export const loadConfig = async () => {
   const buffer = await fs.readFile(CONFIG_FILE_PATH);
   tenantConfig = JSON.parse(buffer.toString());
   return tenantConfig;
-}
+};

--- a/src/drivers/config.ts
+++ b/src/drivers/config.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { Config, RawOrgData } from "../types/org";
+import { Config, GoogleConfig, RawOrgData } from "../types/org";
 import { P0_PATH } from "../util";
 import { bootstrapConfig } from "./env";
 import { bootstrapDoc } from "./firestore";
@@ -23,6 +23,14 @@ let tenantConfig: Config;
 
 export function getTenantConfig(): Config {
   return tenantConfig;
+}
+
+/** Use only if the organization is configured with Google login to P0 */
+export function getGoogleTenantConfig(): GoogleConfig {
+  if ("google" in tenantConfig) {
+    return tenantConfig;
+  }
+  throw "Login failed!\nThis organization is configured to use Google login but the required OAuth client parameters are missing.\nPlease contact support@p0.dev to properly configure your organization login.";
 }
 
 export async function saveConfig(orgId: string) {

--- a/src/drivers/env.ts
+++ b/src/drivers/env.ts
@@ -30,7 +30,13 @@ export const bootstrapConfig = {
       "228132571547-kilcq1er15hlbl6mitghttnacp7u58l8.apps.googleusercontent.com",
     // Despite the name, this is not actually "secret" in any sense of the word.
     // Instead, the client is protected by requiring PKCE and defining the redirect URIs.
-    clientSecret:
+    // PKCE achieves similar security guarantees for public clients with an on-the-fly
+    // generated secret (the code verifier) as the static secret does for confidential clients.
+    // See also: https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-pkce
+    // In the PKCE flow the client secret is an optional parameter, however, Google's
+    // implementation requires it. That's why the "secret" is present here.
+    // This "secret" is only used if the organization uses Google Workspace to log in to P0.
+    publicClientSecretForPkce:
       env.P0_GOOGLE_OIDC_CLIENT_SECRET ?? "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",
   },
   appUrl: env.P0_APP_URL ?? "https://api.p0.app",

--- a/src/plugins/google/login.ts
+++ b/src/plugins/google/login.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { OIDC_HEADERS } from "../../common/auth/oidc";
 import { withRedirectServer } from "../../common/auth/server";
 import { urlEncode, validateResponse } from "../../common/fetch";
-import { getTenantConfig } from "../../drivers/config";
+import { getGoogleTenantConfig } from "../../drivers/config";
 import { print2 } from "../../drivers/stdio";
 import { AuthorizeRequest, TokenResponse } from "../../types/oidc";
 import open from "open";
@@ -28,7 +28,7 @@ const GOOGLE_OIDC_REDIRECT_URL = `http://127.0.0.1:${GOOGLE_OIDC_REDIRECT_PORT}`
 const PKCE_LENGTH = 128;
 
 const requestAuth = async () => {
-  const tenantConfig = getTenantConfig();
+  const tenantConfig = getGoogleTenantConfig();
   const pkceChallenge = (await import("pkce-challenge")).default as any;
   const pkce = await pkceChallenge(PKCE_LENGTH);
   const authBody: AuthorizeRequest = {
@@ -52,10 +52,10 @@ const requestToken = async (
   code: string,
   pkce: { code_challenge: string; code_verifier: string }
 ) => {
-  const tenantConfig = getTenantConfig();
+  const tenantConfig = getGoogleTenantConfig();
   const body = {
     client_id: tenantConfig.google.clientId,
-    client_secret: tenantConfig.google.clientSecret,
+    client_secret: tenantConfig.google.publicClientSecretForPkce,
     code,
     code_verifier: pkce.code_verifier,
     grant_type: "authorization_code",

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-type NonGoogleConfig = {
+type ApplicationConfig = {
   fs: {
     apiKey: string;
     authDomain: string;
@@ -21,14 +21,14 @@ type NonGoogleConfig = {
   environment: string;
 };
 
-export type GoogleConfig = NonGoogleConfig & {
+export type GoogleApplicationConfig = ApplicationConfig & {
   google: {
     clientId: string;
     publicClientSecretForPkce: string;
   };
 };
 
-export type Config = GoogleConfig | NonGoogleConfig;
+export type Config = ApplicationConfig | GoogleApplicationConfig;
 
 type BaseOrgData = {
   clientId: string;

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -8,9 +8,27 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { bootstrapConfig } from "../drivers/env";
+type NonGoogleConfig = {
+  fs: {
+    apiKey: string;
+    authDomain: string;
+    projectId: string;
+    storageBucket: string;
+    messagingSenderId: string;
+    appId: string;
+  };
+  appUrl: string;
+  environment: string;
+};
 
-export type Config = typeof bootstrapConfig;
+export type GoogleConfig = NonGoogleConfig & {
+  google: {
+    clientId: string;
+    publicClientSecretForPkce: string;
+  };
+};
+
+export type Config = GoogleConfig | NonGoogleConfig;
 
 type BaseOrgData = {
   clientId: string;


### PR DESCRIPTION
The `google` object in the tenant config contains the Client ID and Client Secret.
This config is then stored in plain text in the user's home directory.
Although the Client Secret is not really a secret, storing it in plain text gives the impression that the P0 CLI is not secure.

This PR renames the `clientSecret` to `publicClientSecretForPkce` and adds more explanation in code comments. (Although these comments are not visible in the saved `config.json` file.)

The PR also makes the `google` parameters optional so this becomes a non-issue for organizations with different login methods like Okta, Ping, etc.

User-friendly error if the organization is configured with Google login but the OAuth parameters are missing:
![Screenshot 2025-01-14 at 5 32 31 PM](https://github.com/user-attachments/assets/40f4d87c-e375-4436-8548-5f54608499f9)

Saved config without `google` object if the org is not configured with Google:
![Screenshot 2025-01-14 at 5 35 44 PM](https://github.com/user-attachments/assets/6f27767e-690a-4ab4-9935-5333e22983ad)
(The cat'ed values here are already publicly visible in the code base)

Saved config with the `google` object and renamed `publicClientSecretForPkce` if the org is configured with Google:
![Screenshot 2025-01-14 at 5 38 35 PM](https://github.com/user-attachments/assets/00b8dfb8-ec47-4bcb-a7a4-e8f728550baf)
(The cat'ed values here are already publicly visible in the code base)
