### PR TITLE
ssh-resolve and ssh-proxy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,25 +18,6 @@
             ],
             "sourceMaps": true,
             "runtimeExecutable": "ts-node",
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch P0 CLI (with args)",
-            "skipFiles": [
-                "<node_internals>/**"
-            ],
-            "program": "${workspaceFolder}/src/index.ts",
-            "preLaunchTask": "tsc: build - tsconfig.json",
-            "outFiles": [
-                "${workspaceFolder}/**/*.js"
-            ],
-            "sourceMaps": true,
-            "runtimeExecutable": "ts-node",
-            "args": [
-                "ssh-resolve",
-                "miguel-node-1"
-            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,4 +20,4 @@
             "runtimeExecutable": "ts-node",
         }
     ]
-} 
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,4 +20,4 @@
             "runtimeExecutable": "ts-node",
         }
     ]
-}
+} 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,25 @@
             ],
             "sourceMaps": true,
             "runtimeExecutable": "ts-node",
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch P0 CLI (with args)",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/src/index.ts",
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "sourceMaps": true,
+            "runtimeExecutable": "ts-node",
+            "args": [
+                "ssh-resolve",
+                "miguel-node-1"
+            ]
         }
     ]
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -20,6 +20,7 @@ import { requestCommand } from "./request";
 import { scpCommand } from "./scp";
 import { sshCommand } from "./ssh";
 import { sshKeyGenCommand } from "./ssh-keygen";
+import { sshProxyCommand } from "./ssh-proxy";
 import { sys } from "typescript";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -32,6 +33,7 @@ const commands = [
   requestCommand,
   allowCommand,
   sshCommand,
+  sshProxyCommand,
   scpCommand,
   sshKeyGenCommand,
   kubeconfigCommand,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,6 +21,7 @@ import { scpCommand } from "./scp";
 import { sshCommand } from "./ssh";
 import { sshKeyGenCommand } from "./ssh-keygen";
 import { sshProxyCommand } from "./ssh-proxy";
+import { sshResolveCommand } from "./ssh-resolve";
 import { sys } from "typescript";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -34,6 +35,7 @@ const commands = [
   allowCommand,
   sshCommand,
   sshProxyCommand,
+  sshResolveCommand,
   scpCommand,
   sshKeyGenCommand,
   kubeconfigCommand,

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -108,19 +108,17 @@ export const request =
           return "Requesting access";
       }
     };
+
+    const fetchCommandPromise = fetchCommand<RequestResponse<T>>(
+      resolvedAuthn,
+      args,
+      [command, ...args.arguments]
+    );
+
     const data =
       options?.message != "quiet"
-        ? await spinUntil(
-            accessMessage(options?.message),
-            fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
-              command,
-              ...args.arguments,
-            ])
-          )
-        : await fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
-            command,
-            ...args.arguments,
-          ]);
+        ? await spinUntil(accessMessage(options?.message), fetchCommandPromise)
+        : await fetchCommandPromise;
 
     if (data && "ok" in data && "message" in data && data.ok) {
       const logMessage =

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -95,7 +95,7 @@ export const request =
     authn?: Authn,
     options?: {
       accessMessage?: string;
-      message?: "all" | "approval-required" | "none";
+      message?: "all" | "approval-required" | "none" | "quiet";
     }
   ): Promise<RequestResponse<T> | undefined> => {
     const resolvedAuthn = authn ?? (await authenticate());
@@ -108,13 +108,19 @@ export const request =
           return "Requesting access";
       }
     };
-    const data = await spinUntil(
-      accessMessage(options?.message),
-      fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
-        command,
-        ...args.arguments,
-      ])
-    );
+    const data =
+      options?.message != "quiet"
+        ? await spinUntil(
+            accessMessage(options?.message),
+            fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
+              command,
+              ...args.arguments,
+            ])
+          )
+        : await fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
+            command,
+            ...args.arguments,
+          ]);
 
     if (data && "ok" in data && "message" in data && data.ok) {
       const logMessage =

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -165,7 +165,6 @@ export const provisionRequest = async (
     return;
   }
   const { id, isPreexisting } = response;
-  if (!quiet) print2("Did not receive access ID from server");
   if (!isPreexisting) print2("Waiting for access to be provisioned");
   else print2("Existing access found.  Connecting to instance.");
 

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -52,6 +52,11 @@ export type SshCommandArgs = BaseSshCommandArgs & {
   command?: string;
 };
 
+export type SshProxyCommandArgs = BaseSshCommandArgs & {
+  destination: string;
+  port: string;
+};
+
 export type CommandArgs = ScpCommandArgs | SshCommandArgs;
 
 export type SshAdditionalSetup = {

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -85,7 +85,7 @@ const sshProxyAction = async (
     P0_PATH,
     "ssh",
     "configs",
-    `${destination}.config`
+    `${destination}.config` // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   );
 
   if (args.debug) {

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -79,13 +79,13 @@ const sshProxyAction = async (
 
   const privateKey = await fs.readFile(args.identityFile, "utf8");
 
-  verifyDestinationString(args.destination);
+  const destination = verifyDestinationString(args.destination);
 
   const configLocation = path.join(
     P0_PATH,
     "ssh",
     "configs",
-    `${args.destination}.config`
+    `${destination}.config`
   );
 
   if (args.debug) {

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -1,12 +1,15 @@
 import { authenticate } from "../drivers/auth";
 import { fsShutdownGuard } from "../drivers/firestore";
 import { sshProxy } from "../plugins/ssh";
-import { SshProxyCommandArgs, prepareRequest } from "./shared/ssh";
+import { P0_PATH } from "../util";
+import { SSH_PROVIDERS, SshProxyCommandArgs } from "./shared/ssh";
+import * as fs from "fs/promises";
+import path from "path";
 import yargs from "yargs";
 
 export const sshProxyCommand = (yargs: yargs.Argv) =>
   yargs.command<SshProxyCommandArgs>(
-    "ssh-proxy <destination> <port>",
+    "ssh-proxy <destination>",
     "SSH into a virtual machine",
     (yargs) =>
       yargs
@@ -14,38 +17,36 @@ export const sshProxyCommand = (yargs: yargs.Argv) =>
           type: "string",
           demandOption: true,
         })
-        .positional("port", {
+        .option("port", {
           type: "string",
           demandOption: true,
         })
-        .option("sudo", {
-          type: "boolean",
-          describe: "Add user to sudoers file",
-        })
-        // Match `p0 request --reason`
-        .option("reason", {
-          describe: "Reason access is needed",
-          type: "string",
-        })
-        .option("parent", {
-          type: "string",
-          describe:
-            "The containing parent resource which the instance belongs to (account, project, subscription, etc.)",
-        })
         .option("provider", {
+          requiresArg: true,
           type: "string",
           describe: "The cloud provider where the instance is hosted",
           choices: ["aws", "azure", "gcloud"],
+          demandOption: true,
+        })
+        .option("identityFile", {
+          alias: "i",
+          requiresArg: true,
+          type: "string",
+          describe:
+            "Path to the private key file to use for the SSH connection",
+          demandOption: true,
+        })
+        .option("requestJson", {
+          requiresArg: true,
+          type: "string",
+          describe: "JSON string of the SSH request",
+          demandOption: true,
         })
         .option("debug", {
           type: "boolean",
           describe: "Print debug information.",
         })
-        .option("proxy-command", {
-          type: "boolean",
-          describe: "Use p0 as a proxy command", // TODO improve this
-        })
-        .usage("$0 ssh-proxy <destination> <port> [command [arguments..]]"),
+        .usage("$0 ssh-proxy <destination>"),
 
     fsShutdownGuard(sshProxyAction)
   );
@@ -61,17 +62,29 @@ const sshProxyAction = async (
     throw "Azure SSH does not currently support specifying a port. SSH on the target VM must be listening on the default port 22.";
   }
 
-  const { request, privateKey, sshProvider } = await prepareRequest(
-    authn,
-    args,
-    args.destination
+  const sshProvider = SSH_PROVIDERS[args.provider];
+
+  const requestJson = await fs.readFile(args.requestJson, "utf8");
+  const request = JSON.parse(requestJson);
+
+  const privateKey = await fs.readFile(args.identityFile, "utf8");
+
+  const configLocation = path.join(
+    P0_PATH,
+    "ssh",
+    "configs",
+    `${args.destination}.config`
   );
+
+  await fs.rm(args.requestJson);
+  await fs.rm(configLocation);
 
   await sshProxy({
     authn,
-    request,
     cmdArgs: args,
+    request,
     privateKey,
+    debug: args.debug ?? false,
     sshProvider,
     port: args.port,
   });

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -1,0 +1,78 @@
+import { authenticate } from "../drivers/auth";
+import { fsShutdownGuard } from "../drivers/firestore";
+import { sshProxy } from "../plugins/ssh";
+import { SshProxyCommandArgs, prepareRequest } from "./shared/ssh";
+import yargs from "yargs";
+
+export const sshProxyCommand = (yargs: yargs.Argv) =>
+  yargs.command<SshProxyCommandArgs>(
+    "ssh-proxy <destination> <port>",
+    "SSH into a virtual machine",
+    (yargs) =>
+      yargs
+        .positional("destination", {
+          type: "string",
+          demandOption: true,
+        })
+        .positional("port", {
+          type: "string",
+          demandOption: true,
+        })
+        .option("sudo", {
+          type: "boolean",
+          describe: "Add user to sudoers file",
+        })
+        // Match `p0 request --reason`
+        .option("reason", {
+          describe: "Reason access is needed",
+          type: "string",
+        })
+        .option("parent", {
+          type: "string",
+          describe:
+            "The containing parent resource which the instance belongs to (account, project, subscription, etc.)",
+        })
+        .option("provider", {
+          type: "string",
+          describe: "The cloud provider where the instance is hosted",
+          choices: ["aws", "azure", "gcloud"],
+        })
+        .option("debug", {
+          type: "boolean",
+          describe: "Print debug information.",
+        })
+        .option("proxy-command", {
+          type: "boolean",
+          describe: "Use p0 as a proxy command", // TODO improve this
+        })
+        .usage("$0 ssh-proxy <destination> <port> [command [arguments..]]"),
+
+    fsShutdownGuard(sshProxyAction)
+  );
+
+const sshProxyAction = async (
+  args: yargs.ArgumentsCamelCase<SshProxyCommandArgs>
+) => {
+  // Prefix is required because the backend uses it to determine that this is an AWS request
+  const authn = await authenticate();
+
+  // TODO(ENG-3142): Azure SSH currently doesn't support specifying a port; throw an error if one is set.
+  if (args.provider === "azure" && args.port != "22") {
+    throw "Azure SSH does not currently support specifying a port. SSH on the target VM must be listening on the default port 22.";
+  }
+
+  const { request, privateKey, sshProvider } = await prepareRequest(
+    authn,
+    args,
+    args.destination
+  );
+
+  await sshProxy({
+    authn,
+    request,
+    cmdArgs: args,
+    privateKey,
+    sshProvider,
+    port: args.port,
+  });
+};

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -10,7 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { authenticate } from "../drivers/auth";
 import { fsShutdownGuard } from "../drivers/firestore";
-import { sshProxy } from "../plugins/ssh";
+import { sshProxy, verifyDestinationString } from "../plugins/ssh";
 import { P0_PATH } from "../util";
 import { SSH_PROVIDERS, SshProxyCommandArgs } from "./shared/ssh";
 import * as fs from "fs/promises";
@@ -79,6 +79,8 @@ const sshProxyAction = async (
 
   const privateKey = await fs.readFile(args.identityFile, "utf8");
 
+  verifyDestinationString(args.destination);
+
   const configLocation = path.join(
     P0_PATH,
     "ssh",
@@ -86,7 +88,14 @@ const sshProxyAction = async (
     `${args.destination}.config`
   );
 
+  if (args.debug) {
+    ("Deleting request JSON file");
+  }
   await fs.rm(args.requestJson);
+
+  if (args.debug) {
+    ("Deleting ssh Config file");
+  }
   await fs.rm(configLocation);
 
   await sshProxy({

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -1,3 +1,13 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
 import { authenticate } from "../drivers/auth";
 import { fsShutdownGuard } from "../drivers/firestore";
 import { sshProxy } from "../plugins/ssh";

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -71,9 +71,7 @@ const sshResolveAction = async (
 ) => {
   const silentlyExit = conditionalAbortBeforeThrow(args.quiet ?? false);
 
-  const authn = await authenticate({ noRefresh: args.quiet ?? false }).catch(
-    silentlyExit
-  );
+  const authn = await authenticate({ noRefresh: true }).catch(silentlyExit);
 
   let destination = args.destination;
   try {

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -75,8 +75,9 @@ const sshResolveAction = async (
     silentlyExit
   );
 
+  let destination = args.destination;
   try {
-    verifyDestinationString(args.destination);
+    destination = verifyDestinationString(args.destination);
   } catch (e) {
     if (!args.quiet) {
       throw e;
@@ -86,7 +87,7 @@ const sshResolveAction = async (
   const { request, provisionedRequest } = await prepareRequest(
     authn,
     args,
-    args.destination,
+    destination,
     true,
     args.quiet
   ).catch(silentlyExit);
@@ -118,7 +119,7 @@ const sshResolveAction = async (
   const p0Executable = bootstrapConfig.appPath;
 
   const data = `
-Hostname ${args.destination}
+Hostname ${destination}
   User ${request.linuxUserName}
   IdentityFile ${identityFile}
   ${certificateInfo}
@@ -132,7 +133,7 @@ Hostname ${args.destination}
     P0_PATH,
     "ssh",
     "configs",
-    `${args.destination}.config`
+    `${destination}.config`
   );
 
   if (args.debug) {

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -85,7 +85,7 @@ const sshResolveAction = async (
   const { request, provisionedRequest } = await prepareRequest(
     authn,
     args,
-    destination,
+    destination, // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
     true,
     args.quiet
   ).catch(silentlyExit);

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -11,7 +11,6 @@ You should have received a copy of the GNU General Public License along with @p0
 import { authenticate } from "../drivers/auth";
 import { bootstrapConfig } from "../drivers/env";
 import { fsShutdownGuard } from "../drivers/firestore";
-import { print2 } from "../drivers/stdio";
 import { conditionalAbortBeforeThrow, P0_PATH } from "../util";
 import {
   SSH_PROVIDERS,
@@ -21,7 +20,6 @@ import {
 import fs from "fs";
 import path from "path";
 import tmp from "tmp-promise";
-import { sys } from "typescript";
 import yargs from "yargs";
 
 export const sshResolveCommand = (yargs: yargs.Argv) =>
@@ -92,16 +90,6 @@ const sshResolveAction = async (
 
   const tmpFile = tmp.fileSync();
   fs.writeFileSync(tmpFile.name, JSON.stringify(request, null, 2));
-
-  let linuxUserName = provisionedRequest.generated?.linuxUserName;
-
-  if (provisionedRequest.permission.provider === "gcloud") {
-    linuxUserName = (
-      await sshProvider.toCliRequest(provisionedRequest, {
-        debug: args.debug,
-      })
-    ).cliLocalData?.linuxUserName;
-  }
 
   const identityFile =
     keys?.privateKeyPath ?? path.join(P0_PATH, "ssh", "id_rsa");

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -85,7 +85,7 @@ const sshResolveAction = async (
   const { request, provisionedRequest } = await prepareRequest(
     authn,
     args,
-    destination, // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+    destination,
     true,
     args.quiet
   ).catch(silentlyExit);
@@ -131,7 +131,7 @@ Hostname ${destination}
     P0_PATH,
     "ssh",
     "configs",
-    `${destination}.config`
+    `${destination}.config` // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   );
 
   if (args.debug) {

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -1,0 +1,136 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { authenticate } from "../drivers/auth";
+import { bootstrapConfig } from "../drivers/env";
+import { fsShutdownGuard } from "../drivers/firestore";
+import { print2 } from "../drivers/stdio";
+import { conditionalAbortBeforeThrow, P0_PATH } from "../util";
+import {
+  SSH_PROVIDERS,
+  SshResolveCommandArgs,
+  prepareRequest,
+} from "./shared/ssh";
+import fs from "fs";
+import path from "path";
+import tmp from "tmp-promise";
+import { sys } from "typescript";
+import yargs from "yargs";
+
+export const sshResolveCommand = (yargs: yargs.Argv) =>
+  yargs.command<SshResolveCommandArgs>(
+    "ssh-resolve <destination>",
+    "SSH into a virtual machine",
+    (yargs) =>
+      yargs
+        .positional("destination", {
+          type: "string",
+          demandOption: true,
+        })
+        .option("parent", {
+          type: "string",
+          describe:
+            "The containing parent resource which the instance belongs to (account, project, subscription, etc.)",
+        })
+        .option("provider", {
+          type: "string",
+          describe: "The cloud provider where the instance is hosted",
+          choices: ["aws", "azure", "gcloud"],
+        })
+        .option("debug", {
+          type: "boolean",
+          describe: "Print debug information.",
+        })
+        .option("quiet", {
+          alias: "q",
+          type: "boolean",
+          describe: "Suppress output",
+        }),
+
+    fsShutdownGuard(sshResolveAction)
+  );
+
+/** Connect to an SSH backend
+ *
+ * Implicitly gains access to the SSH resource if required.
+ *
+ * Supported SSH mechanisms:
+ * - AWS EC2 via SSM with Okta SAML
+ */
+const sshResolveAction = async (
+  args: yargs.ArgumentsCamelCase<SshResolveCommandArgs>
+) => {
+  const p0Executable = bootstrapConfig.appPath;
+  // Prefix is required because the backend uses it to determine that this is an AWS request
+  const authn = await authenticate({ noRefresh: args.quiet ?? false }).catch(
+    conditionalAbortBeforeThrow(args.quiet ?? false)
+  );
+
+  const { request, provisionedRequest } = await prepareRequest(
+    authn,
+    args,
+    args.destination,
+    true,
+    args.quiet
+  ).catch(conditionalAbortBeforeThrow(args.quiet ?? false));
+
+  const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
+
+  const keys = await sshProvider?.generateKeys?.(
+    provisionedRequest.permission.resource,
+    {
+      debug: args.debug,
+    }
+  );
+
+  const tmpFile = tmp.fileSync();
+  fs.writeFileSync(tmpFile.name, JSON.stringify(request, null, 2));
+
+  let linuxUserName = provisionedRequest.generated?.linuxUserName;
+
+  if (provisionedRequest.permission.provider === "gcloud") {
+    linuxUserName = (
+      await sshProvider.toCliRequest(provisionedRequest, {
+        debug: args.debug,
+      })
+    ).cliLocalData?.linuxUserName;
+  }
+
+  const identityFile =
+    keys?.privateKeyPath ?? path.join(P0_PATH, "ssh", "id_rsa");
+  const certificateInfo = keys?.certificatePath
+    ? `CertificateFile ${keys.certificatePath}`
+    : "";
+
+  print2("=".repeat(80));
+  print2(p0Executable);
+  print2("=".repeat(80));
+  const data = `
+Hostname ${args.destination}
+  User ${request.linuxUserName}
+  IdentityFile ${identityFile}
+  ${certificateInfo}
+  PasswordAuthentication no
+  ProxyCommand ${p0Executable} ssh-proxy %h --port %p --provider ${provisionedRequest.permission.provider} --identity-file ${identityFile} --request-json ${tmpFile.name}`;
+  print2(data);
+  print2("=".repeat(80));
+
+  await fs.promises.mkdir(path.join(P0_PATH, "ssh", "configs"), {
+    recursive: true,
+  });
+  const configLocation = path.join(
+    P0_PATH,
+    "ssh",
+    "configs",
+    `${args.destination}.config`
+  );
+
+  fs.writeFileSync(configLocation, data);
+};

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -109,9 +109,6 @@ const sshResolveAction = async (
     ? `CertificateFile ${keys.certificatePath}`
     : "";
 
-  print2("=".repeat(80));
-  print2(p0Executable);
-  print2("=".repeat(80));
   const data = `
 Hostname ${args.destination}
   User ${request.linuxUserName}
@@ -119,8 +116,6 @@ Hostname ${args.destination}
   ${certificateInfo}
   PasswordAuthentication no
   ProxyCommand ${p0Executable} ssh-proxy %h --port %p --provider ${provisionedRequest.permission.provider} --identity-file ${identityFile} --request-json ${tmpFile.name}`;
-  print2(data);
-  print2("=".repeat(80));
 
   await fs.promises.mkdir(path.join(P0_PATH, "ssh", "configs"), {
     recursive: true,

--- a/src/drivers/env.ts
+++ b/src/drivers/env.ts
@@ -34,5 +34,6 @@ export const bootstrapConfig = {
       env.P0_GOOGLE_OIDC_CLIENT_SECRET ?? "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",
   },
   appUrl: env.P0_APP_URL ?? "https://api.p0.app",
+  appPath: env.P0_APP_PATH ?? "p0",
   environment: env.P0_ENV ?? "production",
 };

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -10,7 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
-import { P0_PATH, throwAssertNever } from "../../util";
+import { throwAssertNever } from "../../util";
 import { assumeRoleWithOktaSaml } from "../okta/aws";
 import { getAwsConfig } from "./config";
 import { assumeRoleWithIdc } from "./idc";
@@ -22,7 +22,6 @@ import {
   AwsSshRequest,
   AwsSshRoleRequest,
 } from "./types";
-import path from "node:path";
 
 const PROPAGATION_TIMEOUT_LIMIT_MS = 30 * 1000;
 

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { SshProvider } from "../../types/ssh";
-import { throwAssertNever } from "../../util";
+import { P0_PATH, throwAssertNever } from "../../util";
 import { assumeRoleWithOktaSaml } from "../okta/aws";
 import { getAwsConfig } from "./config";
 import { assumeRoleWithIdc } from "./idc";
@@ -21,6 +21,7 @@ import {
   AwsSshRequest,
   AwsSshRoleRequest,
 } from "./types";
+import path from "node:path";
 
 const PROPAGATION_TIMEOUT_LIMIT_MS = 30 * 1000;
 
@@ -95,11 +96,11 @@ export const awsSshProvider: SshProvider<
       "--region",
       request.region,
       "--target",
-      "%h",
+      request.id,
       "--document-name",
       START_SSH_SESSION_DOCUMENT_NAME,
       "--parameters",
-      port ? `"portNumber=${port}"` : '"portNumber=%p"',
+      port ? `portNumber=${port}` : "portNumber=%p",
     ];
   },
 
@@ -111,6 +112,12 @@ export const awsSshProvider: SshProvider<
       ];
     }
     return undefined;
+  },
+
+  generateKeys: async (_) => {
+    return {
+      privateKeyPath: path.join(P0_PATH, "ssh", "id_rsa"),
+    };
   },
 
   requestToSsh: (request) => {

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
 import { P0_PATH, throwAssertNever } from "../../util";
 import { assumeRoleWithOktaSaml } from "../okta/aws";
@@ -116,7 +117,7 @@ export const awsSshProvider: SshProvider<
 
   generateKeys: async (_) => {
     return {
-      privateKeyPath: path.join(P0_PATH, "ssh", "id_rsa"),
+      privateKeyPath: PRIVATE_KEY_PATH,
     };
   },
 

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -87,7 +87,7 @@ export const awsSshProvider: SshProvider<
 
   preTestAccessPropagationArgs: () => undefined,
 
-  proxyCommand: (request) => {
+  proxyCommand: (request, port) => {
     return [
       "aws",
       "ssm",
@@ -99,7 +99,7 @@ export const awsSshProvider: SshProvider<
       "--document-name",
       START_SSH_SESSION_DOCUMENT_NAME,
       "--parameters",
-      '"portNumber=%p"',
+      port ? `"portNumber=${port}"` : '"portNumber=%p"',
     ];
   },
 

--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -91,8 +91,6 @@ export const azureSshProvider: SshProvider<
     return undefined;
   },
 
-  // Azure doesn't support ProxyCommand, as nice as that would be. Yet.
-
   proxyCommand: (_, port) => ["nc", "localhost", port ?? "22"],
 
   reproCommands: (request, additionalData) => {

--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -92,7 +92,7 @@ export const azureSshProvider: SshProvider<
   },
 
   // Azure doesn't support ProxyCommand, as nice as that would be. Yet.
-  // proxyCommand: (_, port) => ["ssh", "-W", "localhost", port ?? "22"],
+
   proxyCommand: (_, port) => ["nc", "localhost", port ?? "22"],
 
   reproCommands: (request, additionalData) => {

--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -92,7 +92,8 @@ export const azureSshProvider: SshProvider<
   },
 
   // Azure doesn't support ProxyCommand, as nice as that would be. Yet.
-  proxyCommand: () => [],
+  // proxyCommand: (_, port) => ["ssh", "-W", "localhost", port ?? "22"],
+  proxyCommand: (_, port) => ["nc", "localhost", port ?? "22"],
 
   reproCommands: (request, additionalData) => {
     const { command: azLogoutExe, args: azLogoutArgs } = azLogoutCommand();
@@ -134,6 +135,35 @@ export const azureSshProvider: SshProvider<
       `${azCertGenExe} ${azCertGenArgs.join(" ")}`,
       `${azTunnelExe} ${azTunnelArgs.join(" ")}`,
     ];
+  },
+
+  generateKeys: async (_, options: { debug?: boolean } = {}) => {
+    const { debug } = options;
+    const { path: keyPath } = await createTempDirectoryForKeys();
+    await generateSshKeyAndAzureAdCert(keyPath, { debug });
+    const sshPrivateKeyPath = path.join(keyPath, AD_SSH_KEY_PRIVATE);
+    const sshCertificateKeyPath = path.join(keyPath, AD_CERT_FILENAME);
+
+    return {
+      privateKeyPath: sshPrivateKeyPath,
+      certificatePath: sshCertificateKeyPath,
+    };
+  },
+
+  setupProxy: async (
+    request: AzureSshRequest,
+    options: { debug?: boolean } = {}
+  ) => {
+    const { debug } = options;
+    const { killTunnel, tunnelLocalPort } = await trySpawnBastionTunnel(
+      request,
+      { debug }
+    );
+
+    return {
+      teardown: killTunnel,
+      port: tunnelLocalPort,
+    };
   },
 
   setup: async (request, options = {}) => {

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -10,9 +10,11 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { isSudoCommand } from "../../commands/shared/ssh";
 import { SshProvider } from "../../types/ssh";
+import { P0_PATH } from "../../util";
 import { ensureGcpSshInstall } from "./install";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
+import path from "node:path";
 
 // It typically takes < 1 minute for access to propagate on GCP, so set the time limit to 2 minutes.
 const PROPAGATION_TIMEOUT_LIMIT_MS = 2 * 60 * 1000;
@@ -87,6 +89,13 @@ export const gcpSshProvider: SshProvider<
       };
     }
     return undefined;
+  },
+
+  generateKeys: async (request, _) => {
+    return {
+      username: request.linuxUserName,
+      privateKeyPath: path.join(P0_PATH, "ssh", "id_rsa"),
+    };
   },
 
   proxyCommand: (request, port) => {

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -11,11 +11,9 @@ You should have received a copy of the GNU General Public License along with @p0
 import { isSudoCommand } from "../../commands/shared/ssh";
 import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
-import { P0_PATH } from "../../util";
 import { ensureGcpSshInstall } from "./install";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
-import path from "node:path";
 
 // It typically takes < 1 minute for access to propagate on GCP, so set the time limit to 2 minutes.
 const PROPAGATION_TIMEOUT_LIMIT_MS = 2 * 60 * 1000;

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -9,6 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { isSudoCommand } from "../../commands/shared/ssh";
+import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
 import { P0_PATH } from "../../util";
 import { ensureGcpSshInstall } from "./install";
@@ -94,7 +95,7 @@ export const gcpSshProvider: SshProvider<
   generateKeys: async (request, _) => {
     return {
       username: request.linuxUserName,
-      privateKeyPath: path.join(P0_PATH, "ssh", "id_rsa"),
+      privateKeyPath: PRIVATE_KEY_PATH,
     };
   },
 

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -89,13 +89,13 @@ export const gcpSshProvider: SshProvider<
     return undefined;
   },
 
-  proxyCommand: (request) => {
+  proxyCommand: (request, port) => {
     return [
       "gcloud",
       "compute",
       "start-iap-tunnel",
       request.id,
-      "%p",
+      port ? port : "%p",
       // --listen-on-stdin flag is required for interactive SSH session.
       // It is undocumented on page https://cloud.google.com/sdk/gcloud/reference/compute/start-iap-tunnel
       // but mention on page https://cloud.google.com/iap/docs/tcp-by-host

--- a/src/plugins/okta/aws.ts
+++ b/src/plugins/okta/aws.ts
@@ -26,7 +26,7 @@ export const assumeRoleWithOktaSaml = async (
       );
       const { roles } = rolesFromSaml(account, samlResponse);
       if (!roles.includes(args.role))
-        throw `Role not available. Available roles:\n${roles.map((r) => `  ${r}`).join("\n")}`;
+        throw `Role ${args.role} not available. Available roles:\n${roles.map((r) => `  ${r}`).join("\n")}`;
       return await assumeRoleWithSaml({
         account,
         role: args.role,

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -484,6 +484,7 @@ export const verifyDestinationString = (destination: string) => {
   if (destination.includes("/")) {
     throw "Destination cannot contain a forward slash (/).";
   }
+  return destination;
 };
 
 export const sshProxy = async (args: {

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -480,6 +480,12 @@ export const sshOrScp = async (args: {
   }
 };
 
+export const verifyDestinationString = (destination: string) => {
+  if (destination.includes("/")) {
+    throw "Destination cannot contain a forward slash (/).";
+  }
+};
+
 export const sshProxy = async (args: {
   authn: Authn;
   request: SshRequest;

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -425,9 +425,9 @@ export const sshOrScp = async (args: {
   const credential: AwsCredentials | undefined =
     await sshProvider.cloudProviderLogin(authn, request);
 
-  const proxyCommand = sshProvider.proxyCommand(request);
-
   const setupData = await sshProvider.setup?.(request, { debug });
+
+  const proxyCommand = sshProvider.proxyCommand(request, setupData?.port);
 
   const { command, args: commandArgs } = createCommand(
     request,

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -96,6 +96,22 @@ export type SshProvider<
     options?: { debug?: boolean }
   ) => Promise<SshAdditionalSetup>;
 
+  setupProxy?: (
+    request: SR,
+    options?: { debug?: boolean }
+  ) => Promise<{
+    teardown: () => Promise<void>;
+    port: string;
+  }>;
+
+  generateKeys?: (
+    request: SR,
+    options?: { debug?: boolean }
+  ) => Promise<{
+    privateKeyPath: string;
+    certificatePath?: string;
+  }>;
+
   /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option */
   proxyCommand: (request: SR, port?: string) => string[];
 

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -97,7 +97,7 @@ export type SshProvider<
   ) => Promise<SshAdditionalSetup>;
 
   /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option */
-  proxyCommand: (request: SR) => string[];
+  proxyCommand: (request: SR, port?: string) => string[];
 
   /** Each element in the returned array is a command that can be run to reproduce the
    * steps of logging in the user to the ssh session. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,6 +12,7 @@ import { bootstrapConfig } from "./drivers/env";
 import child_process from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { sys } from "typescript";
 
 export const P0_PATH = path.join(
   os.homedir(),
@@ -95,6 +96,15 @@ export const exec = async (
 export const throwAssertNever = (value: never) => {
   throw assertNever(value);
 };
+
+// If the condition is true, aborts the process before throwing the error
+export const conditionalAbortBeforeThrow =
+  (abortBeforeThrow: boolean) => (err: any) => {
+    if (abortBeforeThrow) {
+      sys.exit(1);
+    }
+    throw err;
+  };
 
 export const assertNever = (value: never) => {
   return unexpectedValueError(value);


### PR DESCRIPTION
This is to allow users to run
`ssh <node-name>` rather than `p0 ssh <node-name>`

It adds two commands to the cli, `ssh-resolve` and `ssh-proxy` meant to be used in an ssh config such as the following
```
Match exec "p0 ssh-resolve %h -q"
 Include .p0/ssh/configs/*.config
```

`ssh-resolve` checks if the resource exists in p0 and if the user has `approved` access to it.  If so it sets up any needed keys and writes an ssh config to `.p0/ssh/configs/` as well as request information to a temporary file, and returns 0 (success). Otherwise it returns 1 (silently if `--quiet` is passed)

`ssh-proxy` is invoked as the `ProxyCommand` by `ssh` when the config file generated by `ssh-resolve` is used, and reads the files written by `ssh-resolve` (and passed to it as cli args) and runs the relevant proxy command as well as any needed setup/teardown