### PR TITLE
Validate tenant access

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -57,6 +57,7 @@ export const login = async (
   // validate auth
   if (!options?.skipAuthenticate) {
     await authenticate();
+    await validateTenantAccess(orgData);
   }
 
   print2(`You are now logged in, and can use the p0 CLI.`);
@@ -105,3 +106,13 @@ export const loginCommand = (yargs: yargs.Argv) =>
       }),
     fsShutdownGuard(login)
   );
+
+const validateTenantAccess = async (org: RawOrgData) => {
+  try {
+    await getDoc(doc(`o/${org.tenantId}/auth/valid`));
+    return true;
+  } catch (e) {
+    await clearIdentityCache();
+    throw "Could not find organization, logging out.";
+  }
+};


### PR DESCRIPTION
This PR adds an additional check to the frontend that will automatically log a user out if they aren't authorized to access that tenant or that tenant doesn't exist. This helps prevent a poor user experience if the user mistyped the org Id or tried to access an org they are no longer a part of.