### PR TITLE
Resolve: Include host in generated files

### DIFF
--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -116,8 +116,8 @@ const sshResolveAction = async (
 
   const p0Executable = bootstrapConfig.appPath;
 
-  const data = `
-Hostname ${destination}
+  const data = `Host ${destination}
+  Hostname ${destination}
   User ${request.linuxUserName}
   IdentityFile ${identityFile}
   ${certificateInfo}


### PR DESCRIPTION
This PR fixes a small bug where using `p0 ssh <hostname>` results in invalid host name detection when the `ssh proxy` is set up in your ssh config file.