### PR TITLE
Terminal login 2 test refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # P0 Security CLI
 
-The offical Command-Line Interface (CLI) for P0.
+The official Command-Line Interface (CLI) for P0.
 
 Supports creating access requests for cloud resources, assuming AWS roles, and connecting to AWS instances.
 

--- a/src/commands/__tests__/grant.test.ts
+++ b/src/commands/__tests__/grant.test.ts
@@ -15,6 +15,7 @@ import yargs from "yargs";
 
 jest.mock("../../drivers/api");
 jest.mock("../../drivers/auth");
+jest.mock("../../drivers/auth/path");
 jest.mock("../../drivers/stdio");
 
 const mockFetchCommand = fetchCommand as jest.Mock;

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -19,7 +19,7 @@ jest.spyOn(Date, "now").mockReturnValue(1.6e12);
 jest.mock("fs/promises");
 jest.mock("../../drivers/auth", () => ({
   ...jest.requireActual("../../drivers/auth"),
-  IDENTITY_FILE_PATH: "/dummy/identity/file/path",
+  getIdentityFilePath: jest.fn(() => "/dummy/identity/file/path"),
 }));
 jest.mock("../../drivers/config", () => ({
   ...jest.requireActual("../../drivers/config"),

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -17,8 +17,7 @@ import { readFile, writeFile } from "fs/promises";
 
 jest.spyOn(Date, "now").mockReturnValue(1.6e12);
 jest.mock("fs/promises");
-jest.mock("../../drivers/auth", () => ({
-  ...jest.requireActual("../../drivers/auth"),
+jest.mock("../../drivers/auth/path", () => ({
   getIdentityFilePath: jest.fn(() => "/dummy/identity/file/path"),
 }));
 jest.mock("../../drivers/config", () => ({

--- a/src/commands/__tests__/ls.test.ts
+++ b/src/commands/__tests__/ls.test.ts
@@ -16,6 +16,7 @@ import yargs from "yargs";
 
 jest.mock("../../drivers/api");
 jest.mock("../../drivers/auth");
+jest.mock("../../drivers/auth/path");
 jest.mock("../../drivers/stdio");
 jest.spyOn(process, "exit");
 

--- a/src/commands/__tests__/ls.test.ts
+++ b/src/commands/__tests__/ls.test.ts
@@ -9,6 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { fetchCommand } from "../../drivers/api";
+import { authenticate } from "../../drivers/auth";
 import { print1, print2 } from "../../drivers/stdio";
 import { failure } from "../../testing/yargs";
 import { lsCommand } from "../ls";
@@ -16,16 +17,23 @@ import yargs from "yargs";
 
 jest.mock("../../drivers/api");
 jest.mock("../../drivers/auth");
-jest.mock("../../drivers/auth/path");
 jest.mock("../../drivers/stdio");
 jest.spyOn(process, "exit");
 
 const mockFetchCommand = fetchCommand as jest.Mock;
+const mockAuthenticate = authenticate as jest.Mock;
 const mockPrint1 = print1 as jest.Mock;
 const mockPrint2 = print2 as jest.Mock;
 
 describe("ls", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticate.mockResolvedValue({
+      userCredential: {
+        user: { tenantId: "dummy-tenant-id" },
+      },
+    });
+  });
 
   describe("when valid ls command", () => {
     const command = "ls ssh destination";

--- a/src/commands/__tests__/request.test.ts
+++ b/src/commands/__tests__/request.test.ts
@@ -9,6 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { fetchCommand } from "../../drivers/api";
+import { authenticate } from "../../drivers/auth";
 import { print1, print2 } from "../../drivers/stdio";
 import { failure } from "../../testing/yargs";
 import { RequestResponse } from "../../types/request";
@@ -22,11 +23,19 @@ jest.mock("../../drivers/auth");
 jest.mock("../../drivers/stdio");
 
 const mockFetchCommand = fetchCommand as jest.Mock;
+const mockAuthenticate = authenticate as jest.Mock;
 const mockPrint1 = print1 as jest.Mock;
 const mockPrint2 = print2 as jest.Mock;
 
 describe("request", () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticate.mockResolvedValue({
+      userCredential: {
+        user: { tenantId: "dummy-tenant-id" },
+      },
+    });
+  });
 
   describe("when valid request command", () => {
     const command = "request gcloud role viewer";

--- a/src/drivers/auth.ts
+++ b/src/drivers/auth.ts
@@ -10,17 +10,24 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { login } from "../commands/login";
 import { Authn, Identity } from "../types/identity";
+import { TokenResponse } from "../types/oidc";
+import { OrgData } from "../types/org";
 import { P0_PATH } from "../util";
 import { authenticateToFirebase } from "./firestore";
 import { print2 } from "./stdio";
 import * as fs from "fs/promises";
+import * as os from "os";
 import * as path from "path";
 
-export const IDENTITY_FILE_PATH = path.join(P0_PATH, "identity.json");
-export const IDENTITY_CACHE_PATH = path.join(
-  path.dirname(IDENTITY_FILE_PATH),
-  "cache"
-);
+const getIdentityFilePath = () =>
+  process.env.P0_ORG
+    ? path.join(os.tmpdir(), "p0", `identity-${process.env.P0_ORG}.json`)
+    : path.join(P0_PATH, "identity.json");
+
+const getIdentityCachePath = () =>
+  process.env.P0_ORG
+    ? path.join(os.tmpdir(), "p0", `cache-${process.env.P0_ORG}`)
+    : path.join(P0_PATH, "cache");
 
 export const cached = async <T>(
   name: string,
@@ -28,10 +35,12 @@ export const cached = async <T>(
   options: { duration: number },
   hasExpired?: (data: T) => boolean
 ): Promise<T> => {
+  const identityCachePath = getIdentityCachePath();
+
   // Following lines sanitize input
   // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
-  const loc = path.resolve(path.join(IDENTITY_CACHE_PATH, `${name}.json`));
-  if (!loc.startsWith(IDENTITY_CACHE_PATH)) {
+  const loc = path.resolve(path.join(identityCachePath, `${name}.json`));
+  if (!loc.startsWith(identityCachePath)) {
     throw new Error("Illegal path traversal");
   }
 
@@ -65,11 +74,33 @@ export const cached = async <T>(
   }
 };
 
+const clearIdentityFile = async () => {
+  try {
+    const identityFilePath = getIdentityFilePath();
+    // check to see if the file exists before trying to remove it
+    await fs.access(identityFilePath);
+    await fs.rm(identityFilePath);
+  } catch {
+    return;
+  }
+};
+
+const clearIdentityCache = async () => {
+  try {
+    const identityCachePath = getIdentityCachePath();
+    // check to see if the directory exists before trying to remove it
+    await fs.access(identityCachePath);
+    await fs.rm(identityCachePath, { recursive: true });
+  } catch {
+    return;
+  }
+};
+
 const loadCredentialsWithAutoLogin = async (options?: {
   noRefresh?: boolean;
 }): Promise<Identity> => {
   try {
-    const buffer = await fs.readFile(IDENTITY_FILE_PATH);
+    const buffer = await fs.readFile(getIdentityFilePath());
     const identity: Identity = JSON.parse(buffer.toString());
     if (
       !options?.noRefresh &&
@@ -86,6 +117,39 @@ const loadCredentialsWithAutoLogin = async (options?: {
     }
     throw error;
   }
+};
+
+export const writeIdentity = async (
+  org: OrgData,
+  credential: TokenResponse
+) => {
+  await clearIdentityCache();
+
+  const identityFilePath = getIdentityFilePath();
+
+  const expires_at = Date.now() * 1e-3 + credential.expires_in - 1; // Add 1 second safety margin
+  print2(`Saving authorization to ${identityFilePath}.`);
+  const dir = path.dirname(identityFilePath);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    identityFilePath,
+    JSON.stringify(
+      {
+        credential: { ...credential, expires_at },
+        org,
+      },
+      null,
+      2
+    ),
+    {
+      mode: "600",
+    }
+  );
+};
+
+export const deleteIdentity = async () => {
+  await clearIdentityCache();
+  await clearIdentityFile();
 };
 
 export const authenticate = async (options?: {

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -8,26 +8,15 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { login } from "../commands/login";
-import { Authn, Identity } from "../types/identity";
-import { TokenResponse } from "../types/oidc";
-import { OrgData } from "../types/org";
-import { P0_PATH } from "../util";
-import { authenticateToFirebase } from "./firestore";
-import { print2 } from "./stdio";
+import { login } from "../../commands/login";
+import { Authn, Identity } from "../../types/identity";
+import { TokenResponse } from "../../types/oidc";
+import { OrgData } from "../../types/org";
+import { authenticateToFirebase } from "../firestore";
+import { print2 } from "../stdio";
+import { getIdentityCachePath, getIdentityFilePath } from "./path";
 import * as fs from "fs/promises";
-import * as os from "os";
 import * as path from "path";
-
-const getIdentityFilePath = () =>
-  process.env.P0_ORG
-    ? path.join(os.tmpdir(), "p0", `identity-${process.env.P0_ORG}.json`)
-    : path.join(P0_PATH, "identity.json");
-
-const getIdentityCachePath = () =>
-  process.env.P0_ORG
-    ? path.join(os.tmpdir(), "p0", `cache-${process.env.P0_ORG}`)
-    : path.join(P0_PATH, "cache");
 
 export const cached = async <T>(
   name: string,

--- a/src/drivers/auth/path.ts
+++ b/src/drivers/auth/path.ts
@@ -1,0 +1,23 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { P0_PATH } from "../../util";
+import * as os from "os";
+import * as path from "path";
+
+export const getIdentityFilePath = () =>
+  process.env.P0_ORG
+    ? path.join(os.tmpdir(), "p0", `identity-${process.env.P0_ORG}.json`)
+    : path.join(P0_PATH, "identity.json");
+
+export const getIdentityCachePath = () =>
+  process.env.P0_ORG
+    ? path.join(os.tmpdir(), "p0", `cache-${process.env.P0_ORG}`)
+    : path.join(P0_PATH, "cache");

--- a/src/drivers/config.ts
+++ b/src/drivers/config.ts
@@ -15,9 +15,14 @@ import { bootstrapDoc } from "./firestore";
 import { print2 } from "./stdio";
 import { getDoc } from "firebase/firestore";
 import fs from "fs/promises";
+import os from "os";
 import path from "path";
+import process from "process";
 
-export const CONFIG_FILE_PATH = path.join(P0_PATH, "config.json");
+const getConfigFilePath = () =>
+  process.env.P0_ORG
+    ? path.join(os.tmpdir(), "p0", `config.json-${process.env.P0_ORG}`)
+    : path.join(P0_PATH, "config.json");
 
 let tenantConfig: Config;
 
@@ -41,17 +46,19 @@ export const saveConfig = async (orgId: string) => {
 
   const config = orgData.config ?? bootstrapConfig;
 
-  print2(`Saving config to ${CONFIG_FILE_PATH}.`);
+  const configFilePath = getConfigFilePath();
 
-  const dir = path.dirname(CONFIG_FILE_PATH);
+  print2(`Saving config to ${configFilePath}.`);
+
+  const dir = path.dirname(configFilePath);
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(CONFIG_FILE_PATH, JSON.stringify(config), { mode: "600" });
+  await fs.writeFile(configFilePath, JSON.stringify(config), { mode: "600" });
 
   tenantConfig = config;
 };
 
 export const loadConfig = async () => {
-  const buffer = await fs.readFile(CONFIG_FILE_PATH);
+  const buffer = await fs.readFile(getConfigFilePath());
   tenantConfig = JSON.parse(buffer.toString());
   return tenantConfig;
 };


### PR DESCRIPTION
Moves the file path helper functions out of the main `drivers/auth.ts` file so they can be mocked cleanly without requireActual.