### PR TITLE
ENG-3667 Support google-oidc login

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -43,6 +43,17 @@ export async function initializeFirebase() {
   }
 }
 
+const findProviderId = (identity: Identity) => {
+  switch (identity.org.ssoProvider) {
+    case "google":
+      return SignInMethod.GOOGLE;
+    case "google-oidc":
+      return "oidc.google-oidc";
+    default:
+      return identity.org.providerId;
+  }
+};
+
 export async function authenticateToFirebase(
   identity: Identity
 ): Promise<UserCredential> {
@@ -51,12 +62,7 @@ export async function authenticateToFirebase(
 
   await initializeFirebase();
 
-  // TODO: Move to map lookup
-  const provider = new OAuthProvider(
-    identity.org.ssoProvider === "google"
-      ? SignInMethod.GOOGLE
-      : identity.org.providerId
-  );
+  const provider = new OAuthProvider(findProviderId(identity));
 
   const firebaseCredential = provider.credential({
     accessToken: credential.access_token,

--- a/src/plugins/login.ts
+++ b/src/plugins/login.ts
@@ -34,5 +34,6 @@ export const pluginLoginMap: Record<
   google: googleLogin,
   okta: oktaLogin,
   ping: pingLogin,
+  "google-oidc": googleLogin,
   "oidc-pkce": async (org) => await pluginLoginMap[org.providerType!]!(org),
 };


### PR DESCRIPTION
If the SSO provider is "google-oidc", the p0 login command currently fails. This PR ensures that the login flow works correctly, and that accounts using "google-oidc" as the login provider can login successfully.