### PR TITLE
Add email to google openid scope

### DIFF
--- a/src/plugins/google/login.ts
+++ b/src/plugins/google/login.ts
@@ -37,7 +37,7 @@ const requestAuth = async () => {
     code_challenge_method: "S256",
     redirect_uri: GOOGLE_OIDC_REDIRECT_URL,
     response_type: "code",
-    scope: "openid",
+    scope: "openid email",
   };
   const url = `${GOOGLE_OIDC_URL}?${urlEncode(authBody)}`;
   open(url).catch(() => {


### PR DESCRIPTION
There is currently a bug that creates a user with a blank email in firestore when a user logs in for the first time.

This blank user breaks all subsequent logins.

I found that adding the email scope to the request for the OIDC token to google fixes this issue.  With this change logging in with the CLI creates a user with my email.

https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters
>If the email scope value is present, the ID token includes email and email_verified claims.
