### PR TITLE
ENG-4294 Correctly pass in account id to assumeRoleWithOktaSaml

### DIFF
--- a/src/commands/aws/role.ts
+++ b/src/commands/aws/role.ts
@@ -107,7 +107,11 @@ export const rolesFromSaml = (account: string, saml: string) => {
  */
 const oktaAwsAssumeRole = async (args: { account?: string; role: string }) => {
   const authn = await authenticate();
-  const awsCredential = await assumeRoleWithOktaSaml(authn, args);
+  const awsCredential = await assumeRoleWithOktaSaml(authn, {
+    accountId: args.account,
+    role: args.role,
+  });
+
   const isTty = sys.writeOutputIsTTY?.();
   if (isTty) print2("Execute the following commands:\n");
   const indent = isTty ? "  " : "";


### PR DESCRIPTION
Fixes issue where the AWS account id was not accepted by the `p0 aws assume role` command.