### PR TITLE
ENG-4099 Move Okta SAML-related functions to okta/aws.ts

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:

--- a/src/commands/aws/role.ts
+++ b/src/commands/aws/role.ts
@@ -8,16 +8,15 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { parseXml } from "../../common/xml";
 import { authenticate } from "../../drivers/auth";
 import { fsShutdownGuard } from "../../drivers/firestore";
 import { print1, print2 } from "../../drivers/stdio";
-import { getAwsConfig } from "../../plugins/aws/config";
-import { AwsFederatedLogin, AwsItem } from "../../plugins/aws/types";
-import { assumeRoleWithOktaSaml } from "../../plugins/okta/aws";
-import { getSamlResponse } from "../../plugins/okta/login";
-import { Authn } from "../../types/identity";
-import { flatten, identity, uniq } from "lodash";
+import {
+  assumeRoleWithOktaSaml,
+  initOktaSaml,
+  rolesFromSaml,
+} from "../../plugins/okta/aws";
+import { identity, uniq } from "lodash";
 import { sys } from "typescript";
 import yargs from "yargs";
 
@@ -45,54 +44,6 @@ export const role = (yargs: yargs.Argv<{ account: string | undefined }>) =>
       )
       .demandCommand(1)
   );
-
-const isFederatedLogin = (
-  config: AwsItem
-): config is AwsItem & { login: AwsFederatedLogin } =>
-  config.login?.type === "federated";
-
-/** Retrieves the configured Okta SAML response for the specified account
- *
- * If no account is passed, and the organization only has one account configured,
- * assumes that account.
- */
-export const initOktaSaml = async (
-  authn: Authn,
-  account: string | undefined
-) => {
-  const { identity, config } = await getAwsConfig(authn, account);
-  if (!isFederatedLogin(config))
-    throw `Account ${config.label ?? config.id} is not configured for Okta SAML login.`;
-  const samlResponse = await getSamlResponse(identity, config.login);
-  return {
-    samlResponse,
-    config,
-    account: config.id,
-  };
-};
-
-/** Extracts all roles from a SAML assertion */
-export const rolesFromSaml = (account: string, saml: string) => {
-  const samlText = Buffer.from(saml, "base64").toString("ascii");
-  const samlObject = parseXml(samlText);
-  const samlAttributes =
-    samlObject["saml2p:Response"]["saml2:Assertion"][
-      "saml2:AttributeStatement"
-    ]["saml2:Attribute"];
-  const roleAttribute = samlAttributes.find(
-    (a: any) =>
-      a._attributes.Name === "https://aws.amazon.com/SAML/Attributes/Role"
-  );
-  // Format:
-  //   'arn:aws:iam::391052057035:saml-provider/p0dev-ext_okta_sso,arn:aws:iam::391052057035:role/path/to/role/SSOAmazonS3FullAccess'
-  const arns = (
-    flatten([roleAttribute?.["saml2:AttributeValue"]]) as string[]
-  )?.map((r) => r.split(",")[1]!);
-  const roles = arns
-    .filter((r) => r.startsWith(`arn:aws:iam::${account}:role/`))
-    .map((r) => r.split("/").slice(1).join("/"));
-  return { arns, roles };
-};
 
 /** Assumes a role in AWS via Okta SAML federation.
  *

--- a/src/plugins/okta/aws.ts
+++ b/src/plugins/okta/aws.ts
@@ -8,10 +8,62 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { initOktaSaml, rolesFromSaml } from "../../commands/aws/role";
+import { parseXml } from "../../common/xml";
 import { cached } from "../../drivers/auth";
 import { Authn } from "../../types/identity";
 import { assumeRoleWithSaml } from "../aws/assumeRole";
+import { getAwsConfig } from "../aws/config";
+import { AwsFederatedLogin, AwsItem } from "../aws/types";
+import { getSamlResponse } from "./login";
+import { flatten } from "lodash";
+
+/** Extracts all roles from a SAML assertion */
+export const rolesFromSaml = (account: string, saml: string) => {
+  const samlText = Buffer.from(saml, "base64").toString("ascii");
+  const samlObject = parseXml(samlText);
+  const samlAttributes =
+    samlObject["saml2p:Response"]["saml2:Assertion"][
+      "saml2:AttributeStatement"
+    ]["saml2:Attribute"];
+  const roleAttribute = samlAttributes.find(
+    (a: any) =>
+      a._attributes.Name === "https://aws.amazon.com/SAML/Attributes/Role"
+  );
+  // Format:
+  //   'arn:aws:iam::391052057035:saml-provider/p0dev-ext_okta_sso,arn:aws:iam::391052057035:role/path/to/role/SSOAmazonS3FullAccess'
+  const arns = (
+    flatten([roleAttribute?.["saml2:AttributeValue"]]) as string[]
+  )?.map((r) => r.split(",")[1]!);
+  const roles = arns
+    .filter((r) => r.startsWith(`arn:aws:iam::${account}:role/`))
+    .map((r) => r.split("/").slice(1).join("/"));
+  return { arns, roles };
+};
+
+const isFederatedLogin = (
+  config: AwsItem
+): config is AwsItem & { login: AwsFederatedLogin } =>
+  config.login?.type === "federated";
+
+/** Retrieves the configured Okta SAML response for the specified account
+ *
+ * If no account is passed, and the organization only has one account configured,
+ * assumes that account.
+ */
+export const initOktaSaml = async (
+  authn: Authn,
+  account: string | undefined
+) => {
+  const { identity, config } = await getAwsConfig(authn, account);
+  if (!isFederatedLogin(config))
+    throw `Account ${config.label ?? config.id} is not configured for Okta SAML login.`;
+  const samlResponse = await getSamlResponse(identity, config.login);
+  return {
+    samlResponse,
+    config,
+    account: config.id,
+  };
+};
 
 export const assumeRoleWithOktaSaml = async (
   authn: Authn,


### PR DESCRIPTION
Move common Okta SAML-related functions to okta/aws.ts. This is in preparation for adding a new `p0 aws assume permission-set` command.