### PR TITLE
ENG-4566 Fix issue with CLI config/auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/aws/permission-set.ts
+++ b/src/commands/aws/permission-set.ts
@@ -28,19 +28,17 @@ export const permissionSet = (
     "permission-set",
     "Interact with AWS permission sets",
     (yargs) =>
-      yargs
-        .command(
-          "assume <permission-set>",
-          "Assume an AWS permission set",
-          (y: yargs.Argv<AssumeCommandArgs>) =>
-            y.positional("permission-set", {
-              type: "string",
-              demandOption: true,
-              describe: "An AWS permission set name",
-            }),
-          fsShutdownGuard((argv) => oktaAwsAssumePermissionSet(argv, authn))
-        )
-        .demandCommand(1)
+      yargs.command(
+        "assume <permission-set>",
+        "Assume an AWS permission set",
+        (y: yargs.Argv<AssumeCommandArgs>) =>
+          y.positional("permission-set", {
+            type: "string",
+            demandOption: true,
+            describe: "An AWS permission set name",
+          }),
+        fsShutdownGuard((argv) => oktaAwsAssumePermissionSet(argv, authn))
+      )
   );
 
 const oktaAwsAssumePermissionSet = async (

--- a/src/commands/aws/role.ts
+++ b/src/commands/aws/role.ts
@@ -24,20 +24,18 @@ export const role = (
   authn: Authn
 ) =>
   yargs.command("role", "Interact with AWS roles", (yargs) =>
-    yargs
-      .command(
-        "assume <role>",
-        "Assume an AWS role",
-        (y: yargs.Argv<{ account: string | undefined }>) =>
-          y.positional("role", {
-            type: "string",
-            demandOption: true,
-            describe: "An AWS role name",
-          }),
-        // TODO: select based on uidLocation
-        fsShutdownGuard((argv) => oktaAwsAssumeRole(argv, authn))
-      )
-      .demandCommand(1)
+    yargs.command(
+      "assume <role>",
+      "Assume an AWS role",
+      (y: yargs.Argv<{ account: string | undefined }>) =>
+        y.positional("role", {
+          type: "string",
+          demandOption: true,
+          describe: "An AWS role name",
+        }),
+      // TODO: select based on uidLocation
+      fsShutdownGuard((argv) => oktaAwsAssumeRole(argv, authn))
+    )
   );
 
 /** Assumes a role in AWS via Okta SAML federation.

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -107,7 +107,11 @@ export const fsShutdownGuard =
     try {
       await cb(args);
     } finally {
-      if (bootstrapFirestore) void terminate(bootstrapFirestore);
-      if (firestore) void terminate(firestore);
+      shutdownFirebase();
     }
   };
+
+export const shutdownFirebase = () => {
+  if (bootstrapFirestore) void terminate(bootstrapFirestore);
+  if (firestore) void terminate(firestore);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,9 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { cli } from "./commands";
-import { initializeFirebase } from "./drivers/firestore";
 import { noop } from "lodash";
 
 export const main = async () => {
-  await initializeFirebase();
-
   // We can suppress output here, as .fail() already print2 errors
   void (cli.parse() as any).catch(noop);
 };


### PR DESCRIPTION
* Fixes an issue that prevented users from using the CLI if they do not already have an existing config.
* Removed unnecessary authentication call.
* Updated error handling for '/p0 aws role assume' and '/p0 aws permission-set assume' if user does not have an existing config.
* Removed superfluous demandCommand() calls.
* Verified behavior by executing aws, ls & ssh commands with/without config.