### PR TITLE
Support ARNs as host names in the ssh-resolve command

### DIFF
--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -116,8 +116,11 @@ const sshResolveAction = async (
 
   const p0Executable = bootstrapConfig.appPath;
 
+  // Replace any characters that don't make a good 
+  const sanitizedDestination = destination.replace(/[^a-zA-Z0-9-_]/g, "_");
+
   const data = `Host ${destination}
-  Hostname ${destination}
+  Hostname ${sanitizedDestination}
   User ${request.linuxUserName}
   IdentityFile ${identityFile}
   ${certificateInfo}
@@ -127,11 +130,12 @@ const sshResolveAction = async (
   await fs.promises.mkdir(path.join(P0_PATH, "ssh", "configs"), {
     recursive: true,
   });
+
   const configLocation = path.join(
     P0_PATH,
     "ssh",
     "configs",
-    `${destination}.config` // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+    `${sanitizedDestination}.config` // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   );
 
   if (args.debug) {


### PR DESCRIPTION
AWS SSM managed instance ARNs are of the form:
```
arn:aws:ssm:us-west-1:391052057035:managed-instance/i-024f03df9d0417bc8
```

The forward slash in this pattern causes an issue when we try to create the file that holds the ssh config for this instance:

```
p0cli % ssh arn:aws:ssm:us-west-1:391052057035:managed-instance/i-025f03df240417bc8
Existing access found.  Connecting to instance.
Error: ENOENT: no such file or directory, open '/Users/me/.p0/ssh/configs/arn:aws:ssm:us-west-1:123456789012:managed-instance/i-025f03df240417bc8.config'
    at Object.writeFileSync (node:fs:2346:20)
    at /Users/gergo/.nvm/versions/node/v20.14.0/lib/node_modules/@p0security/cli/dist/commands/ssh-resolve.js:116:18
    at Generator.next (<anonymous>)
    at fulfilled (/Users/gergo/.nvm/versions/node/v20.14.0/lib/node_modules/@p0security/cli/dist/commands/ssh-resolve.js:5:58) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/gergo/.p0/ssh/configs/arn:aws:ssm:us-west-1:123456789012:managed-instance/i-025f03df240417bc8.config'
}
ssh: Could not resolve hostname arn:aws:ssm:us-west-1:123456789012:managed-instance/i-025f03df240417bc8: -65540
```

This change sanitizes the host name. It goes beyond the minimal fix to be more defensive by also removing other potentially invalid characters.