### PR TITLE
Hide `p0 ssh-proxy` and `p0 ssh-resolve` commands in the help

### DIFF
--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -20,7 +20,7 @@ import yargs from "yargs";
 export const sshProxyCommand = (yargs: yargs.Argv) =>
   yargs.command<SshProxyCommandArgs>(
     "ssh-proxy <destination>",
-    "SSH into a virtual machine",
+    "Use p0 as a proxy in ssh commands to connect to managed nodes, to be used with p0 ssh-resolve",
     (yargs) =>
       yargs
         .positional("destination", {

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -20,7 +20,7 @@ import yargs from "yargs";
 export const sshProxyCommand = (yargs: yargs.Argv) =>
   yargs.command<SshProxyCommandArgs>(
     "ssh-proxy <destination>",
-    "Use p0 as a proxy in ssh commands to connect to managed nodes, to be used with p0 ssh-resolve",
+    false,
     (yargs) =>
       yargs
         .positional("destination", {

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -28,7 +28,7 @@ import yargs from "yargs";
 export const sshResolveCommand = (yargs: yargs.Argv) =>
   yargs.command<SshResolveCommandArgs>(
     "ssh-resolve <destination>",
-    "SSH into a virtual machine",
+    "Determine if a hostname is managed by p0 and prepare an ssh configuration for immediate use with p0 ssh-proxy",
     (yargs) =>
       yargs
         .positional("destination", {

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -28,7 +28,7 @@ import yargs from "yargs";
 export const sshResolveCommand = (yargs: yargs.Argv) =>
   yargs.command<SshResolveCommandArgs>(
     "ssh-resolve <destination>",
-    "Determine if a hostname is managed by p0 and prepare an ssh configuration for immediate use with p0 ssh-proxy",
+    false,
     (yargs) =>
       yargs
         .positional("destination", {


### PR DESCRIPTION
Hides `p0 ssh-proxy` and `p0 ssh-resolve` commands in the help