### PR TITLE
Password login

### DIFF
--- a/__mocks__/@firebase/auth.ts
+++ b/__mocks__/@firebase/auth.ts
@@ -2,8 +2,9 @@ export const getAuth = jest.fn().mockReturnValue({});
 
 export const signInWithCredential = jest.fn();
 
-export const SignInMethod = {
+export const ProviderId = {
   GOOGLE: "google.com",
+  PASSWORD: "password",
 };
 
 export class OAuthProvider {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -34,6 +34,7 @@ const mockIdentity: Identity = {
   org: {
     tenantId: "test-tenant",
     slug: "test-org",
+    ssoProvider: "google",
   },
 } as Identity;
 
@@ -50,7 +51,7 @@ describe("login", () => {
 
   it("prints a friendly error if the org is not provided", async () => {
     mockGetDoc(undefined);
-    await expect(login({})).rejects.toMatchInlineSnapshot(
+    await expect(login({} as any)).rejects.toMatchInlineSnapshot(
       `"The P0 organization ID is required. Please provide it as an argument or set the P0_ORG environment variable."`
     );
   });
@@ -166,7 +167,7 @@ Please contact support@p0.dev for assistance."
       });
 
       it("no org provided, prints current logged-in status", async () => {
-        await login({});
+        await login({} as any);
 
         expect(print2).toHaveBeenCalledWith(
           "You are currently logged in to the test-org organization."

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -27,8 +27,11 @@ import yargs from "yargs";
 const MIN_REMAINING_TOKEN_TIME_SECONDS = 5 * 60;
 
 const doActualLogin = async (orgWithSlug: OrgData) => {
-  const plugin = orgWithSlug?.ssoProvider;
-  const loginFn = pluginLoginMap[plugin];
+  const plugin =
+    orgWithSlug?.ssoProvider ??
+    (orgWithSlug.usePassword ? "password" : undefined);
+
+  const loginFn = plugin && pluginLoginMap[plugin];
 
   if (!loginFn) throw "Unsupported login for your organization";
 
@@ -53,8 +56,8 @@ const formatTimeLeft = (seconds: number) => {
  * Otherwise, the identity file is written to the ~/.p0 directory.
  */
 export const login = async (
-  args: { org?: string; refresh?: boolean },
-  options?: { skipAuthenticate?: boolean }
+  args: { org: string; refresh?: boolean },
+  options?: { debug?: boolean; skipAuthenticate?: boolean }
 ) => {
   let identity;
   try {
@@ -112,7 +115,7 @@ export const login = async (
   }
 
   if (!options?.skipAuthenticate) {
-    await authenticate();
+    await authenticate({ debug: options?.debug });
     await validateTenantAccess(orgData);
   }
 
@@ -137,8 +140,21 @@ export const loginCommand = (yargs: yargs.Argv) =>
           type: "boolean",
           describe: "Force re-authentication",
           default: false,
+        })
+        .option("debug", {
+          type: "boolean",
+          describe: "Print debug information.",
         }),
-    fsShutdownGuard(login)
+    fsShutdownGuard(
+      (
+        args: yargs.ArgumentsCamelCase<{
+          org: string;
+          refresh?: boolean;
+          debug?: boolean;
+        }>
+      ) =>
+        login({ org: args.org, refresh: args.refresh }, { debug: args.debug })
+    )
   );
 
 const validateTenantAccess = async (org: RawOrgData) => {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -56,7 +56,7 @@ const formatTimeLeft = (seconds: number) => {
  * Otherwise, the identity file is written to the ~/.p0 directory.
  */
 export const login = async (
-  args: { org: string; refresh?: boolean },
+  args: { org?: string; refresh?: boolean },
   options?: { debug?: boolean; skipAuthenticate?: boolean }
 ) => {
   let identity;
@@ -152,8 +152,7 @@ export const loginCommand = (yargs: yargs.Argv) =>
           refresh?: boolean;
           debug?: boolean;
         }>
-      ) =>
-        login({ org: args.org, refresh: args.refresh }, { debug: args.debug })
+      ) => login(args, args)
     )
   );
 

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -105,6 +105,7 @@ export const remainingTokenTime = (identity: Identity) =>
 
 const loadCredentialsWithAutoLogin = async (options?: {
   noRefresh?: boolean;
+  debug?: boolean;
 }): Promise<Identity> => {
   const identity = await loadCredentials();
   if (remainingTokenTime(identity) > MIN_REMAINING_TOKEN_TIME_SECONDS) {
@@ -115,7 +116,10 @@ const loadCredentialsWithAutoLogin = async (options?: {
     throw EXPIRED_CREDENTIALS_MESSAGE;
   }
 
-  await login({ org: identity.org.slug }, { skipAuthenticate: true });
+  await login(
+    { org: identity.org.slug },
+    { debug: options?.debug, skipAuthenticate: true }
+  );
   print2("\u200B"); // Force a new line
   return loadCredentialsWithAutoLogin({ noRefresh: true });
 };
@@ -149,6 +153,9 @@ export const authenticate = async (options?: {
   debug?: boolean;
 }): Promise<Authn> => {
   const identity = await loadCredentialsWithAutoLogin(options);
+  // Note: if the `providerId` is "password", we already actually already
+  // retrieved the UserCredential object in `loadCredentialsWithAutoLogin`.
+  // This following call to `authenticateToFirebase` could be omitted.
   const userCredential = await authenticateToFirebase(identity, options);
 
   return { userCredential, identity };

--- a/src/plugins/email/login.ts
+++ b/src/plugins/email/login.ts
@@ -1,0 +1,44 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { signInToTenant } from "../../drivers/firestore";
+import { TokenResponse } from "../../types/oidc";
+import { OrgData } from "../../types/org";
+import { EmailAuthProvider } from "firebase/auth";
+
+export const getPasswordCredential = () => {
+  const email = process.env["P0_EMAIL"];
+  const password = process.env["P0_PASSWORD"];
+  if (!email || !password) {
+    throw new Error(
+      "Your organization uses email / password login. The P0_EMAIL and P0_PASSWORD environment variables must be set."
+    );
+  }
+  return EmailAuthProvider.credential(email, password);
+};
+
+export const emailPasswordLogin = async (
+  org: OrgData
+): Promise<TokenResponse> => {
+  const credential = getPasswordCredential();
+  const userCredential = await signInToTenant(org, credential, { debug: true });
+  const idTokenResult = await userCredential.user.getIdTokenResult();
+  // expirationTime is in UTC, e.g. "Wed, 14 May 2025 04:07:13 GMT"
+  const expiresAt = new Date(idTokenResult.expirationTime).getTime();
+  return {
+    // Placeholder, do not store the actual password
+    // We always read the password from environment variable
+    access_token: "PASSWORD",
+    id_token: idTokenResult.token,
+    expires_in: Math.floor((expiresAt - Date.now()) * 1e-3),
+    refresh_token: userCredential.user.refreshToken,
+    expiry: idTokenResult.expirationTime,
+  };
+};

--- a/src/plugins/login.ts
+++ b/src/plugins/login.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { TokenResponse } from "../types/oidc";
 import { OrgData } from "../types/org";
+import { emailPasswordLogin } from "./email/login";
 import { googleLogin } from "./google/login";
 import { oktaLogin } from "./okta/login";
 import { pingLogin } from "./ping/login";
@@ -36,4 +37,5 @@ export const pluginLoginMap: Record<
   ping: pingLogin,
   "google-oidc": googleLogin,
   "oidc-pkce": async (org) => await pluginLoginMap[org.providerType!]!(org),
+  password: emailPasswordLogin,
 };

--- a/src/types/oidc.ts
+++ b/src/types/oidc.ts
@@ -34,11 +34,11 @@ export type AuthorizeResponse = {
 export type TokenResponse = {
   access_token: string;
   id_token: string;
-  token_type: string;
-  scope: string;
+  token_type?: string;
+  scope?: string;
   expires_in: number;
-  refresh_token: string;
-  device_secret: string;
+  refresh_token?: string;
+  device_secret?: string;
   expiry: string;
 };
 

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -36,13 +36,14 @@ type BaseOrgData = {
   clientId: string;
   providerId: string;
   providerDomain?: string;
-  ssoProvider:
+  ssoProvider?:
     | "azure-oidc"
     | "google-oidc"
     | "google"
     | "microsoft"
     | "oidc-pkce"
     | "okta";
+  usePassword?: boolean;
   tenantId: string;
   config: Config;
 };


### PR DESCRIPTION
Add support for email / password login to P0 backend.

The email and password are provided by the user via the `P0_EMAIL` and `P0_PASSWORD` environment variables to avoid storing these in the cached identity file.

If an org uses password login then their "login" is the same as authenticating to firebase. That, however is not deduplicated. `loadCredentialsWithAutoLogin` and `authenticateToFirebase` both sign in the user with email / password to firebase. Although this is redundant, keeping that logic makes the change much smaller and easier to see that existing functionality is not affected.

Manually tested the following cases:
- The P0_ORG environment variable continues to work
- Google login to P0 + AWS SSH access using AWS Identity Center with Okta
- email / password login + AWS SSH access using AWS Identity Center with Okta
- email / password login + AWS SSH access using AWS Account Federation with Okta:
    this errors out with
    ```{"error":"invalid_request","error_description":"'subject_token' is invalid."}```
    because we cannot sign in to the Okta AWS Account Federation app with a token from Firebase

Example commands:
<img width="602" alt="Screenshot 2025-05-13 at 10 30 40 PM" src="https://github.com/user-attachments/assets/944d143c-898d-4152-8b23-391aacdc8471" />

Added the `--debug` flag to the `p0 login` command as well. This prints various Firebase errors, for instance, if the user has not signed up yet:

<img width="474" alt="image" src="https://github.com/user-attachments/assets/003b3294-3f89-4196-9c3d-0cc7f809c648" />


