### PR TITLE
Print only AWS credentials on `p0 aws permission-set assume` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
+++ b/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
@@ -9,9 +9,8 @@ exports[`aws role a single installed account with Okta SAML assume should assume
   [
     "
 Or, populate these environment variables using BASH command substitution:
-
-  $(p0 aws role assume Role1)
-",
+  
+  $(p0 aws role assume Role1) ",
   ],
 ]
 `;
@@ -19,10 +18,16 @@ Or, populate these environment variables using BASH command substitution:
 exports[`aws role a single installed account with Okta SAML assume should assume a role: stdout 1`] = `
 [
   [
-    "  export AWS_ACCESS_KEY_ID=test-access-key
-  export AWS_SECRET_ACCESS_KEY=secret-access-key
-  export AWS_SESSION_TOKEN=session-token
-  export AWS_SECURITY_TOKEN=session-token",
+    "  export AWS_ACCESS_KEY_ID=test-access-key",
+  ],
+  [
+    "  export AWS_SECRET_ACCESS_KEY=secret-access-key",
+  ],
+  [
+    "  export AWS_SESSION_TOKEN=session-token",
+  ],
+  [
+    "  export AWS_SECURITY_TOKEN=session-token",
   ],
 ]
 `;

--- a/src/commands/aws/util.ts
+++ b/src/commands/aws/util.ts
@@ -1,0 +1,44 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { print1, print2 } from "../../drivers/stdio";
+import { AwsCredentials } from "../../plugins/aws/types";
+import { sys } from "typescript";
+
+const CREDENTIAL_FIELDS: (keyof AwsCredentials)[] = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_SECURITY_TOKEN",
+];
+
+export const printAwsCredentials = (
+  awsCredentials: AwsCredentials,
+  command: string
+) => {
+  const isTty = sys.writeOutputIsTTY?.();
+  const indent = isTty ? "  " : "";
+
+  if (isTty) print2("Execute the following commands:\n");
+
+  for (const key of CREDENTIAL_FIELDS) {
+    const value = awsCredentials[key];
+    if (value) {
+      print1(`${indent}export ${key}=${value}`);
+    }
+  }
+
+  if (isTty) {
+    print2(`
+Or, populate these environment variables using BASH command substitution:
+  
+  $(${command}) `);
+  }
+};


### PR DESCRIPTION
The printAwsCredential() function was iterating over any field in the AwsCredential object, which include an extra `expiresAt` field used for only for caching.
    
Instead, changed it to print only the specific field values that contain the credentials.

