### PR TITLE
ENG-4653 Suppress ssh-resolve output if host is not managed by P0

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -61,9 +61,26 @@ const buildArgv = () => {
   return argv;
 };
 
+// Skip the version check for these non-interactive commands
+const skipVersionCheckFor = ["ssh-proxy", "ssh-resolve"];
+
+function conditionalCheckVersion(argv: yargs.ArgumentsCamelCase) {
+  const invokedCommand = argv._[0];
+
+  if (typeof invokedCommand !== "string") {
+    return;
+  }
+
+  if (skipVersionCheckFor.includes(invokedCommand)) {
+    return;
+  } else {
+    return checkVersion(argv);
+  }
+}
+
 export const cli = commands
   .reduce((m, c) => c(m), buildArgv())
-  .middleware(checkVersion)
+  .middleware(conditionalCheckVersion)
   .strict()
   .demandCommand(1)
   .fail((message, error, yargs) => {

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -22,6 +22,7 @@ import {
 import fs from "fs";
 import path from "path";
 import tmp from "tmp-promise";
+import { sys } from "typescript";
 import yargs from "yargs";
 
 const ENV_PREFIX = "P0_SSH";
@@ -86,6 +87,17 @@ const sshResolveAction = async (
         `Please set the ${ENV_PREFIX}_REASON environment variable or request access with "p0 request ssh ... --reason ..." to the destination first.`
       );
     }
+
+    if (
+      typeof err === "string" &&
+      err.startsWith("Could not find any instances matching")
+    ) {
+      if (args.debug) {
+        print2(err);
+      }
+      sys.exit(1);
+    }
+
     return silentlyExit(err);
   };
 


### PR DESCRIPTION
* Skip version check for ssh-resolve and ssh-proxy commands
* Suppress ssh-resolve output if host is not managed by P0