### PR TITLE
ENG-1737 API to list access for any/all users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { AnsiSgr } from "../drivers/ansi";
-import { fetchCommand } from "../drivers/api";
+import { fetchAdminLsCommand, fetchCommand } from "../drivers/api";
 import { authenticate } from "../drivers/auth";
 import { fsShutdownGuard } from "../drivers/firestore";
 import { print2, print1, spinUntil } from "../drivers/stdio";
@@ -83,13 +83,21 @@ const ls = async (
   const authn = await authenticate();
   const { convertedArgs, requestedSize } = convertLsSizeArg(args.arguments);
 
-  const data = await spinUntil(
-    "Listing accessible resources",
-    fetchCommand<LsResponse>(authn, args, [
-      "ls",
-      ...(args.json ? args.arguments : convertedArgs),
-    ])
-  );
+  const isAdminCommand =
+    args.arguments.includes("--all") || args.arguments.includes("--principal");
+
+  const command = isAdminCommand
+    ? fetchAdminLsCommand<LsResponse>(authn, args, [
+        "ls",
+        ...(args.json ? args.arguments : convertedArgs),
+      ])
+    : fetchCommand<LsResponse>(authn, args, [
+        "ls",
+        ...(args.json ? args.arguments : convertedArgs),
+      ]);
+
+  const data = await spinUntil("Listing accessible resources", command);
+
   if (data && "ok" in data && data.ok) {
     if (args.json) {
       print1(JSON.stringify(data, null, 2));

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -16,7 +16,9 @@ import yargs from "yargs";
 const tenantUrl = (tenant: string) => `${getTenantConfig().appUrl}/o/${tenant}`;
 const publicKeysUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/public-keys`;
+
 const commandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/`;
+const adminLsCommandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/ls`;
 
 export const fetchCommand = async <T>(
   authn: Authn,
@@ -26,6 +28,22 @@ export const fetchCommand = async <T>(
   baseFetch<T>(
     authn,
     commandUrl(authn.identity.org.slug),
+    "POST",
+    JSON.stringify({
+      argv,
+      scriptName: path.basename(args.$0),
+    })
+  );
+
+/** Special admin 'ls' command that can retrieve results for all users. Requires 'owner' permission. */
+export const fetchAdminLsCommand = async <T>(
+  authn: Authn,
+  args: yargs.ArgumentsCamelCase,
+  argv: string[]
+) =>
+  baseFetch<T>(
+    authn,
+    adminLsCommandUrl(authn.identity.org.slug),
     "POST",
     JSON.stringify({
       argv,


### PR DESCRIPTION
* Extends the existing /ls command API to list access for any given user.
* This will be used by the p0 CLI when executing the `ls` command, with either -all or --principal <email> arguments.
* The purpose of this feature is support / troubleshooting / auditing.