### PR TITLE
Change the User-Agent to report P0 CLI/{version}

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { P0_VERSION } from "..";
 import { Authn } from "../types/identity";
 import { getTenantConfig } from "./config";
 import * as path from "node:path";
@@ -79,6 +80,7 @@ export const baseFetch = async <T>(
       headers: {
         authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
+        "User-Agent": `P0 CLI/${P0_VERSION}`,
       },
       body,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import { cli } from "./commands";
 import { loadConfig } from "./drivers/config";
 import { noop } from "lodash";
 
+export const P0_VERSION = "0.18.1';";
+
 export const main = async () => {
   // Try to load the config early here to get the custom help/contact messages (if any)
   try {


### PR DESCRIPTION
Changes the User-Agent header to report `P0 CLI/version` when making calls to the P0 backend. This is to aid with auditing.