### PR TITLE
Alias generated kubeconfig entries

### DIFF
--- a/src/plugins/kubeconfig/index.ts
+++ b/src/plugins/kubeconfig/index.ts
@@ -26,6 +26,8 @@ import { getDoc } from "firebase/firestore";
 import { pick } from "lodash";
 import yargs from "yargs";
 
+const prefix = "p0cli-managed-eks";
+
 export const getAndValidateK8sIntegration = async (
   authn: Authn,
   clusterId: string
@@ -71,11 +73,7 @@ export const getAndValidateK8sIntegration = async (
   }
 
   return {
-    clusterConfig: {
-      clusterId,
-      awsAccountId,
-      awsClusterArn,
-    },
+    clusterConfig: { clusterId, awsAccountId, awsClusterArn },
     awsLoginType: awsLogin.type,
   };
 };
@@ -120,7 +118,10 @@ export const requestAccessToCluster = async (
 };
 
 export const profileName = (eksCluterName: string): string =>
-  `p0cli-managed-eks-${eksCluterName}`;
+  `${prefix}-${eksCluterName}`;
+
+export const aliasedArn = (eksCluterArn: string): string =>
+  `${prefix}-${eksCluterArn}`;
 
 export const awsCloudAuth = async (
   authn: Authn,


### PR DESCRIPTION
Previously, the generated kubeconfig user and generated kubeconfig context defaulted to the cluster ARN. If the user had already configured the cluster than the `aws eks update-kubeconfig` command overwrote the existing context and user, adding the AWS_PROFILE env var to the user. Once access expired this env var remained in the kube config, essentially making the context unusable.

This change aliases the context name and the user name by prefixing them with `p0cli-managed-eks`, so P0 updates its own entries instead of modifying existing ones.

Example user entry:
```
- name: p0cli-managed-eks-arn:aws:eks:us-west-2:391052057035:cluster/my-cluster
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args:
      - --region
      - us-west-2
      - eks
      - get-token
      - --cluster-name
      - my-cluster
      - --output
      - json
      command: aws
      env:
      - name: AWS_PROFILE
        value: p0cli-managed-eks-my-cluster
```

Example context entry:
```
- context:
    cluster: arn:aws:eks:us-west-2:391052057035:cluster/my-cluster
    user: p0cli-managed-eks-arn:aws:eks:us-west-2:391052057035:cluster/my-cluster
  name: p0cli-managed-eks-arn:aws:eks:us-west-2:391052057035:cluster/my-cluster
```