### PR TITLE
Bump CLI to v18.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { loadConfig } from "./drivers/config";
 import { noop } from "lodash";
 import { isSea } from "node:sea";
 
-export const P0_VERSION = "0.18.3';";
+export const P0_VERSION = "0.18.4";
 
 export const main = async () => {
   // Try to load the config early here to get the custom help/contact messages (if any)


### PR DESCRIPTION
For a new release with the MacOS CLI .pkg distribution