### PR TITLE
General improvements to CLI version management

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To learn more about P0, see our [docs](https://docs.p0.dev/).
 
 ### Installation
 
-To install the P0 CLI, ensure your `node` version is 22 or higher, then run:
+To install the P0 CLI as an NPM package, ensure your `node` version is 22 or higher, then run:
 
 ```
 npm install -g @p0security/cli
@@ -49,6 +49,12 @@ If your node version is incompatible, use `nvm`. E.g.:
 nvm install 22
 nvm use 22
 ```
+
+We also provide the ability to install the P0 CLI as a standalone executable that does not require
+an existing installation of NodeJS. The installer is available on the GitHub [releases page](https://github.com/p0-security/p0cli/releases)
+
+The standalone CLI is currently only available on MacOS. Using the standalone CLI doesn't have any functionality that is not included
+when installing via NPM, so for most users installing via NPM is likely to fulfill your needs.
 
 ### Configuration
 

--- a/sea-config.json
+++ b/sea-config.json
@@ -4,6 +4,7 @@
   "disableExperimentalSEAWarning": true,
   "assets": {
     "favicon.ico": "./public/favicon.ico",
-    "redirect-landing.html": "./public/redirect-landing.html"
+    "redirect-landing.html": "./public/redirect-landing.html",
+    "package.json": "./package.json"
   }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { getHelpMessage } from "../drivers/config";
 import { print1, print2 } from "../drivers/stdio";
 import { checkVersion } from "../middlewares/version";
-import { P0_VERSION_INFO } from "../version";
+import { p0VersionInfo } from "../version";
 import { allowCommand } from "./allow";
 import { awsCommand } from "./aws";
 import { grantCommand } from "./grant";
@@ -44,7 +44,7 @@ const commands = [
 ];
 
 const buildArgv = async () => {
-  const { version } = await P0_VERSION_INFO;
+  const { version } = await p0VersionInfo;
   const argv = yargs(hideBin(process.argv)).version(version);
 
   // Override the default yargs showHelp() function to include a custom help message at the end
@@ -80,8 +80,8 @@ function conditionalCheckVersion(argv: yargs.ArgumentsCamelCase) {
   }
 }
 
-export const getCli = async () => {
-  const cli = commands
+export const getCli = async () =>
+  commands
     .reduce((m, c) => c(m), await buildArgv())
     .middleware(conditionalCheckVersion)
     .strict()
@@ -96,6 +96,3 @@ export const getCli = async () => {
       }
       sys.exit(1);
     });
-
-  return cli;
-};

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { Authn } from "../types/identity";
-import { P0_VERSION_INFO } from "../version";
+import { p0VersionInfo } from "../version";
 import { getTenantConfig } from "./config";
 import * as path from "node:path";
 import yargs from "yargs";
@@ -73,7 +73,7 @@ export const baseFetch = async <T>(
   body: string
 ) => {
   const token = await authn.userCredential.user.getIdToken();
-  const { version } = await P0_VERSION_INFO;
+  const { version } = await p0VersionInfo;
 
   try {
     const response = await fetch(url, {

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -8,8 +8,8 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { P0_VERSION } from "..";
 import { Authn } from "../types/identity";
+import { P0_VERSION_INFO } from "../version";
 import { getTenantConfig } from "./config";
 import * as path from "node:path";
 import yargs from "yargs";
@@ -73,6 +73,7 @@ export const baseFetch = async <T>(
   body: string
 ) => {
   const token = await authn.userCredential.user.getIdToken();
+  const { version } = await P0_VERSION_INFO;
 
   try {
     const response = await fetch(url, {
@@ -80,7 +81,7 @@ export const baseFetch = async <T>(
       headers: {
         authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
-        "User-Agent": `P0 CLI/${P0_VERSION}`,
+        "User-Agent": `P0 CLI/${version}`,
       },
       body,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,10 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { cli } from "./commands";
+import { getCli } from "./commands";
 import { loadConfig } from "./drivers/config";
 import { noop } from "lodash";
 import { isSea } from "node:sea";
-
-export const P0_VERSION = "0.18.4";
 
 export const main = async () => {
   // Try to load the config early here to get the custom help/contact messages (if any)
@@ -28,6 +26,7 @@ export const main = async () => {
     }
   }
 
+  const cli = await getCli();
   // We can suppress output here, as .fail() already print2 errors
   void (cli.parse() as any).catch(noop);
 };

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -10,7 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { print2 } from "../drivers/stdio";
 import { P0_PATH, exec, timeout } from "../util";
-import { P0_VERSION_INFO } from "../version";
+import { p0VersionInfo } from "../version";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isSea } from "node:sea";
@@ -45,7 +45,7 @@ export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
     // Write the version-check file first to avoid retrying errors
     await fs.writeFile(latestFile, "");
 
-    const { name, version } = await P0_VERSION_INFO;
+    const { name, version } = await p0VersionInfo;
 
     const npmResult = exec("npm", ["view", name, "--json"], { check: true });
     const npmPackage = await timeout(npmResult, VERSION_CHECK_TIMEOUT_MILLIS);
@@ -56,13 +56,13 @@ export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
     if (semver.lt(version, latest)) {
       if (isSea()) {
         print2(
-          `╔══════════════════════════════════════╗
-║ A new version of P0 CLI is available ║
-║                                      ║
-║ To install, please view our GitHub   ║
-║ repository README for instructions:  ║
-║ https://github.com/p0-security/p0cli ║
-╚══════════════════════════════════════╝
+          `╔═══════════════════════════════════════════════╗
+║ A new version of P0 CLI is available          ║
+║                                               ║
+║ To install, download the latest version       ║
+║ from the GitHub releases page:                ║
+║ https://github.com/p0-security/p0cli/releases ║
+╚═══════════════════════════════════════════════╝
 `
         );
       } else {

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { print2 } from "../drivers/stdio";
 import { P0_PATH, exec, timeout } from "../util";
+import { P0_VERSION_INFO } from "../version";
 import fs from "node:fs/promises";
 import path from "node:path";
 import semver from "semver";
@@ -43,11 +44,7 @@ export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
     // Write the version-check file first to avoid retrying errors
     await fs.writeFile(latestFile, "");
 
-    // Note that package.json is installed one level above "dist"
-    // We can't require package.json as it is outside the TypeScript root
-    const { name, version } = JSON.parse(
-      (await fs.readFile(`${__dirname}/../../package.json`)).toString("utf-8")
-    );
+    const { name, version } = await P0_VERSION_INFO;
 
     const npmResult = exec("npm", ["view", name, "--json"], { check: true });
     const npmPackage = await timeout(npmResult, VERSION_CHECK_TIMEOUT_MILLIS);

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -13,6 +13,7 @@ import { P0_PATH, exec, timeout } from "../util";
 import { P0_VERSION_INFO } from "../version";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isSea } from "node:sea";
 import semver from "semver";
 import yargs from "yargs";
 
@@ -53,15 +54,28 @@ export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
     } = JSON.parse(npmPackage.stdout);
 
     if (semver.lt(version, latest)) {
-      print2(
-        `╔══════════════════════════════════════╗
+      if (isSea()) {
+        print2(
+          `╔══════════════════════════════════════╗
+║ A new version of P0 CLI is available ║
+║                                      ║
+║ To install, please view our GitHub   ║
+║ repository README for instructions:  ║
+║ https://github.com/p0-security/p0cli ║
+╚══════════════════════════════════════╝
+`
+        );
+      } else {
+        print2(
+          `╔══════════════════════════════════════╗
 ║ A new version of P0 CLI is available ║
 ║                                      ║
 ║ To install, run                      ║
 ║   npm -g update ${name.padEnd(20)} ║
 ╚══════════════════════════════════════╝
 `
-      );
+        );
+      }
     }
   } catch (error: any) {
     // Silently pass errors

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,38 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import fs from "node:fs/promises";
+import { getAssetAsBlob, isSea } from "node:sea";
+
+const loadCurrentVersion = async (): Promise<{
+  name: string;
+  version: string;
+}> => {
+  if (isSea()) {
+    const packageJsonBytes = getAssetAsBlob("package.json");
+    const json = JSON.parse(await packageJsonBytes.text());
+    const { name, version } = json;
+    return { name, version };
+  }
+
+  // Note that package.json is installed at <root>/package.json,
+  // whereas this gets compiled to <root>/build/dist/version.js
+  // in the build. We also need to adjust the path when running tests
+  const packageJsonPath = process.env.TS_JEST
+    ? `${__dirname}/../package.json`
+    : `${__dirname}/../../package.json`;
+  const { name, version } = JSON.parse(
+    (await fs.readFile(packageJsonPath)).toString("utf-8")
+  );
+
+  return { name, version };
+};
+
+export const P0_VERSION_INFO = loadCurrentVersion();

--- a/src/version.ts
+++ b/src/version.ts
@@ -41,4 +41,10 @@ const loadCurrentVersion = async (): Promise<{
   }
 };
 
+// p0VersionInfo is a promise that resolves to the current version info
+// The importer needs to await this promise to actually read the version number
+// e.g. `const { name, version } = await p0VersionInfo;`
+//
+// This allows us to memoize the version info and avoid reading the
+// package.json files multiple times
 export const p0VersionInfo = loadCurrentVersion();

--- a/src/version.ts
+++ b/src/version.ts
@@ -16,6 +16,8 @@ const loadCurrentVersion = async (): Promise<{
   version: string;
 }> => {
   if (isSea()) {
+    // When building with the standalone CLI, we need to manually include the package.json as a
+    // static asset in sea-config.json, as it is not included in the build by default.
     const packageJsonBytes = getAssetAsBlob("package.json");
     const json = JSON.parse(await packageJsonBytes.text());
     const { name, version } = json;


### PR DESCRIPTION
Running `p0 --version` using the standalone CLI prints "unknown". This is likely due to yargs' default --version parser not being able to locate package.json. That + a few other fixes.

- Makes it so the version in package.json is the source of truth (no need to change it in multiple places)
- Add a function that identifies the version in all environments
- Use this implementation everywhere we need the version number
- Fix a potential bug where the auto-update message may not display
- Improve docs and messaging indicating how to install / upgrade

Tested by building locally and seeing that the version prints itself and the CLI still runs