### PR TITLE
Do not freeze CLI when aws or aws role commands are used

### DIFF
--- a/src/commands/aws/index.ts
+++ b/src/commands/aws/index.ts
@@ -24,6 +24,9 @@ const awsArgs = async (yargs: yargs.Argv) => {
     const { config } = await getFirstAwsConfig(authn);
 
     const base = yargs
+      // This parent command hangs without a handler, if we require at
+      // least 1 arg we'll always correctly display a help message.
+      .demandCommand(1)
       .option("account", {
         type: "string",
         describe: "AWS account ID or alias (or set P0_AWS_ACCOUNT)",

--- a/src/commands/aws/role.ts
+++ b/src/commands/aws/role.ts
@@ -22,18 +22,23 @@ export const role = (
   authn: Authn
 ) =>
   yargs.command("role", "Interact with AWS roles", (yargs) =>
-    yargs.command(
-      "assume <role>",
-      "Assume an AWS role",
-      (y: yargs.Argv<{ account: string | undefined }>) =>
-        y.positional("role", {
-          type: "string",
-          demandOption: true,
-          describe: "An AWS role name",
-        }),
-      // TODO: select based on uidLocation
-      fsShutdownGuard((argv) => oktaAwsAssumeRole(argv, authn))
-    )
+    yargs
+      // this parent command hangs because it doesn't have a handler,
+      // while building we'll require an argument which ensures that we'll
+      // always correctly display a help message
+      .demandCommand(1)
+      .command(
+        "assume <role>",
+        "Assume an AWS role",
+        (y: yargs.Argv<{ account: string | undefined }>) =>
+          y.positional("role", {
+            type: "string",
+            demandOption: true,
+            describe: "An AWS role name",
+          }),
+        // TODO: select based on uidLocation
+        fsShutdownGuard((argv) => oktaAwsAssumeRole(argv, authn))
+      )
   );
 
 /** Assumes a role in AWS via Okta SAML federation.


### PR DESCRIPTION
This PR adds requirements to the amount of arguments that must be presented to `p0 aws` and `p0 aws role`. This ensures that the CLI won't hang if no arguments are provided to the commands.

![image](https://github.com/user-attachments/assets/2cdaf01b-b97c-4075-a18a-82dd041b1871)

![image](https://github.com/user-attachments/assets/8c6cdafc-1c0b-4672-92b4-6b3472e2b639)

![image](https://github.com/user-attachments/assets/ca4c7e6e-c589-49f4-b998-d30040aa9fc2)


