### PR TITLE
Audit log ssh session start and end

### DIFF
--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -98,7 +98,7 @@ const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
     throw "Could not determine host identifier from source or destination";
   }
 
-  const { request, docId, privateKey, sshProvider } = await prepareRequest(
+  const { request, requestId, privateKey, sshProvider } = await prepareRequest(
     authn,
     args,
     host
@@ -110,7 +110,7 @@ const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
   await sshOrScp({
     authn,
     request,
-    docId,
+    requestId,
     cmdArgs: {
       ...args,
       source,

--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -98,7 +98,7 @@ const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
     throw "Could not determine host identifier from source or destination";
   }
 
-  const { request, privateKey, sshProvider } = await prepareRequest(
+  const { request, docId, privateKey, sshProvider } = await prepareRequest(
     authn,
     args,
     host
@@ -110,6 +110,7 @@ const scpAction = async (args: yargs.ArgumentsCamelCase<ScpCommandArgs>) => {
   await sshOrScp({
     authn,
     request,
+    docId,
     cmdArgs: {
       ...args,
       source,

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -174,7 +174,7 @@ export const provisionRequest = async (
     id
   );
 
-  return { docId: id, provisionedRequest, publicKey, privateKey };
+  return { requestId: id, provisionedRequest, publicKey, privateKey };
 };
 
 export const prepareRequest = async (
@@ -195,14 +195,14 @@ export const prepareRequest = async (
     throw `Server did not return a request id. ${getContactMessage()}`;
   }
 
-  const { docId, publicKey, provisionedRequest } = result;
+  const { requestId, publicKey, provisionedRequest } = result;
 
   const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
 
   await sshProvider.submitPublicKey?.(
     authn,
     provisionedRequest,
-    docId,
+    requestId,
     publicKey
   );
 
@@ -213,5 +213,5 @@ export const prepareRequest = async (
   });
   const request = sshProvider.requestToSsh(cliRequest);
 
-  return { ...result, docId, request, sshProvider, provisionedRequest };
+  return { ...result, request, sshProvider, provisionedRequest };
 };

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -174,7 +174,7 @@ export const provisionRequest = async (
     id
   );
 
-  return { requestId: id, provisionedRequest, publicKey, privateKey };
+  return { docId: id, provisionedRequest, publicKey, privateKey };
 };
 
 export const prepareRequest = async (
@@ -195,14 +195,14 @@ export const prepareRequest = async (
     throw `Server did not return a request id. ${getContactMessage()}`;
   }
 
-  const { requestId, publicKey, provisionedRequest } = result;
+  const { docId, publicKey, provisionedRequest } = result;
 
   const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
 
   await sshProvider.submitPublicKey?.(
     authn,
     provisionedRequest,
-    requestId,
+    docId,
     publicKey
   );
 
@@ -213,5 +213,5 @@ export const prepareRequest = async (
   });
   const request = sshProvider.requestToSsh(cliRequest);
 
-  return { ...result, request, sshProvider, provisionedRequest };
+  return { ...result, docId, request, sshProvider, provisionedRequest };
 };

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -104,6 +104,7 @@ const sshProxyAction = async (
     authn,
     cmdArgs: args,
     request,
+    docId: request.docId,
     privateKey,
     debug: args.debug ?? false,
     sshProvider,

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -104,7 +104,7 @@ const sshProxyAction = async (
     authn,
     cmdArgs: args,
     request,
-    docId: request.docId,
+    requestId: request.requestId,
     privateKey,
     debug: args.debug ?? false,
     sshProvider,

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -106,7 +106,7 @@ const sshResolveAction = async (
     debug: args.debug,
   }).catch(silentlyExit);
 
-  const { request, provisionedRequest } = await prepareRequest(
+  const { request, docId, provisionedRequest } = await prepareRequest(
     authn,
     args,
     args.destination,
@@ -131,7 +131,10 @@ const sshResolveAction = async (
   if (args.debug) {
     print2("Writing request output to disk for use by ssh-proxy");
   }
-  fs.writeFileSync(tmpFile.name, JSON.stringify(request, null, 2));
+  fs.writeFileSync(
+    tmpFile.name,
+    JSON.stringify({ ...request, docId }, null, 2)
+  );
 
   const identityFile = keys?.privateKeyPath ?? PRIVATE_KEY_PATH;
   const certificateInfo = keys?.certificatePath

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -106,7 +106,7 @@ const sshResolveAction = async (
     debug: args.debug,
   }).catch(silentlyExit);
 
-  const { request, docId, provisionedRequest } = await prepareRequest(
+  const { request, requestId, provisionedRequest } = await prepareRequest(
     authn,
     args,
     args.destination,
@@ -133,7 +133,7 @@ const sshResolveAction = async (
   }
   fs.writeFileSync(
     tmpFile.name,
-    JSON.stringify({ ...request, docId }, null, 2)
+    JSON.stringify({ ...request, requestId }, null, 2)
   );
 
   const identityFile = keys?.privateKeyPath ?? PRIVATE_KEY_PATH;

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -97,7 +97,7 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
     throw "Azure SSH does not currently support specifying a port. SSH on the target VM must be listening on the default port 22.";
   }
 
-  const { request, privateKey, sshProvider } = await prepareRequest(
+  const { request, docId, privateKey, sshProvider } = await prepareRequest(
     authn,
     args,
     args.destination
@@ -106,6 +106,7 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
   await sshOrScp({
     authn,
     request,
+    docId,
     cmdArgs: args,
     privateKey,
     sshProvider,

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -97,7 +97,7 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
     throw "Azure SSH does not currently support specifying a port. SSH on the target VM must be listening on the default port 22.";
   }
 
-  const { request, docId, privateKey, sshProvider } = await prepareRequest(
+  const { request, requestId, privateKey, sshProvider } = await prepareRequest(
     authn,
     args,
     args.destination
@@ -106,7 +106,7 @@ const sshAction = async (args: yargs.ArgumentsCamelCase<SshCommandArgs>) => {
   await sshOrScp({
     authn,
     request,
-    docId,
+    requestId,
     cmdArgs: args,
     privateKey,
     sshProvider,

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -72,17 +72,17 @@ export const submitPublicKey = async <T>(
 
 export const auditSshSessionActivity = async (args: {
   authn: Authn;
-  docId: string;
-  sessionId: string;
-  action: `${"proxy" | "scp" | "ssh"}.session.${"end" | "start"}`;
+  requestId: string;
+  sshSessionId: string;
+  action: `ssh.session.${"end" | "start"}`;
   debug: boolean | undefined;
 }) => {
-  const { authn, docId, action, sessionId, debug } = args;
+  const { authn, requestId, action, sshSessionId, debug } = args;
 
   if (debug) {
-    print2(`Submitting audit log for request: ${docId}`);
-    print2(`Action: ${action}`);
-    print2(`Session ID: ${sessionId}`);
+    print2(
+      `Submitting audit log for request: ${requestId}, action: ${action}, sshSessionId: ${sshSessionId}`
+    );
   }
 
   try {
@@ -91,17 +91,17 @@ export const auditSshSessionActivity = async (args: {
       sshAuditUrl(authn.identity.org.slug),
       "POST",
       JSON.stringify({
-        docId,
+        requestId,
         action,
-        sessionId,
+        sshSessionId,
       })
     );
     if (debug) {
-      print2(`Audit log submitted for request: ${docId}`);
+      print2(`Audit log submitted for request: ${requestId}`);
     }
   } catch (error) {
     if (debug) {
-      print2(`Failed to submit audit log for request: ${docId}`);
+      print2(`Failed to submit audit log for request: ${requestId}`);
       print2(`Error: ${JSON.stringify(error)}`);
     }
   }

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -11,12 +11,15 @@ You should have received a copy of the GNU General Public License along with @p0
 import { Authn } from "../types/identity";
 import { p0VersionInfo } from "../version";
 import { getTenantConfig } from "./config";
+import { print2 } from "./stdio";
 import * as path from "node:path";
 import yargs from "yargs";
 
 const tenantUrl = (tenant: string) => `${getTenantConfig().appUrl}/o/${tenant}`;
 const publicKeysUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/public-keys`;
+const sshAuditUrl = (tenant: string) =>
+  `${tenantUrl(tenant)}/integrations/ssh/audit`;
 
 const commandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/`;
 const adminLsCommandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/ls`;
@@ -66,6 +69,43 @@ export const submitPublicKey = async <T>(
       publicKey: args.publicKey,
     })
   );
+
+export const auditSshSessionActivity = async (args: {
+  authn: Authn;
+  docId: string;
+  sessionId: string;
+  action: `${"proxy" | "scp" | "ssh"}.session.${"end" | "start"}`;
+  debug: boolean | undefined;
+}) => {
+  const { authn, docId, action, sessionId, debug } = args;
+
+  if (debug) {
+    print2(`Submitting audit log for request: ${docId}`);
+    print2(`Action: ${action}`);
+    print2(`Session ID: ${sessionId}`);
+  }
+
+  try {
+    await baseFetch(
+      authn,
+      sshAuditUrl(authn.identity.org.slug),
+      "POST",
+      JSON.stringify({
+        docId,
+        action,
+        sessionId,
+      })
+    );
+    if (debug) {
+      print2(`Audit log submitted for request: ${docId}`);
+    }
+  } catch (error) {
+    if (debug) {
+      print2(`Failed to submit audit log for request: ${docId}`);
+      print2(`Error: ${JSON.stringify(error)}`);
+    }
+  }
+};
 
 export const baseFetch = async <T>(
   authn: Authn,

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -428,13 +428,13 @@ const preTestAccessPropagationIfNeeded = async <
 export const sshOrScp = async (args: {
   authn: Authn;
   request: SshRequest;
-  docId: string;
+  requestId: string;
   cmdArgs: CommandArgs;
   privateKey: string;
   sshProvider: SshProvider<any, any, any, any>;
 }) => {
-  const sessionId = randomUUID();
-  const { authn, request, docId, cmdArgs, privateKey, sshProvider } = args;
+  const sshSessionId = randomUUID();
+  const { authn, request, requestId, cmdArgs, privateKey, sshProvider } = args;
   const { debug } = cmdArgs;
 
   if (!privateKey) {
@@ -494,10 +494,10 @@ export const sshOrScp = async (args: {
       audit: (action) =>
         void auditSshSessionActivity({
           authn,
-          docId,
-          sessionId,
+          requestId,
+          sshSessionId,
           debug,
-          action: `${command}.session.${action}`,
+          action: `ssh.session.${action}`,
         }),
       credential,
       abortController,
@@ -516,14 +516,14 @@ export const sshOrScp = async (args: {
 export const sshProxy = async (args: {
   authn: Authn;
   request: SshRequest;
-  docId: string;
+  requestId: string;
   cmdArgs: SshProxyCommandArgs;
   privateKey: string;
   sshProvider: SshProvider<any, any, any, any>;
   debug: boolean;
   port: string;
 }) => {
-  const { authn, sshProvider, request, docId, debug } = args;
+  const { authn, sshProvider, request, requestId, debug } = args;
 
   const credential: AwsCredentials | undefined =
     await sshProvider.cloudProviderLogin(authn, request);
@@ -551,9 +551,9 @@ export const sshProxy = async (args: {
 
   const auditArgs = {
     authn,
-    docId,
+    requestId,
     debug,
-    sessionId: randomUUID(),
+    sshSessionId: randomUUID(),
   };
 
   try {
@@ -562,7 +562,7 @@ export const sshProxy = async (args: {
     // to check for stdout/stderr for session start/end messages.
     void auditSshSessionActivity({
       ...auditArgs,
-      action: `proxy.session.start`,
+      action: `ssh.session.start`,
     });
     return await spawnSshNode({
       credential,
@@ -577,7 +577,7 @@ export const sshProxy = async (args: {
   } finally {
     await auditSshSessionActivity({
       ...auditArgs,
-      action: `proxy.session.end`,
+      action: `ssh.session.end`,
     });
     await setupData?.teardown();
   }


### PR DESCRIPTION
**Problem**

Splunk wants audit logs for when sessions start to help keep track of who is using the p0 CLI.

**Change**

Adds support audit logging session start and end for `p0 ssh`, `p0 scp`, and `p0 ssh-proxy` commands

**Validation**

In conjunction with Backend service PR https://github.com/p0-security/app/pull/4029 use the SSH/SCP/SSH-PROXY commands and check that audit logs generate correct information.

Sample commands:
```
# azure w/ scp
./p0 scp test.txt miguel-node-1:test.txt

# gcp w/ ssh and sudo
./p0 ssh private-node --provider gcloud --sudo

# aws w/ ssh-proxy
ssh netfoundry-edge-router 
```

**Tracking**

https://linear.app/p0-security/issue/ENG-3248/capture-every-session-start

**Attachments**

---

<img width="340" height="345" alt="image" src="https://github.com/user-attachments/assets/b8990956-652c-49f4-b85b-114b4c51ddf5" />
<img width="350" height="353" alt="image" src="https://github.com/user-attachments/assets/2abf0c2e-ae83-416a-94c6-b8fcb4f231b1" />

---

<img width="350" height="340" alt="image" src="https://github.com/user-attachments/assets/8216bf27-326c-46e2-85bf-d1620c8d7da7" />
<img width="335" height="348" alt="image" src="https://github.com/user-attachments/assets/f1d928b4-6d38-4491-8f37-023d34482128" />

---

<img width="348" height="347" alt="image" src="https://github.com/user-attachments/assets/2f262757-3213-493f-82e8-edd3bb885faf" />
<img width="343" height="344" alt="image" src="https://github.com/user-attachments/assets/d0dd2f97-f2b1-40b7-94f7-04b8d6c5ecac" />

