### PR TITLE
Do not exit parent process when terminating child process

### DIFF
--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -179,7 +179,8 @@ async function spawnSshNode(
         } catch {
           // Ignore errors
         }
-        process.exit();
+        // Resolving the promise so that we don't hang the process forever.
+        resolve(0);
       });
     });
 


### PR DESCRIPTION
This PR fixes an issue where a hard-exit prevents clean up processes from running. Instead we resolve the promise which allows the process to end gracefully. Using `pgrep -fl ssh` reveals that no zombie processes are left behind when sending kill signals like: `["exit", "SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"]`