### PR TITLE
Remove --recursive flag from scp command

### DIFF
--- a/src/commands/scp.ts
+++ b/src/commands/scp.ts
@@ -32,11 +32,6 @@ export const scpCommand = (yargs: yargs.Argv) =>
           demandOption: true,
           description: "Format [hostname:]file",
         })
-        .option("r", {
-          alias: "recursive",
-          type: "boolean",
-          describe: "Recursively copy entire directories",
-        })
         .option("reason", {
           describe: "Reason access is needed",
           type: "string",

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -43,7 +43,6 @@ export type BaseSshCommandArgs = {
 export type ScpCommandArgs = BaseSshCommandArgs & {
   source: string;
   destination: string;
-  recursive?: boolean;
 };
 
 export type SshCommandArgs = BaseSshCommandArgs & {

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -357,7 +357,7 @@ const addScpArgs = (args: ScpCommandArgs) => {
   }
 
   const recursiveOptionExists = sshOptions.some((opt) => opt === "-r");
-  if (!recursiveOptionExists && args.recursive) {
+  if (!recursiveOptionExists) {
     sshOptions.push("-r");
   }
 };


### PR DESCRIPTION
You can copy recursively using scp's native recursive (`-r` or `--recursive`) flag. P0's own flag is redundant and can be removed.

Here is a demonstration that the `-r` flag works when passed after `--`:

https://github.com/user-attachments/assets/4c90ab24-64ec-4b5a-bb37-856c8f8e79cb

