### PR TITLE
Show access request provisioning errors to user

### DIFF
--- a/src/commands/shared/index.ts
+++ b/src/commands/shared/index.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { getContactMessage } from "../../drivers/config";
 import { doc } from "../../drivers/firestore";
 import { Authn } from "../../types/identity";
 import {
@@ -42,9 +43,10 @@ export const waitForProvisioning = async <P extends PluginRequest>(
         } else if (DENIED_STATUSES.includes(data.status as any)) {
           reject("Your access request was denied");
         } else if (ERROR_STATUSES.includes(data.status as any)) {
-          reject(
-            "Your access request encountered an error (see Slack for details)"
-          );
+          const message =
+            data.error?.message ??
+            `Your access request encountered an unknown error. ${getContactMessage()}`;
+          reject(message);
         } else {
           return;
         }


### PR DESCRIPTION
The error message from access request provisioning was not shown to the user.

Verified new behavior manually by triggering an error:

Before
```
p0cli % ./p0 ssh nano-node-1
Access requested (see https://... for details)
Will wait up to 5 minutes for this request to complete...
Your request was approved
Waiting for access to be provisioned
Your access request encountered an error (see Slack for details)
```

After - error message
```
p0cli % ./p0 ssh nano-node-1   
Access requested (see https://... for details)
Will wait up to 5 minutes for this request to complete...
Your request was approved
Waiting for access to be provisioned
Error in service aws: User: arn:aws:sts::123456789012:assumed-role/P0RoleIamManager/aws-sdk-js-session-123456789012 is not authorized to perform: ssm:SendCommand on resource: arn:aws:ec2:us-west-1:123456789012:instance/i-021f03df9d24g7bc8 because no identity-based policy allows the ssm:SendCommand action (account=123456789012 region=us-west-1)
```

After - error message with internal error (this is automatically returned by P0 backend for internal errors, the CLI just displays it by reading the `error.message` field)
```
p0cli % ./p0 ssh nano-node-1
Access requested (see https://... for details)
Will wait up to 5 minutes for this request to complete...
Your request was approved
Waiting for access to be provisioned
P0 encountered an unknown error. Please contact support@p0.dev for assistance. (Error ID 26df821b-376d-49ae-a4c5-c62aad7e3b96)
```

After - fallback error message (should never be the case if the P0 backend correctly adds an error message to every errored request)
```
p0cli % ./p0 ssh nano-node-1
Access requested (see https://... for details)
Will wait up to 5 minutes for this request to complete...
Your request was approved
Waiting for access to be provisioned
Your access request encountered an unknown error. Please contact support@p0.dev for assistance.
```