### PR TITLE
Use forwardslash for action-gh-release on Windows

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -130,6 +130,6 @@ jobs:
       - name: Upload artifact to release
         uses: softprops/action-gh-release@v2
         with:
-          files: build\sea\p0-windows-${{ env.VERSION }}.msi
+          files: build/sea/p0-windows-${{ env.VERSION }}.msi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes a minor bug with the release action:

From https://github.com/softprops/action-gh-release:

> Note for Windows: Paths must use / as a separator, not \, as \ is used to escape characters with special meaning in the pattern; for example, instead of specifying D:\Foo.txt, you must specify D:/Foo.txt. If you're using PowerShell, you can do this with $Path = $Path -replace '\\','/'