### PR TITLE
Adjust warnings emitted by CLI

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -16,7 +16,6 @@ esbuild
     // SEA does not support an ESM entrypoint script, so we need to output CommonJS
     format: "cjs",
     outfile: "build/sea/p0.js",
-    legalComments: "none",
     footer: {
       js: `
 // This is a workaround to suppress deprecation warnings in the SEA binary

--- a/esbuild.js
+++ b/esbuild.js
@@ -16,6 +16,24 @@ esbuild
     // SEA does not support an ESM entrypoint script, so we need to output CommonJS
     format: "cjs",
     outfile: "build/sea/p0.js",
+    legalComments: "none",
+    footer: {
+      js: `
+// This is a workaround to suppress deprecation warnings in the SEA binary
+// without having to run NODE_OPTIONS='--no-deprecation' p0 [...args]
+// Without this, the SEA binary will emit deprecation warnings that may be
+// confusing to users
+(() => {
+  const originalEmit = process.emit;
+  process.emit = function (name, data, ...args) {
+    if (typeof data === 'object' && data.name === 'DeprecationWarning') {
+      return false;
+    }
+    return originalEmit.apply(process, arguments);
+  };
+})();
+      `,
+    },
   })
   .then(() => {
     console.log("Bundling succeeded.");

--- a/p0
+++ b/p0
@@ -1,16 +1,3 @@
 #!/usr/bin/env node --no-deprecation
 
-const originalEmit = process.emit;
-process.emit = function (name, data, ...args) {
-  if (
-    name === `warning` &&
-    typeof data === `object` &&
-    data.name === `ExperimentalWarning` &&
-    data.message.startsWith(`The Fetch API is an experimental feature.`)
-  ) {
-    return false;
-  }
-  return originalEmit.apply(process, arguments);
-};
-
 require(`${__dirname}/build/dist/index.js`).main();


### PR DESCRIPTION
When running the standalone CLI, I currently get a deprecation warning for 'punycode':

```
dhing@Mac p0cli % yarn build:macos && ./mac/build-macOS.sh 
yarn run v1.22.22
warning ../../package.json: No license field
$ tsc && cp -r public build/dist/ && node esbuild.js
Bundling succeeded.
✨  Done in 2.07s.
Wrote single executable preparation blob to ./build/sea/p0.blob
Start injection of NODE_SEA_BLOB in ./build/sea/p0...
💉 Injection done!
dhing@Mac p0cli % ./build/sea/p0 --version
(node:24002) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `p0 --trace-deprecation ...` to show where the warning was created)
0.18.8
```

I would like to silence these warnings so that end users don't see them, since they aren't actionable.

This only happens since #211 and only in the standalone CLI. This doesn't happen in the NPM package installable, even if you remove the `--no-deprecation` flags from the `p0` file shebang. My guess is that it has something to do with the esbuild step, possibly in the translation from ESM to CJS, but don't know for sure. My solution for silencing these warnings is to add a `footer` parameter, which adds custom code to the end of esbuild's output *.js file that manually silences deprecation warnings. There isn't really a way to set NodeJS flags such as `--no-deprecation` within code itself, so instead I am just intercepting the warning right before it appears in the user's terminal.

With this change:
```
dhing@Mac p0cli % yarn build:macos && ./mac/build-macOS.sh
yarn run v1.22.22
warning ../../package.json: No license field
$ tsc && cp -r public build/dist/ && node esbuild.js
Bundling succeeded.
✨  Done in 2.11s.
Wrote single executable preparation blob to ./build/sea/p0.blob
Start injection of NODE_SEA_BLOB in ./build/sea/p0...
💉 Injection done!
dhing@Mac p0cli % ./build/sea/p0 --version
0.18.8
```