### PR TITLE
ENG 5461: Add auth passthrough mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "build:windows": "tsc && xcopy public build\\dist\\ /E /I /Y && node esbuild.js",
     "test:unit": "NODE_ENV=unit jest --color",
     "clean": "rm -rf build",
+    "format": "yarn prettier --write .",
     "lint": "yarn prettier --check . &&  yarn run eslint --max-warnings 0 .",
     "p0": "node --no-deprecation ./p0",
     "prepublishOnly": "npm run clean && npm run build"

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -28,11 +28,11 @@ jest.mock("../../drivers/stdio");
 jest.mock("../../plugins/login");
 
 const mockIdentity: Identity = {
-// @ts-expect-error credential has more fields, this is enough for tests
+  // @ts-expect-error credential has more fields, this is enough for tests
   credential: {
     expires_at: Date.now() * 1e-3 + 60 * 1000,
   },
-// @ts-expect-error org has more fields, this is enough for tests
+  // @ts-expect-error org has more fields, this is enough for tests
   org: {
     tenantId: "test-tenant",
     slug: "test-org",

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -28,15 +28,18 @@ jest.mock("../../drivers/stdio");
 jest.mock("../../plugins/login");
 
 const mockIdentity: Identity = {
+// @ts-expect-error credential has more fields
   credential: {
     expires_at: Date.now() * 1e-3 + 60 * 1000,
   },
+// @ts-expect-error org has more fields
   org: {
     tenantId: "test-tenant",
     slug: "test-org",
     ssoProvider: "google",
   },
-} as Identity;
+  token: "test",
+};
 
 const mockSignInWithCredential = signInWithCredential as jest.Mock;
 const mockReadFile = readFile as jest.Mock;

--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -28,11 +28,11 @@ jest.mock("../../drivers/stdio");
 jest.mock("../../plugins/login");
 
 const mockIdentity: Identity = {
-// @ts-expect-error credential has more fields
+// @ts-expect-error credential has more fields, this is enough for tests
   credential: {
     expires_at: Date.now() * 1e-3 + 60 * 1000,
   },
-// @ts-expect-error org has more fields
+// @ts-expect-error org has more fields, this is enough for tests
   org: {
     tenantId: "test-tenant",
     slug: "test-org",

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -49,7 +49,7 @@ const formatTimeLeft = (seconds: number) => {
 };
 
 // TODO ENG-5627: Org discovery needs to be decoupled from Firestore
-const discoverOrg = async (orgSlug: string): Promise<OrgData> => {
+const fetchOrg = async (orgSlug: string): Promise<OrgData> => {
   const orgDoc = await getDoc<RawOrgData, object>(doc(`orgs/${orgSlug}`));
   const orgData = orgDoc.data();
 
@@ -108,15 +108,15 @@ export const login = async (
   }
 
   await initializeFirebase();
-  const org = await discoverOrg(orgSlug);
+  const orgData = await fetchOrg(orgSlug);
 
   if (!loggedIn) {
-    await doActualLogin(org);
+    await doActualLogin(orgData);
   }
 
   if (!options?.skipAuthenticate) {
     await authenticate({ debug: options?.debug });
-    await validateTenantAccess(org);
+    await validateTenantAccess(orgData);
   }
 
   if (!loggedIn) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -48,6 +48,15 @@ const formatTimeLeft = (seconds: number) => {
   return `${h}h${m}m${s}s`;
 };
 
+const discoverOrg = async (orgSlug: string): Promise<OrgData> => {
+  const orgDoc = await getDoc<RawOrgData, object>(doc(`orgs/${orgSlug}`));
+  const orgData = orgDoc.data();
+
+  if (!orgData) throw "Could not find organization";
+
+  return { ...orgData, slug: orgSlug };
+};
+
 /** Logs in the user.
  *
  * If the P0_ORG environment variable is set, it is used as the organization name,
@@ -59,24 +68,20 @@ export const login = async (
   args: { org?: string; refresh?: boolean },
   options?: { debug?: boolean; skipAuthenticate?: boolean }
 ) => {
-  let identity;
-  try {
-    identity = await loadCredentials();
-  } catch {
-    // Ignore error, as no credentials may yet be present
-  }
+  // Ignore error, as no credentials may yet be present
+  const identity = await loadCredentials().catch(() => undefined);
 
   const tokenTimeRemaining = identity ? remainingTokenTime(identity) : 0;
 
   let loggedIn = tokenTimeRemaining > MIN_REMAINING_TOKEN_TIME_SECONDS;
-  let org = args.org || process.env.P0_ORG;
+  let orgSlug = args.org || process.env.P0_ORG;
 
-  if (!org) {
+  if (!orgSlug) {
     if (identity && loggedIn) {
       // If no org is provided, and the user is logged in, use the one from the identity
-      org = identity.org.slug;
+      orgSlug = identity.org.slug;
 
-      print2(`You are currently logged in to the ${org} organization.`);
+      print2(`You are currently logged in to the ${orgSlug} organization.`);
       print2(
         `The current session expires in ${formatTimeLeft(tokenTimeRemaining)}.`
       );
@@ -85,11 +90,11 @@ export const login = async (
     }
   } else {
     if (identity && loggedIn) {
-      if (org !== identity.org.slug || args.refresh) {
+      if (orgSlug !== identity.org.slug || args.refresh) {
         // Force login if user is switching organizations or if --refresh argument is provided
         loggedIn = false;
       } else {
-        print2(`You are already logged in to the ${org} organization.`);
+        print2(`You are already logged in to the ${orgSlug} organization.`);
         print2(
           `The current session expires in ${formatTimeLeft(tokenTimeRemaining)}.`
         );
@@ -98,30 +103,24 @@ export const login = async (
   }
 
   if (!loggedIn) {
-    await saveConfig(org);
+    await saveConfig(orgSlug);
   }
 
   await initializeFirebase();
-
-  const orgDoc = await getDoc<RawOrgData, object>(doc(`orgs/${org}`));
-  const orgData = orgDoc.data();
-
-  if (!orgData) throw "Could not find organization";
-
-  const orgWithSlug: OrgData = { ...orgData, slug: org };
+  const org = await discoverOrg(orgSlug);
 
   if (!loggedIn) {
-    await doActualLogin(orgWithSlug);
+    await doActualLogin(org);
   }
 
   if (!options?.skipAuthenticate) {
     await authenticate({ debug: options?.debug });
-    await validateTenantAccess(orgData);
+    await validateTenantAccess(org);
   }
 
   if (!loggedIn) {
     print2(
-      `You are now logged in to the ${org} organization, and can use the p0 CLI.`
+      `You are now logged in to the ${orgSlug} organization, and can use the p0 CLI.`
     );
   }
 };

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -48,6 +48,7 @@ const formatTimeLeft = (seconds: number) => {
   return `${h}h${m}m${s}s`;
 };
 
+// TODO ENG-5627: Org discovery needs to be decoupled from Firestore
 const discoverOrg = async (orgSlug: string): Promise<OrgData> => {
   const orgDoc = await getDoc<RawOrgData, object>(doc(`orgs/${orgSlug}`));
   const orgData = orgDoc.data();

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -114,6 +114,7 @@ export const request =
   ): Promise<RequestResponse<T> | undefined> => {
     const resolvedAuthn = authn ?? (await authenticate());
     const { identity } = resolvedAuthn;
+    const { tenantId } = identity.org;
     const accessMessage = (message?: string) => {
       switch (message) {
         case "approval-required":
@@ -143,12 +144,8 @@ export const request =
           !data.isPersistent);
       if (logMessage) print2(data.message);
       const { id } = data;
-      if (args.wait && id && identity.org.tenantId) {
-        const code = await waitForRequest(
-          identity.org.tenantId,
-          id,
-          logMessage
-        );
+      if (args.wait && id && tenantId) {
+        const code = await waitForRequest(tenantId, id, logMessage);
         if (code) {
           sys.exit(code);
           return undefined;

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -113,7 +113,7 @@ export const request =
     }
   ): Promise<RequestResponse<T> | undefined> => {
     const resolvedAuthn = authn ?? (await authenticate());
-    const { userCredential } = resolvedAuthn;
+    const { identity } = resolvedAuthn;
     const accessMessage = (message?: string) => {
       switch (message) {
         case "approval-required":
@@ -143,9 +143,9 @@ export const request =
           !data.isPersistent);
       if (logMessage) print2(data.message);
       const { id } = data;
-      if (args.wait && id && userCredential.user.tenantId) {
+      if (args.wait && id && identity.org.tenantId) {
         const code = await waitForRequest(
-          userCredential.user.tenantId,
+          identity.org.tenantId,
           id,
           logMessage
         );

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -113,14 +113,13 @@ export const baseFetch = async <T>(
   method: string,
   body: string
 ) => {
-  const token = await authn.userCredential.user.getIdToken();
   const { version } = p0VersionInfo;
 
   try {
     const response = await fetch(url, {
       method,
       headers: {
-        authorization: `Bearer ${token}`,
+        authorization: `Bearer ${await authn.getToken()}`,
         "Content-Type": "application/json",
         "User-Agent": `P0 CLI/${version}`,
       },

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -114,12 +114,13 @@ export const baseFetch = async <T>(
   body: string
 ) => {
   const { version } = p0VersionInfo;
+  const token = await authn.getToken();
 
   try {
     const response = await fetch(url, {
       method,
       headers: {
-        authorization: `Bearer ${await authn.getToken()}`,
+        authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
         "User-Agent": `P0 CLI/${version}`,
       },

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -151,35 +151,35 @@ export const deleteIdentity = async () => {
 };
 
 /** Set up trace exporter to authenticated collector endpoint */
-const setOpentelemetryExporter = async (authn: Authn): Promise<Authn> => {
+const setOpentelemetryExporter = async (authn: Authn): Promise<void> => {
   const url = tracesUrl(authn.identity.org.slug);
   await setExporterAfterLogin(url, await authn.getToken());
-  return authn;
 };
 
 export const authenticate = async (options?: {
   noRefresh?: boolean;
   debug?: boolean;
 }): Promise<Authn> => {
-  const getAuthn = async () => {
-    const identity = await loadCredentialsWithAutoLogin(options);
-    if (identity.org.authPassthrough) {
-      return {
-        identity,
-        getToken: () => Promise.resolve(identity.credential.access_token),
-      };
-    }
+  const identity = await loadCredentialsWithAutoLogin(options);
+  let authn: Authn;
 
+  if (identity.org.useProviderToken) {
+    authn = {
+      identity,
+      getToken: () => Promise.resolve(identity.credential.access_token),
+    };
+  } else {
     // Note: if the `providerId` is "password", we already actually already
     // retrieved the UserCredential object in `loadCredentialsWithAutoLogin`.
     // This following call to `authenticateToFirebase` could be omitted.
     const userCredential = await authenticateToFirebase(identity, options);
-    return {
+    authn = {
       identity,
       userCredential,
       getToken: () => userCredential.user.getIdToken(),
     };
-  };
+  }
 
-  return await getAuthn().then(setOpentelemetryExporter);
+  await setOpentelemetryExporter(authn);
+  return authn;
 };

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -177,7 +177,7 @@ export const authenticate = async (options?: {
     return {
       identity,
       userCredential,
-      getToken: userCredential.user.getIdToken,
+      getToken: () => userCredential.user.getIdToken(),
     };
   };
 

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -18,9 +18,7 @@ import { authenticateToFirebase } from "../firestore";
 import { print2 } from "../stdio";
 import { EXPIRED_CREDENTIALS_MESSAGE } from "../util";
 import { getIdentityCachePath, getIdentityFilePath } from "./path";
-import { UserCredential } from "firebase/auth";
 import * as fs from "fs/promises";
-import { flow } from "lodash";
 import * as path from "path";
 
 const MIN_REMAINING_TOKEN_TIME_SECONDS = 60;
@@ -159,11 +157,11 @@ const setOpentelemetryExporter = async (authn: Authn): Promise<Authn> => {
   return authn;
 };
 
-export const authenticate = flow(
-  async (options?: {
-    noRefresh?: boolean;
-    debug?: boolean;
-  }): Promise<Authn> => {
+export const authenticate = async (options?: {
+  noRefresh?: boolean;
+  debug?: boolean;
+}): Promise<Authn> => {
+  const getAuthn = async () => {
     const identity = await loadCredentialsWithAutoLogin(options);
     if (identity.org.authPassthrough) {
       return {
@@ -181,6 +179,7 @@ export const authenticate = flow(
       userCredential,
       getToken: userCredential.user.getIdToken,
     };
-  },
-  setOpentelemetryExporter
-);
+  };
+
+  return await getAuthn().then(setOpentelemetryExporter);
+};

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -19,5 +19,6 @@ export type Identity = {
 
 export type Authn = {
   identity: Identity;
-  userCredential: UserCredential;
+  userCredential?: UserCredential;
+  getToken(): Promise<string>;
 };

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -46,7 +46,8 @@ type BaseOrgData = {
   usePassword?: boolean;
   tenantId: string;
   config: Config;
-  authPassthrough?: boolean;
+  /** Swaps API auth to tokens from the ssoProvider, rather than firebase */
+  useProviderToken?: boolean;
 };
 
 /** Publicly readable organization data */

--- a/src/types/org.ts
+++ b/src/types/org.ts
@@ -46,6 +46,7 @@ type BaseOrgData = {
   usePassword?: boolean;
   tenantId: string;
   config: Config;
+  authPassthrough?: boolean;
 };
 
 /** Publicly readable organization data */


### PR DESCRIPTION
Adds a method for passing through the provider access_token to the API calls made, skipping firebase auth.

**Note:** firebase is still initialized + used for org discovery.