### PR TITLE
ENG-5443 Add bootstrap org config

### DIFF
--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { fetchOrgData } from "../../drivers/api";
 import * as auth from "../../drivers/auth";
 import * as config from "../../drivers/config";
-import { bootstrapConfig } from "../../drivers/env";
+import { defaultConfig } from "../../drivers/env";
 import { print2 } from "../../drivers/stdio";
 import { pluginLoginMap } from "../../plugins/login";
 import { Identity } from "../../types/identity";
@@ -49,9 +49,9 @@ const mockFetchOrgData = fetchOrgData as jest.Mock;
 
 describe("login", () => {
   beforeEach(() => {
-    jest.spyOn(config, "loadConfig").mockResolvedValueOnce(bootstrapConfig);
+    jest.spyOn(config, "loadConfig").mockResolvedValueOnce(defaultConfig);
     jest.spyOn(config, "saveConfig").mockImplementation(jest.fn());
-    jest.spyOn(config, "getTenantConfig").mockReturnValue(bootstrapConfig);
+    jest.spyOn(config, "getTenantConfig").mockReturnValue(defaultConfig);
     // do NOT spyOn getContactMessage — you want the real one
   });
 
@@ -111,7 +111,7 @@ describe("login", () => {
     beforeEach(() => {
       credentialData = "";
       jest.clearAllMocks();
-      jest.spyOn(config, "loadConfig").mockResolvedValueOnce(bootstrapConfig);
+      jest.spyOn(config, "loadConfig").mockResolvedValueOnce(defaultConfig);
       mockReadFile.mockImplementation(async () =>
         Buffer.from(credentialData, "utf-8")
       );

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { Authn } from "../types/identity";
 import { p0VersionInfo } from "../version";
 import { getTenantConfig } from "./config";
-import { bootstrapConfig } from "./env";
+import { defaultConfig } from "./env";
 import { print2 } from "./stdio";
 import * as path from "node:path";
 import yargs from "yargs";
@@ -19,7 +19,7 @@ import yargs from "yargs";
 const DEFAULT_PERMISSION_REQUEST_TIMEOUT = 300e3; // 5 minutes
 
 const tenantOrgUrl = (tenant: string) =>
-  `${getTenantConfig()?.appUrl ?? bootstrapConfig.appUrl}/orgs/${tenant}`;
+  `${getTenantConfig()?.appUrl ?? defaultConfig.appUrl}/orgs/${tenant}`;
 const tenantUrl = (tenant: string) => `${getTenantConfig().appUrl}/o/${tenant}`;
 const publicKeysUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/public-keys`;
@@ -155,6 +155,7 @@ export const fetchWithStreaming = async function* <T>(
       }
       const value = read.value;
       const text = textDecoder.decode(value);
+      print2(text);
       const parsedResponse = JSON.parse(text);
       if (parsedResponse.type === "error") {
         throw new Error(parsedResponse.error);

--- a/src/drivers/auth/path.ts
+++ b/src/drivers/auth/path.ts
@@ -11,6 +11,9 @@ You should have received a copy of the GNU General Public License along with @p0
 import { P0_PATH } from "../../util";
 import * as path from "path";
 
+const BASE_DIR = path.resolve(P0_PATH);
+const ORG_ID_FORMAT = /^[A-Za-z0-9_-]{1,32}$/;
+
 export const getIdentityFilePath = () =>
   process.env.P0_ORG
     ? path.join(P0_PATH, `identity-${process.env.P0_ORG}.json`)
@@ -26,5 +29,17 @@ export const getConfigFilePath = () =>
     ? path.join(P0_PATH, `config.json-${process.env.P0_ORG}`)
     : path.join(P0_PATH, "config.json");
 
-export const getBootstrapOrgDataPath = (orgId: string) =>
-  path.join(P0_PATH, `bootstrap-${orgId}.json`);
+export const getBootstrapOrgDataPath = (orgId: string): string => {
+  if (!ORG_ID_FORMAT.test(orgId)) {
+    throw new Error("Invalid organization");
+  }
+
+  const filename = `bootstrap-${orgId}.json`;
+  const resolvedFilename = path.resolve(BASE_DIR, filename);
+
+  if (!resolvedFilename.startsWith(BASE_DIR)) {
+    throw new Error("Invalid organization");
+  }
+
+  return resolvedFilename;
+};

--- a/src/drivers/auth/path.ts
+++ b/src/drivers/auth/path.ts
@@ -25,3 +25,6 @@ export const getConfigFilePath = () =>
   process.env.P0_ORG
     ? path.join(P0_PATH, `config.json-${process.env.P0_ORG}`)
     : path.join(P0_PATH, "config.json");
+
+export const getBootstrapOrgDataPath = (orgId: string) =>
+  path.join(P0_PATH, `bootstrap-${orgId}.json`);

--- a/src/drivers/auth/path.ts
+++ b/src/drivers/auth/path.ts
@@ -33,6 +33,7 @@ export const getBootstrapOrgDataPath = (orgId: string): string => {
   }
 
   const filename = `bootstrap-${safeOrgId}.json`;
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
   const resolvedFilename = path.resolve(P0_PATH, filename);
 
   if (!resolvedFilename.startsWith(P0_PATH)) {

--- a/src/drivers/auth/path.ts
+++ b/src/drivers/auth/path.ts
@@ -11,9 +11,6 @@ You should have received a copy of the GNU General Public License along with @p0
 import { P0_PATH } from "../../util";
 import * as path from "path";
 
-const BASE_DIR = path.resolve(P0_PATH);
-const ORG_ID_FORMAT = /^[A-Za-z0-9_-]{1,32}$/;
-
 export const getIdentityFilePath = () =>
   process.env.P0_ORG
     ? path.join(P0_PATH, `identity-${process.env.P0_ORG}.json`)
@@ -30,14 +27,15 @@ export const getConfigFilePath = () =>
     : path.join(P0_PATH, "config.json");
 
 export const getBootstrapOrgDataPath = (orgId: string): string => {
-  if (!ORG_ID_FORMAT.test(orgId)) {
+  const safeOrgId = path.basename(orgId);
+  if (safeOrgId !== orgId) {
     throw new Error("Invalid organization");
   }
 
-  const filename = `bootstrap-${orgId}.json`;
-  const resolvedFilename = path.resolve(BASE_DIR, filename);
+  const filename = `bootstrap-${safeOrgId}.json`;
+  const resolvedFilename = path.resolve(P0_PATH, filename);
 
-  if (!resolvedFilename.startsWith(BASE_DIR)) {
+  if (!resolvedFilename.startsWith(P0_PATH)) {
     throw new Error("Invalid organization");
   }
 

--- a/src/drivers/config.ts
+++ b/src/drivers/config.ts
@@ -10,7 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { Config } from "../types/org";
 import { getConfigFilePath } from "./auth/path";
-import { bootstrapConfig } from "./env";
+import { defaultConfig } from "./env";
 import { getOrgData } from "./org";
 import { print2 } from "./stdio";
 import fs from "fs/promises";
@@ -21,10 +21,10 @@ let tenantConfig: Config;
 export const getTenantConfig = () => tenantConfig;
 
 export const getContactMessage = () =>
-  tenantConfig?.contactMessage ?? bootstrapConfig.contactMessage;
+  tenantConfig?.contactMessage ?? defaultConfig.contactMessage;
 
 export const getHelpMessage = () =>
-  tenantConfig?.helpMessage ?? bootstrapConfig.helpMessage;
+  tenantConfig?.helpMessage ?? defaultConfig.helpMessage;
 
 /** Use only if the organization is configured with Google login to P0 */
 export const getGoogleTenantConfig = () => {
@@ -37,7 +37,7 @@ export const getGoogleTenantConfig = () => {
 export const saveConfig = async (orgId: string) => {
   const orgData = await getOrgData(orgId);
 
-  const config = orgData.config ?? bootstrapConfig;
+  const config = orgData.config ?? defaultConfig;
 
   const configFilePath = getConfigFilePath();
 

--- a/src/drivers/env.ts
+++ b/src/drivers/env.ts
@@ -15,7 +15,7 @@ dotenv.config();
 
 const { env } = process;
 
-export const bootstrapConfig: GoogleApplicationConfig = {
+export const defaultConfig: GoogleApplicationConfig = {
   fs: {
     // Falls back to public production Firestore credentials
     apiKey: env.P0_FS_API_KEY ?? "AIzaSyCaL-Ik_l_5tdmgNUNZ4Nv6NuR4o5_PPfs",

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { bootstrapConfig } from "./drivers/env";
+import { defaultConfig } from "./drivers/env";
 import child_process from "node:child_process";
 import os from "node:os";
 import path from "node:path";
@@ -19,9 +19,9 @@ export const getAppPath = () => env.P0_APP_PATH ?? "p0";
 
 export const P0_PATH = path.join(
   os.homedir(),
-  bootstrapConfig.environment === "production"
+  defaultConfig.environment === "production"
     ? ".p0"
-    : `.p0-${bootstrapConfig.environment}`
+    : `.p0-${defaultConfig.environment}`
 );
 
 /** Waits the specified delay (in ms)


### PR DESCRIPTION
Adds the ability to configure the P0 CLI using an optional `bootstrap-<org id>.json` file that gets placed in the `~\.p0` directory. This alleviates the need to connect to P0 servers to load the org config.