### PR TITLE
Fix intermittent failures using p0 ssh

### DIFF
--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -156,9 +156,6 @@ export const request =
         if (!chunkData) {
           throw new Error("Errored waiting for request to complete");
         }
-        if ("skip" in chunkData) {
-          continue;
-        }
         const code = resolveCode(
           chunkData.request as PermissionRequest<PluginRequest>,
           shouldLogMessage

--- a/src/drivers/__tests__/api.test.ts
+++ b/src/drivers/__tests__/api.test.ts
@@ -317,7 +317,7 @@ describe("fetchWithStreaming", () => {
       results.push(chunk);
     }
 
-    expect(results.length).toBeGreaterThanOrEqual(0);
+    expect(results.length).toEqual(0);
   });
 
   it("should handle empty chunks", async () => {


### PR DESCRIPTION
**Problem**

P0 cli faces intermittent issues because of streaming response having jsonl format. The client tries to parse jsonl and fails. i.e, if the server responds with more than one json separated by new lines in a single chunk.

**Change**

Update client streaming method to parse response as jsonl.

**Implementation**
1. instead of processing response as a single object, break on new line and parse them as individual strings.
2. Reuse jsonlToArray implementation.

