### PR TITLE
Fix gcloud resolution on Windows

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -131,3 +131,17 @@ export const ciEquals = (a: string, b: string) =>
 
 export const delay = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+type OperatingSystem = "linux" | "mac" | "unknown" | "win";
+export const getOperatingSystem = (): OperatingSystem => {
+  const platform = process.platform;
+  if (platform === "win32") {
+    return "win";
+  } else if (platform === "darwin") {
+    return "mac";
+  } else if (platform === "linux") {
+    return "linux";
+  } else {
+    return "unknown";
+  }
+};


### PR DESCRIPTION
Fixes gcloud SSH on Windows machines. The problem is that on Windows, when installing the Google Cloud tools, the main `gcloud` file is a `.cmd` (shell script) file rather than a `.exe` (binary executable) file, so when calling `spawn`, it cannot be located.

That is because the underlying Windows OS API that `spawn` uses doesn't resolve `.CMD` files by default (MacOS does not have this problem because MacOS will automatically resolve "gcloud" to the correct executable).

Fix is when on a Windows machine to instead call `cmd.exe` with `gcloud.cmd` and the remaining parameters as args, which will resolve the correct file.

Validated that `gcloud` could be correctly resolved on:
- [x] Parallels desktop pro for MacOS
- [x] Azure VM (Windows 11 23h2 client)
- [x] Azure VM (Windows 11 24h2 client)