### PR TITLE
ENG-5485 Update description of SSH args to explicitly specify options

### DIFF
--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -63,7 +63,7 @@ export const sshCommand = (yargs: yargs.Argv) =>
         })
         .epilogue(
           `[-- SSH_ARGS ...]
-  Flags and positionals passed to the underlying ssh implementation.
+  Options passed to the underlying ssh implementation.
   The '--' argument must be specified between P0-specific args on the left and SSH_ARGS on the right. Example;
 
   $ p0 ssh example-instance --provider gcloud -- -NR '*:8080:localhost:8088' -o 'GatewayPorts yes'`


### PR DESCRIPTION
Current text:
"Flags and positionals passed to the underlying ssh implementation."

New text:
"Options passed to the underlying ssh implementation."

We don't currently support specifying positionals after `--`. Updated the description accordingly.

Specifically, the command to be executed is already an argument to `p0 ssh` and must be specified before the `--`.