### PR TITLE
Fix stream api handling of errors without type and new line

### DIFF
--- a/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
+++ b/src/commands/__tests__/__snapshots__/ssh.test.ts.snap
@@ -16,6 +16,7 @@ exports[`ssh ephemeral access should call p0 request with reason arg: args 1`] =
     "--reason",
     "reason",
   ],
+  "debug": undefined,
   "wait": true,
 }
 `;
@@ -70,6 +71,7 @@ exports[`ssh persistent access should call p0 request with reason arg: args 1`] 
     "--reason",
     "reason",
   ],
+  "debug": undefined,
   "wait": true,
 }
 `;

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -54,6 +54,7 @@ export const requestArgs = <T>(yargs: yargs.Argv<T>) =>
       default: false,
       describe: "Block until the command is completed",
     })
+    .option("debug", { type: "boolean", describe: "Print debug information." })
     .option("arguments", {
       array: true,
       string: true,
@@ -84,6 +85,7 @@ export const request =
     args: yargs.ArgumentsCamelCase<{
       arguments: string[];
       wait?: boolean;
+      debug?: boolean;
     }>,
     authn?: Authn,
     options?: {
@@ -136,7 +138,7 @@ export const request =
     const executeStreamingRequest = async () => {
       const fetchStreamingCommandGenerator = fetchStreamingCommand<
         RequestResponse<T>
-      >(resolvedAuthn, args, [command, ...args.arguments]);
+      >(resolvedAuthn, args, [command, ...args.arguments], args.debug);
       const getNextPermissionRequestChunk = async () => {
         const generatedValue = await fetchStreamingCommandGenerator.next();
         if (generatedValue.done) {

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -137,7 +137,6 @@ export const provisionRequest = async (
   await validateSshInstall(authn, args);
 
   const { publicKey, privateKey } = await createKeyPair();
-
   const response = await request("request")<
     PermissionRequest<PluginSshRequest>
   >(
@@ -156,6 +155,7 @@ export const provisionRequest = async (
         ...(args.parent ? ["--parent", args.parent] : []),
       ],
       wait: true,
+      debug: args.debug,
     },
     authn,
     { message: quiet ? "quiet" : "approval-required" }

--- a/src/drivers/__tests__/api.test.ts
+++ b/src/drivers/__tests__/api.test.ts
@@ -345,6 +345,25 @@ describe("fetchWithStreaming", () => {
     expect(results).toEqual([{ id: "1" }, { id: "2" }]);
   });
 
+  it("should throw errors if there is leftover error chunk without new-line and a type", async () => {
+    const chunks = ['{"error":"Something went wrong"}'];
+
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(createMockStreamingResponse(chunks) as any);
+
+    const generator = fetchWithStreaming(mockAuthn, {
+      url: "/stream",
+      method: "GET",
+    });
+
+    await expect(async () => {
+      for await (const _chunk of generator) {
+        // Should throw before yielding
+      }
+    }).rejects.toBe("Something went wrong");
+  });
+
   it("should throw network error for terminated", async () => {
     jest.spyOn(global, "fetch").mockRejectedValue(new TypeError("terminated"));
 

--- a/src/drivers/__tests__/api.test.ts
+++ b/src/drivers/__tests__/api.test.ts
@@ -298,9 +298,9 @@ describe("fetchWithStreaming", () => {
     expect(results).toEqual([{ id: "test" }]);
   });
 
-  it("should handle chunks with no newlines", async () => {
+  it("should handle chunks with no invalid json and no new lines", async () => {
     const chunks = [
-      '{"type":"data","data":{"id":"1"}}{"type":"data","data":{"id":"2"}}', // No newlines
+      '{"type":"data","data":{"id":"1"}', // No newlines
     ];
 
     jest
@@ -312,12 +312,11 @@ describe("fetchWithStreaming", () => {
       method: "GET",
     });
 
-    const results = [];
-    for await (const chunk of generator) {
-      results.push(chunk);
-    }
-
-    expect(results.length).toEqual(0);
+    await expect(async () => {
+      for await (const _chunk of generator) {
+        // Should throw before yielding
+      }
+    }).rejects.toBe("Invalid response from the server");
   });
 
   it("should handle empty chunks", async () => {


### PR DESCRIPTION
Problem:

We do not handle stream api errors which fail during permission request creation. This is apparent when we try to ssh into a non-existent node.
1. the errors thrown by errorBoundary and unhandled error objects from the backend do not have "type" defined like streaming responses.
2. these errors are not new line delimited.

Change:
1. introduce way to debug these requests.
2. try parsing the leftover buffer and validate compelete-ness.
3. if the json is error, surface the error to the user.

Tracking:
ENG-5801

Commands:
the node should not exist
./p0 ssh dummy-node-123
./p0 ssh dummy-node-123 --debug

Attachements:

Before:

<img width="938" height="43" alt="image" src="https://github.com/user-attachments/assets/7296c8cf-4435-40d6-b36c-3d2c67acd748" />


After:

<img width="1506" height="301" alt="Screenshot 2025-08-15 at 11 50 09 AM" src="https://github.com/user-attachments/assets/7e45eec2-cea9-4fea-a982-9dbdbecc1586" />



<img width="1498" height="150" alt="Screenshot 2025-08-15 at 11 50 28 AM" src="https://github.com/user-attachments/assets/16be064b-3712-4a78-9303-cae67aed0b2a" />
