### PR TITLE
Bump CLI version to 0.18.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {


### PR DESCRIPTION
Includes the following changes:

dhing@Mac p0cli % git log --oneline
e341989 (HEAD -> dominickhing/bump-version-to-v0.18.10, origin/dominickhing/bump-version-to-v0.18.10) Bump CLI version to 0.18.10
84458c4 (origin/main, origin/HEAD, main) self-hosted ssh (#235)
06f7a6c Fix stream api handling of errors without type and new line (#237)
03bd84d ENG-5485 Update description of SSH args to explicitly specify options (#236)
4292b78 Fix gcloud resolution on Windows (#233)
3ce1dfa Fix intermittent failures using p0 ssh (#232)
238f49a Remove print2() statement (#231)
0accbd6 ENG-5443 Add bootstrap org config (#230)
746bfdc ENG-5460 remove firestore dependency from CLI (#224)
16febd0 add logout command (#227)
8d6fab4 add support for azure-oidc pkce login (#226)
82e2ec2 ENG 5461: Add auth passthrough mechanism (#225)

