### PR TITLE
Switch to certificates for self-hosted SSH access

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -73,10 +73,10 @@ export type SshAdditionalSetup = {
   sshOptions: string[];
 
   /** The path to the private key file to use for the SSH connection, instead of the default P0 CLI managed key */
-  identityFile: string;
+  identityFile?: string;
 
   /** The port to connect to, overriding the default */
-  port: string;
+  port?: string;
 
   /** Perform any teardown required after the SSH command exits but before terminating the P0 CLI */
   teardown: () => Promise<void>;

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -119,8 +119,10 @@ const sshResolveAction = async (
     print2("Generating Keys");
   }
   const keys = await sshProvider?.generateKeys?.(
+    authn,
     provisionedRequest.permission.resource,
     {
+      requestId,
       debug: args.debug,
     }
   );

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -13,7 +13,6 @@ import { p0VersionInfo } from "../version";
 import { getTenantConfig } from "./config";
 import { defaultConfig } from "./env";
 import { print2 } from "./stdio";
-import { pick } from "lodash";
 import * as path from "node:path";
 import yargs from "yargs";
 
@@ -124,15 +123,17 @@ export const submitPublicKey = async <T>(
     }),
   });
 
-const CSR_KEYS = ["requestId", "publicKey"] as const;
 export const certificateSigningRequest = async (
   authn: Authn,
-  args: Record<(typeof CSR_KEYS)[number], string>
+  args: { publicKey: string; requestId: string }
 ) =>
   baseFetch<{ signedCertificate: string }>(authn, {
     url: certSignRequestUrl(authn.identity.org.slug),
     method: "POST",
-    body: JSON.stringify(pick(args, CSR_KEYS)),
+    body: JSON.stringify({
+      requestId: args.requestId,
+      publicKey: args.publicKey,
+    }),
   });
 
 export const fetchWithStreaming = async function* <T>(

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -23,6 +23,8 @@ const tenantOrgUrl = (tenant: string) =>
 const tenantUrl = (tenant: string) => `${getTenantConfig().appUrl}/o/${tenant}`;
 const publicKeysUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/public-keys`;
+const certSignRequestUrl = (tenant: string) =>
+  `${tenantUrl(tenant)}/integrations/ssh/certificates`;
 const sshAuditUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/audit`;
 
@@ -114,6 +116,19 @@ export const submitPublicKey = async <T>(
 ) =>
   authFetch<T>(authn, {
     url: publicKeysUrl(authn.identity.org.slug),
+    method: "POST",
+    body: JSON.stringify({
+      requestId: args.requestId,
+      publicKey: args.publicKey,
+    }),
+  });
+
+export const certificateSigningRequest = async (
+  authn: Authn,
+  args: { publicKey: string; requestId: string }
+) =>
+  baseFetch<{ signedCertificate: string }>(authn, {
+    url: certSignRequestUrl(authn.identity.org.slug),
     method: "POST",
     body: JSON.stringify({
       requestId: args.requestId,

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -127,7 +127,7 @@ export const certificateSigningRequest = async (
   authn: Authn,
   args: { publicKey: string; requestId: string }
 ) =>
-  baseFetch<{ signedCertificate: string }>(authn, {
+  authFetch<{ signedCertificate: string }>(authn, {
     url: certSignRequestUrl(authn.identity.org.slug),
     method: "POST",
     body: JSON.stringify({

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -13,6 +13,7 @@ import { p0VersionInfo } from "../version";
 import { getTenantConfig } from "./config";
 import { defaultConfig } from "./env";
 import { print2 } from "./stdio";
+import { pick } from "lodash";
 import * as path from "node:path";
 import yargs from "yargs";
 
@@ -123,17 +124,15 @@ export const submitPublicKey = async <T>(
     }),
   });
 
+const CSR_KEYS = ["requestId", "publicKey"] as const;
 export const certificateSigningRequest = async (
   authn: Authn,
-  args: { publicKey: string; requestId: string }
+  args: Record<(typeof CSR_KEYS)[number], string>
 ) =>
   baseFetch<{ signedCertificate: string }>(authn, {
     url: certSignRequestUrl(authn.identity.org.slug),
     method: "POST",
-    body: JSON.stringify({
-      requestId: args.requestId,
-      publicKey: args.publicKey,
-    }),
+    body: JSON.stringify(pick(args, CSR_KEYS)),
   });
 
 export const fetchWithStreaming = async function* <T>(

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -122,7 +122,7 @@ export const awsSshProvider: SshProvider<
     return undefined;
   },
 
-  generateKeys: async (_) => {
+  generateKeys: async () => {
     return {
       privateKeyPath: PRIVATE_KEY_PATH,
     };

--- a/src/plugins/azure/keygen.ts
+++ b/src/plugins/azure/keygen.ts
@@ -11,7 +11,6 @@ You should have received a copy of the GNU General Public License along with @p0
 import { print2 } from "../../drivers/stdio";
 import { exec } from "../../util";
 import path from "node:path";
-import tmp from "tmp-promise";
 
 // We pass in the name of the certificate file to generate
 export const AD_CERT_FILENAME = "p0cli-azure-ad-ssh-cert.pub";
@@ -23,21 +22,6 @@ export const azSshCertCommand = (keyPath: string) => ({
   command: "az",
   args: ["ssh", "cert", "--file", path.join(keyPath, AD_CERT_FILENAME)],
 });
-
-export const createTempDirectoryForKeys = async (): Promise<{
-  path: string;
-  cleanup: () => Promise<void>;
-}> => {
-  // unsafeCleanup lets us delete the directory even if there are still files in it, which is fine since the
-  // files are no longer needed once we've authenticated to the remote system.
-  const { path, cleanup } = await tmp.dir({
-    mode: 0o700,
-    prefix: "p0cli-",
-    unsafeCleanup: true,
-  });
-
-  return { path, cleanup };
-};
 
 export const generateSshKeyAndAzureAdCert = async (
   keyPath: string,

--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { isSudoCommand } from "../../commands/shared/ssh";
 import { SshProvider } from "../../types/ssh";
+import { createTempDirectoryForKeys } from "../ssh/shared";
 import {
   azAccountSetCommand,
   azSetSubscription,
@@ -21,7 +22,6 @@ import {
   AD_CERT_FILENAME,
   AD_SSH_KEY_PRIVATE,
   azSshCertCommand,
-  createTempDirectoryForKeys,
   generateSshKeyAndAzureAdCert,
 } from "./keygen";
 import { azBastionTunnelCommand, trySpawnBastionTunnel } from "./tunnel";
@@ -107,7 +107,7 @@ export const azureSshProvider: SshProvider<
       // elsewhere. It'll be an annoying long temporary directory name, but it strictly will work for reproduction. If
       // additionalData isn't present (which it always should be for the azureSshProvider), we'll use the user's home
       // directory.
-      if (additionalData) {
+      if (additionalData?.identityFile) {
         return path.dirname(additionalData.identityFile);
       } else {
         const basePath = process.env.HOME || process.env.USERPROFILE || "";
@@ -137,7 +137,7 @@ export const azureSshProvider: SshProvider<
     ];
   },
 
-  generateKeys: async (request, options: { debug?: boolean } = {}) => {
+  generateKeys: async (_authn, request, options: { debug?: boolean } = {}) => {
     const { debug } = options;
     const { path: keyPath } = await createTempDirectoryForKeys();
     await azSetSubscription(request, options);
@@ -166,7 +166,7 @@ export const azureSshProvider: SshProvider<
     };
   },
 
-  setup: async (request, options) => {
+  setup: async (_authn, request, options) => {
     // The subscription ID here is used to ensure that the user is logged in to the correct tenant/directory.
     // As long as a subscription ID in the correct tenant is provided, this will work; it need not be the same
     // subscription as which contains the Bastion host or the target VM.

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -87,7 +87,7 @@ export const gcpSshProvider: SshProvider<
     return undefined;
   },
 
-  generateKeys: async (request, _) => {
+  generateKeys: async (_authn, request) => {
     return {
       username: request.linuxUserName,
       privateKeyPath: PRIVATE_KEY_PATH,

--- a/src/plugins/self-hosted/keygen.ts
+++ b/src/plugins/self-hosted/keygen.ts
@@ -1,0 +1,40 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { certificateSigningRequest } from "../../drivers/api";
+import { print2 } from "../../drivers/stdio";
+import { Authn } from "../../types/identity";
+
+export const generateSelfHostedCertificate = async (
+  authn: Authn,
+  {
+    requestId,
+    publicKey,
+    debug,
+  }: {
+    publicKey: string;
+    requestId: string;
+    debug?: boolean;
+  }
+) => {
+  if (debug) {
+    print2(`Generating self-hosted SSH certificate for request ${requestId}`);
+  }
+  const { signedCertificate } = await certificateSigningRequest(authn, {
+    publicKey,
+    requestId,
+  });
+
+  if (debug) {
+    print2(`Generated self-hosted SSH certificate for request ${requestId}`);
+  }
+
+  return signedCertificate;
+};

--- a/src/plugins/self-hosted/ssh.ts
+++ b/src/plugins/self-hosted/ssh.ts
@@ -62,15 +62,14 @@ export const selfHostedSshProvider: SshProvider<
     const { publicKey } = await createKeyPair();
 
     const signedCertificate = await generateSelfHostedCertificate(authn, {
-      requestId: options.requestId,
-      debug: options.debug,
+      ...options,
       publicKey,
     });
 
-    const sshCertificateKeyPath = path.join(keyPath, SELF_HOSTED_CERT_FILENAME);
-    await fs.writeFile(sshCertificateKeyPath, signedCertificate);
+    const certificatePath = path.join(keyPath, SELF_HOSTED_CERT_FILENAME);
+    await fs.writeFile(certificatePath, signedCertificate);
     return {
-      certificatePath: sshCertificateKeyPath,
+      certificatePath,
     };
   },
 
@@ -87,13 +86,9 @@ export const selfHostedSshProvider: SshProvider<
     const sshCertificateKeyPath = path.join(keyPath, SELF_HOSTED_CERT_FILENAME);
     await fs.writeFile(sshCertificateKeyPath, signedCertificate);
 
-    const teardown = async () => {
-      await sshKeyPathCleanup();
-    };
-
     return {
       sshOptions: [`CertificateFile=${sshCertificateKeyPath}`],
-      teardown,
+      teardown: sshKeyPathCleanup,
     };
   },
 

--- a/src/plugins/self-hosted/ssh.ts
+++ b/src/plugins/self-hosted/ssh.ts
@@ -9,10 +9,16 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { isSudoCommand } from "../../commands/shared/ssh";
-import { PRIVATE_KEY_PATH } from "../../common/keys";
-import { submitPublicKey } from "../../drivers/api";
+import { createKeyPair } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
+import { createTempDirectoryForKeys } from "../ssh/shared";
+import { generateSelfHostedCertificate } from "./keygen";
 import { SelfHostedSshPermissionSpec, SelfHostedSshRequest } from "./types";
+import * as fs from "fs/promises";
+import path from "node:path";
+
+// We pass in the name of the certificate file to generate
+export const SELF_HOSTED_CERT_FILENAME = "p0cli-self-hosted-ssh-cert.pub";
 
 const PROPAGATION_TIMEOUT_LIMIT_MS = 2 * 60 * 1000;
 
@@ -51,9 +57,43 @@ export const selfHostedSshProvider: SshProvider<
     return undefined;
   },
 
-  generateKeys: async (_) => {
+  generateKeys: async (authn, _request, options) => {
+    const { path: keyPath } = await createTempDirectoryForKeys();
+    const { publicKey } = await createKeyPair();
+
+    const signedCertificate = await generateSelfHostedCertificate(authn, {
+      requestId: options.requestId,
+      debug: options.debug,
+      publicKey,
+    });
+
+    const sshCertificateKeyPath = path.join(keyPath, SELF_HOSTED_CERT_FILENAME);
+    await fs.writeFile(sshCertificateKeyPath, signedCertificate);
     return {
-      privateKeyPath: PRIVATE_KEY_PATH,
+      certificatePath: sshCertificateKeyPath,
+    };
+  },
+
+  setup: async (authn, _request, options) => {
+    const { path: keyPath, cleanup: sshKeyPathCleanup } =
+      await createTempDirectoryForKeys();
+    const { publicKey } = await createKeyPair();
+
+    const signedCertificate = await generateSelfHostedCertificate(authn, {
+      debug: options.debug,
+      requestId: options.requestId,
+      publicKey,
+    });
+    const sshCertificateKeyPath = path.join(keyPath, SELF_HOSTED_CERT_FILENAME);
+    await fs.writeFile(sshCertificateKeyPath, signedCertificate);
+
+    const teardown = async () => {
+      await sshKeyPathCleanup();
+    };
+
+    return {
+      sshOptions: [`CertificateFile=${sshCertificateKeyPath}`],
+      teardown,
     };
   },
 
@@ -74,14 +114,4 @@ export const selfHostedSshProvider: SshProvider<
   unprovisionedAccessPatterns,
 
   toCliRequest: async (request) => ({ ...request, cliLocalData: undefined }),
-
-  async submitPublicKey(authn, request, requestId, publicKey) {
-    if (request.generated.publicKey) {
-      if (request.generated.publicKey !== publicKey) {
-        throw "Public key mismatch. Please revoke the request and try again.";
-      }
-    } else {
-      await submitPublicKey(authn, { publicKey, requestId });
-    }
-  },
 };

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -447,7 +447,8 @@ export const sshOrScp = async (args: {
   const credential: AwsCredentials | undefined =
     await sshProvider.cloudProviderLogin(authn, request);
 
-  const setupData = await sshProvider.setup?.(request, {
+  const setupData = await sshProvider.setup?.(authn, request, {
+    requestId,
     abortController,
     debug,
   });

--- a/src/plugins/ssh/shared.ts
+++ b/src/plugins/ssh/shared.ts
@@ -1,0 +1,26 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import tmp from "tmp-promise";
+
+export const createTempDirectoryForKeys = async (): Promise<{
+  path: string;
+  cleanup: () => Promise<void>;
+}> => {
+  // unsafeCleanup lets us delete the directory even if there are still files in it, which is fine since the
+  // files are no longer needed once we've authenticated to the remote system.
+  const { path, cleanup } = await tmp.dir({
+    mode: 0o700,
+    prefix: "p0cli-",
+    unsafeCleanup: true,
+  });
+
+  return { path, cleanup };
+};

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -100,8 +100,13 @@ export type SshProvider<
   /** Perform any setup required before running the SSH command. Returns a list of additional arguments to pass to the
    * SSH command. */
   setup?: (
+    authn: Authn,
     request: SR,
-    options: { abortController: AbortController; debug?: boolean }
+    options: {
+      requestId: string;
+      abortController: AbortController;
+      debug?: boolean;
+    }
   ) => Promise<SshAdditionalSetup>;
 
   setupProxy?: (
@@ -120,10 +125,11 @@ export type SshProvider<
   ) => Promise<void>;
 
   generateKeys?: (
+    authn: Authn,
     request: SR,
-    options?: { debug?: boolean }
+    options: { requestId: string; debug?: boolean }
   ) => Promise<{
-    privateKeyPath: string;
+    privateKeyPath?: string;
     certificatePath?: string;
   }>;
 


### PR DESCRIPTION
**Problem**

Public keys are not as secure as certificates for SSH access.

**Change**

Implements automatic registration and short-lived certificate access.

**Validation**

1. Registration Process & changing a node's name.
<img width="630" height="284" alt="image" src="https://github.com/user-attachments/assets/327511cd-c103-448d-9296-dd4db5c7bc5b" />

<img width="566" height="336" alt="image" src="https://github.com/user-attachments/assets/b438d8e1-49aa-4bc3-b115-21ff39ec97c7" />

<img width="571" height="449" alt="image" src="https://github.com/user-attachments/assets/04b9a35f-bd2b-44f0-87a0-9883ae15b131" />


2. Making an access request.
<img width="740" height="233" alt="image" src="https://github.com/user-attachments/assets/9536658c-ecb6-4ba9-83ff-caf14f002d1a" />

3. Connecting with tailscale on NixOS
<img width="401" height="234" alt="image" src="https://github.com/user-attachments/assets/eceb6256-e79d-4903-b13a-0db1ec5c2f97" />


**Tracking**

https://linear.app/p0-security/issue/ENG-5826/switch-to-short-lived-certificates-for-access

**Implementation**

1. We switched to automatic registration so that user's don't need to manually configure the node anymore, they just pass in the api key (which will switch to auth token)

2. We're saving the CA public key in the user's authorized_keys file, this makes it so that machines don't implicitly trust any signed certificate but allows us to selectively determine which machines a user has access to without being in-band using the `AuthorizedPrincipalsCommand`. 

3. One other advantage of this approach is that rotating CA's is much easier since with every access request we'll only insert the most up to date certificate when access is provisioned. There is one edge case where this might not be true is if the CA rotates while a user has access, they will need to re-request but this can be solved later. 

4. If you are developing using ngrok you will need to modify your tunnelHost in your config in order to connect to your braekhus proxy.

**Future Work**
https://linear.app/p0-security/issue/ENG-5895/add-support-for-automatic-ca-rotation
https://linear.app/p0-security/issue/ENG-5896/restrict-certificates-to-a-single-target-machine
https://linear.app/p0-security/issue/ENG-5897/add-a-watch-dog-service-to-terminate-potentially-expired-access
https://linear.app/p0-security/issue/ENG-5898/add-a-ephemeral-user-toggle-to-self-hosted-environment-config
https://linear.app/p0-security/issue/ENG-5899/execute-a-force-command-on-ssh-login-that-places-users-in-a-nix-shell
