### PR TITLE
Add FIPS-compliant Node.js build for macOS SEA artifacts

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -40,6 +40,60 @@ jobs:
           security import codesign_certificate.p12 -k build.keychain -P "${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
           security import installer_certificate.p12 -k build.keychain -P "${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}" -T /usr/bin/pkgbuild
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+      - name: Cache FIPS-compliant Node.js
+        id: cache-fips-node
+        uses: actions/cache@v4
+        with:
+          path: ~/fips-node
+          key: fips-node-${{ hashFiles('.nvmrc') }}-${{ runner.os }}-openssl3.0.9-v1
+      - name: Build FIPS-compliant Node.js
+        if: steps.cache-fips-node.outputs.cache-hit != 'true'
+        run: |
+          # Install build dependencies
+          brew install python@3.11
+          export PATH="/opt/homebrew/bin:$PATH"
+          
+          # Create build directory
+          mkdir -p ~/fips-node-build
+          cd ~/fips-node-build
+          
+          # Build OpenSSL 3.0.9 with FIPS support
+          curl -L https://www.openssl.org/source/openssl-3.0.9.tar.gz | tar -xz
+          cd openssl-3.0.9
+          ./Configure darwin64-arm64-cc --prefix=$HOME/fips-node/openssl enable-fips
+          make -j$(sysctl -n hw.ncpu)
+          make install
+          cd ..
+          
+          # Get Node.js version from .nvmrc
+          NODE_VERSION=$(cat $GITHUB_WORKSPACE/.nvmrc | tr -d 'v')
+          
+          # Download and extract Node.js source
+          curl -L https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.gz | tar -xz
+          cd node-v${NODE_VERSION}
+          
+          # Configure Node.js with FIPS support using our custom OpenSSL 3.0.9
+          ./configure \
+            --shared-openssl \
+            --shared-openssl-libpath=$HOME/fips-node/openssl/lib64 \
+            --shared-openssl-includes=$HOME/fips-node/openssl/include \
+            --shared-openssl-libname=crypto,ssl \
+            --openssl-is-fips \
+            --prefix=$HOME/fips-node
+          
+          # Build Node.js (this takes a while)
+          make -j$(sysctl -n hw.ncpu)
+          make install
+      - name: Setup FIPS Node.js in PATH
+        run: |
+          echo "$HOME/fips-node/bin" >> $GITHUB_PATH
+      - name: Verify FIPS Node.js
+        run: |
+          # Verify the custom Node.js build
+          $HOME/fips-node/bin/node --version
+          
+          # Test FIPS capability
+          $HOME/fips-node/bin/node -e "console.log('FIPS available:', process.versions.openssl, require('crypto').getFips ? require('crypto').getFips() : 'N/A')"
       - name: Yarn install
         run: yarn install
       - name: Build

--- a/mac/build-macOS.sh
+++ b/mac/build-macOS.sh
@@ -1,5 +1,5 @@
 # See https://nodejs.org/docs/latest-v20.x/api/single-executable-applications.html for more information.
-node --experimental-sea-config sea-config.json 
+node --enable-fips --experimental-sea-config sea-config.json 
 cp $(node -p process.execPath) ./build/sea/p0
 codesign --remove-signature ./build/sea/p0
 npx postject ./build/sea/p0 NODE_SEA_BLOB ./build/sea/p0.blob \


### PR DESCRIPTION
Implement FIPS compliance for macOS Single Executable Application builds by:
- Building custom Node.js with OpenSSL 3.0.9 and FIPS support enabled
- Using --enable-fips flag during SEA blob generation
- Adding GitHub Actions caching for efficient FIPS Node.js build reuse
- Ensuring all cryptographic operations use FIPS-validated modules

🤖 Generated with [Claude Code](https://claude.ai/code)