### PR TITLE
handle both '--size n' and '--size=n' args

### DIFF
--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -63,13 +63,29 @@ export const lsCommand = (yargs: yargs.Argv) =>
  */
 const convertLsSizeArg = (args: string[]) => {
   const convertedArgs = [...args];
+
   const sizeIndex = convertedArgs.findIndex((a) => a === "--size");
-  const requestedSize = +(
-    (sizeIndex >= 0
-      ? pullAt(convertedArgs, sizeIndex, sizeIndex + 1)[1]
-      : undefined) ?? DEFAULT_RESPONSE_SIZE
+  const sizeEqualIndex = convertedArgs.findIndex((a) =>
+    a.startsWith("--size=")
   );
+
+  let requestedSize: number;
+
+  if (sizeIndex >= 0) {
+    // Handle --size n format
+    const sizeValue = pullAt(convertedArgs, sizeIndex, sizeIndex + 1)[1];
+    requestedSize = +(sizeValue ?? DEFAULT_RESPONSE_SIZE);
+  } else if (sizeEqualIndex >= 0) {
+    // Handle --size=n format
+    const sizeArg = pullAt(convertedArgs, sizeEqualIndex)[0];
+    const sizeValue = sizeArg?.split("=")[1];
+    requestedSize = +(sizeValue ?? DEFAULT_RESPONSE_SIZE);
+  } else {
+    requestedSize = DEFAULT_RESPONSE_SIZE;
+  }
+
   convertedArgs.push("--size", String(requestedSize * 2));
+
   return { convertedArgs, requestedSize };
 };
 


### PR DESCRIPTION
This PR fixes a bug which prevents the `--size=n` argument from working correctly. Right now this command makes LS fail:
<img width="1110" height="66" alt="image" src="https://github.com/user-attachments/assets/308e2b1e-759e-4d58-8561-4e11839191cb" />

After this update both `--size n` and `--size=n` works.
<img width="1110" height="66" alt="image" src="https://github.com/user-attachments/assets/9245660c-980e-4ec3-8c54-6260859f834d" />
<img width="1110" height="66" alt="image" src="https://github.com/user-attachments/assets/fb8e400b-eefb-4d3b-acfc-997d5c9f7855" />
<img width="1110" height="66" alt="image" src="https://github.com/user-attachments/assets/bd6242f7-c4c7-49d7-b79f-3e33dc18c4f7" />
