### PR TITLE
Retrieve server host keys for AWS SSH

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -222,7 +222,7 @@ export const prepareRequest = async (
 
   const request = sshProvider.requestToSsh(cliRequest);
 
-  await sshProvider.saveHostKeys?.(request, options);
+  const hostKeysPath = await sshProvider.saveHostKeys?.(request, options);
 
-  return { ...result, request, sshProvider, provisionedRequest };
+  return { ...result, request, sshProvider, provisionedRequest, hostKeysPath };
 };

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -222,7 +222,7 @@ export const prepareRequest = async (
 
   const request = sshProvider.requestToSsh(cliRequest);
 
-  const hostKeysPath = await sshProvider.saveHostKeys?.(request, options);
+  const hostKeys = await sshProvider.saveHostKeys?.(request, options);
 
-  return { ...result, request, sshProvider, provisionedRequest, hostKeysPath };
+  return { ...result, request, sshProvider, provisionedRequest, hostKeys };
 };

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -217,10 +217,12 @@ export const prepareRequest = async (
 
   await sshProvider.ensureInstall();
 
-  const cliRequest = await pluginToCliRequest(provisionedRequest, {
-    debug: args.debug,
-  });
+  const options = { debug: args.debug };
+  const cliRequest = await pluginToCliRequest(provisionedRequest, options);
+
   const request = sshProvider.requestToSsh(cliRequest);
+
+  await sshProvider.saveHostKeys?.(request, options);
 
   return { ...result, request, sshProvider, provisionedRequest };
 };

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -105,13 +105,10 @@ const sshResolveAction = async (
     debug: args.debug,
   }).catch(silentlyExit);
 
-  const { request, requestId, provisionedRequest } = await prepareRequest(
-    authn,
-    args,
-    args.destination,
-    true,
-    args.quiet
-  ).catch(requestErrorHandler);
+  const { request, requestId, provisionedRequest, hostKeysPath } =
+    await prepareRequest(authn, args, args.destination, true, args.quiet).catch(
+      requestErrorHandler
+    );
 
   const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
 
@@ -141,6 +138,7 @@ const sshResolveAction = async (
   const certificateInfo = keys?.certificatePath
     ? `CertificateFile ${keys.certificatePath}`
     : "";
+  const hostKeysInfo = hostKeysPath ? `UserKnownHostsFile ${hostKeysPath}` : "";
 
   const appPath = getAppPath();
 
@@ -159,7 +157,9 @@ const sshResolveAction = async (
   IdentityFile ${identityFile}
   ${certificateInfo}
   PasswordAuthentication no
-  ProxyCommand ${appPath} ssh-proxy %h --port %p --provider ${provisionedRequest.permission.provider} --identity-file ${identityFile} --request-json ${tmpFile.name} ${args.debug ? "--debug" : ""}`;
+  ProxyCommand ${appPath} ssh-proxy %h --port %p --provider ${provisionedRequest.permission.provider} --identity-file ${identityFile} --request-json ${tmpFile.name} ${args.debug ? "--debug" : ""}
+  ${hostKeysInfo}
+`;
 
   await fs.promises.mkdir(path.join(P0_PATH, "ssh", "configs"), {
     recursive: true,

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -105,7 +105,7 @@ const sshResolveAction = async (
     debug: args.debug,
   }).catch(silentlyExit);
 
-  const { request, requestId, provisionedRequest, hostKeysPath } =
+  const { request, requestId, provisionedRequest, hostKeys } =
     await prepareRequest(authn, args, args.destination, true, args.quiet).catch(
       requestErrorHandler
     );
@@ -138,7 +138,9 @@ const sshResolveAction = async (
   const certificateInfo = keys?.certificatePath
     ? `CertificateFile ${keys.certificatePath}`
     : "";
-  const hostKeysInfo = hostKeysPath ? `UserKnownHostsFile ${hostKeysPath}` : "";
+  const hostKeysInfo = hostKeys
+    ? `UserKnownHostsFile ${hostKeys.path}\nHostKeyAlias ${hostKeys.alias}`
+    : "";
 
   const appPath = getAppPath();
 

--- a/src/common/__mocks__/keys.ts
+++ b/src/common/__mocks__/keys.ts
@@ -13,3 +13,5 @@ export const createKeyPair = jest.fn().mockImplementation(() => ({
   publicKey: "test-public-key",
   privateKey: "test-private-key",
 }));
+export const saveHostKeys = jest.fn().mockResolvedValue(undefined);
+export const getKnownHostsFilePath = jest.fn().mockReturnValue("/mock/path/to/known_hosts/instance");

--- a/src/common/__mocks__/keys.ts
+++ b/src/common/__mocks__/keys.ts
@@ -14,4 +14,6 @@ export const createKeyPair = jest.fn().mockImplementation(() => ({
   privateKey: "test-private-key",
 }));
 export const saveHostKeys = jest.fn().mockResolvedValue(undefined);
-export const getKnownHostsFilePath = jest.fn().mockReturnValue("/mock/path/to/known_hosts/instance");
+export const getKnownHostsFilePath = jest
+  .fn()
+  .mockReturnValue("/mock/path/to/known_hosts/instance");

--- a/src/common/keys.ts
+++ b/src/common/keys.ts
@@ -115,7 +115,7 @@ export const saveHostKeys = async (
 ): Promise<string | undefined> => {
   if (!hostKeys || hostKeys.length === 0) {
     if (options?.debug) {
-      print2("No host keys provided, skipping");
+      print2("No host keys provided, skipping saving of host keys");
     }
     return;
   }
@@ -129,32 +129,24 @@ export const saveHostKeys = async (
 
   const hostFilePath = getKnownHostsFilePath(instanceId);
 
-  if (hostKeys.length > 0) {
-    // Check if file already exists
-    if (await fileExists(hostFilePath)) {
-      if (options?.debug) {
-        print2(
-          `Host keys file for instance ${instanceId} already exists, skipping`
-        );
-      }
-      return hostFilePath;
-    }
-
-    const content = hostKeys.join("\n") + "\n";
-    await fs.writeFile(hostFilePath, content, { mode: 0o600 });
-
+  // Always overwrite the file with the latest host keys
+  if (await fileExists(hostFilePath)) {
     if (options?.debug) {
       print2(
-        `Saved ${hostKeys.length} host keys for instance ${instanceId} to ${hostFilePath}`
+        `Host keys file for instance ${instanceId} already exists, overwriting`
       );
     }
-    return hostFilePath;
-  } else {
-    if (options?.debug) {
-      print2("No valid host keys to save");
-    }
-    return;
   }
+
+  const content = hostKeys.join("\n") + "\n";
+  await fs.writeFile(hostFilePath, content, { mode: 0o600 });
+
+  if (options?.debug) {
+    print2(
+      `Saved ${hostKeys.length} host keys for instance ${instanceId} to ${hostFilePath}`
+    );
+  }
+  return hostFilePath;
 };
 
 /**

--- a/src/common/keys.ts
+++ b/src/common/keys.ts
@@ -112,7 +112,7 @@ export const saveHostKeys = async (
   instanceId: string,
   hostKeys: string[],
   options?: { debug?: boolean }
-): Promise<void> => {
+): Promise<string | undefined> => {
   if (!hostKeys || hostKeys.length === 0) {
     if (options?.debug) {
       print2("No host keys provided, skipping");
@@ -137,7 +137,7 @@ export const saveHostKeys = async (
           `Host keys file for instance ${instanceId} already exists, skipping`
         );
       }
-      return;
+      return hostFilePath;
     }
 
     const content = hostKeys.join("\n") + "\n";
@@ -148,10 +148,12 @@ export const saveHostKeys = async (
         `Saved ${hostKeys.length} host keys for instance ${instanceId} to ${hostFilePath}`
       );
     }
+    return hostFilePath;
   } else {
     if (options?.debug) {
       print2("No valid host keys to save");
     }
+    return;
   }
 };
 

--- a/src/common/keys.ts
+++ b/src/common/keys.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { print2 } from "../drivers/stdio";
 import { P0_PATH } from "../util";
 import * as crypto from "crypto";
 import * as fs from "fs/promises";
@@ -96,4 +97,66 @@ const toOpenSshFormat = (keyObject: crypto.KeyObject): string => {
   // Base64 encode and format as OpenSSH key
   const base64Key = sshWireFormat.toString("base64");
   return `${keyType} ${base64Key} p0-generated-key`;
+};
+
+export const KNOWN_HOSTS_DIR = path.join(P0_KEY_FOLDER, "known_hosts");
+export const KNOWN_HOSTS_PATH = path.join(P0_KEY_FOLDER, "known_hosts_config");
+
+/**
+ * Save host keys to separate files in the P0 SSH known_hosts directory
+ * - Creates a separate file for each host in known_hosts/ directory
+ * - Replaces the entire file with the most up-to-date host keys for that host
+ * - Creates an SSH config file that includes all host key files
+ */
+export const saveHostKeys = async (
+  instanceId: string,
+  hostKeys: string[],
+  options?: { debug?: boolean }
+): Promise<void> => {
+  if (!hostKeys || hostKeys.length === 0) {
+    if (options?.debug) {
+      print2("No host keys provided, skipping");
+    }
+    return;
+  }
+
+  if (options?.debug) {
+    print2(`Processing ${hostKeys.length} host keys`);
+    print2(`Known hosts directory: ${KNOWN_HOSTS_DIR}`);
+  }
+
+  await fs.mkdir(KNOWN_HOSTS_DIR, { recursive: true });
+
+  const hostFilePath = getKnownHostsFilePath(instanceId);
+
+  if (hostKeys.length > 0) {
+    // Check if file already exists
+    if (await fileExists(hostFilePath)) {
+      if (options?.debug) {
+        print2(`Host keys file for instance ${instanceId} already exists, skipping`);
+      }
+      return;
+    }
+    
+    const content = hostKeys.join("\n") + "\n";
+    await fs.writeFile(hostFilePath, content, { mode: 0o600 });
+
+    if (options?.debug) {
+      print2(
+        `Saved ${hostKeys.length} host keys for instance ${instanceId} to ${hostFilePath}`
+      );
+    }
+  } else {
+    if (options?.debug) {
+      print2("No valid host keys to save");
+    }
+  }
+};
+
+/**
+ * Get the known_hosts file path for a specific instance ID
+ */
+export const getKnownHostsFilePath = (instanceId: string): string => {
+  const sanitizedId = instanceId.replace(/[^a-zA-Z0-9.-]/g, "_");
+  return path.join(KNOWN_HOSTS_DIR, sanitizedId);
 };

--- a/src/common/keys.ts
+++ b/src/common/keys.ts
@@ -133,11 +133,13 @@ export const saveHostKeys = async (
     // Check if file already exists
     if (await fileExists(hostFilePath)) {
       if (options?.debug) {
-        print2(`Host keys file for instance ${instanceId} already exists, skipping`);
+        print2(
+          `Host keys file for instance ${instanceId} already exists, skipping`
+        );
       }
       return;
     }
-    
+
     const content = hostKeys.join("\n") + "\n";
     await fs.writeFile(hostFilePath, content, { mode: 0o600 });
 

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { PRIVATE_KEY_PATH } from "../../common/keys";
+import { PRIVATE_KEY_PATH, saveHostKeys } from "../../common/keys";
 import { submitPublicKey } from "../../drivers/api";
 import { SshProvider } from "../../types/ssh";
 import { throwAssertNever } from "../../util";
@@ -128,13 +128,24 @@ export const awsSshProvider: SshProvider<
     };
   },
 
+  saveHostKeys: async (request, options) => {
+    const { hostKeys, id } = request;
+    await saveHostKeys(id, hostKeys, { ...options });
+  },
+
   requestToSsh: (request) => {
     const { permission, generated } = request;
     const { resource, region } = permission;
     const { idcId, idcRegion, instanceId, accountId } = resource;
-    const { linuxUserName, resource: generatedResource } = generated;
+    const { linuxUserName, hostKeys, resource: generatedResource } = generated;
     const { name } = generatedResource;
-    const common = { linuxUserName, accountId, region, id: instanceId };
+    const common = {
+      linuxUserName,
+      accountId,
+      region,
+      id: instanceId,
+      hostKeys,
+    };
     return !idcId || !idcRegion
       ? { ...common, role: name, type: "aws", access: "role" }
       : {

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -130,7 +130,8 @@ export const awsSshProvider: SshProvider<
 
   saveHostKeys: async (request, options) => {
     const { hostKeys, id } = request;
-    return await saveHostKeys(id, hostKeys, { ...options });
+    const path = await saveHostKeys(id, hostKeys, { ...options });
+    return path ? { alias: id, path } : undefined;
   },
 
   requestToSsh: (request) => {

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -130,7 +130,7 @@ export const awsSshProvider: SshProvider<
 
   saveHostKeys: async (request, options) => {
     const { hostKeys, id } = request;
-    await saveHostKeys(id, hostKeys, { ...options });
+    return await saveHostKeys(id, hostKeys, { ...options });
   },
 
   requestToSsh: (request) => {

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -83,6 +83,7 @@ export type AwsSshPermission = CommonSshPermissionSpec & {
 
 export type AwsSshGenerated = {
   resource: { name: string };
+  hostKeys: string[];
   linuxUserName: string;
   publicKey: string;
 };
@@ -98,6 +99,7 @@ export type AwsSsh = CliPermissionSpec<AwsSshPermissionSpec, undefined>;
 export type BaseAwsSshRequest = {
   linuxUserName: string;
   accountId: string;
+  hostKeys: string[];
   region: string;
   id: string;
   type: "aws";

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -249,12 +249,12 @@ async function spawnSshNode(
 }
 
 const createCommand = (
-  data: SshRequest,
+  request: SshRequest,
   args: CommandArgs,
   setupData: SshAdditionalSetup | undefined,
   proxyCommand: string[]
 ) => {
-  addCommonArgs(args, proxyCommand, setupData, data);
+  addCommonArgs(args, proxyCommand, setupData, request);
 
   const sshOptionsOverrides = setupData?.sshOptions ?? [];
   const port = setupData?.port;
@@ -282,7 +282,7 @@ const createCommand = (
       ...(args.sshOptions ? args.sshOptions : []),
       ...argsOverride,
       ...(port ? ["-p", port] : []),
-      `${data.linuxUserName}@${data.id}`,
+      `${request.linuxUserName}@${request.id}`,
       ...(args.command ? [args.command] : []),
       ...args.arguments.map(
         (argument) =>

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -120,7 +120,7 @@ export type SshProvider<
   saveHostKeys?: (
     request: SR,
     options?: { debug?: boolean }
-  ) => Promise<string | undefined>;
+  ) => Promise<{ alias: string; path: string } | undefined>;
 
   submitPublicKey?: (
     authn: Authn,

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -117,7 +117,10 @@ export type SshProvider<
     port: string;
   }>;
 
-  saveHostKeys?: (request: SR, options?: { debug?: boolean }) => Promise<void>;
+  saveHostKeys?: (
+    request: SR,
+    options?: { debug?: boolean }
+  ) => Promise<string | undefined>;
 
   submitPublicKey?: (
     authn: Authn,

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -117,6 +117,8 @@ export type SshProvider<
     port: string;
   }>;
 
+  saveHostKeys?: (request: SR, options?: { debug?: boolean }) => Promise<void>;
+
   submitPublicKey?: (
     authn: Authn,
     request: PR,


### PR DESCRIPTION
**Problem**

User's have to do host key validation even though they have instances managed by P0.

**Change**

This PR adds a new SSM document that we can run on target machines to retrieve dynamic registration information such as a server's host keys.

**Validation**

Tested in conjunction with the P0 APP PR: https://github.com/p0-security/app/pull/4314

Remove all my known host keys from my known host key file. Ensure that the prompt doesn't appear.

<img width="476" height="77" alt="image" src="https://github.com/user-attachments/assets/729ff8aa-247e-4fce-aa83-5ccb9d53960f" />

<img width="484" height="218" alt="image" src="https://github.com/user-attachments/assets/dfffca57-47cf-4f83-8335-00675be191d1" />

**Tracking**

https://linear.app/p0-security/issue/ENG-5884/validate-ssh-fingerprint-on-aws-machines

**Implementation**

I was thinking about accessing the host keys on the fly and doing it lazily, but in scenarios where customers are requesting access to 100's of nodes this creates a significant bottle neck in SSM.
