### PR TITLE
Read config from firestore directly

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -10,8 +10,8 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { decodeProvisionStatus } from ".";
 import { createKeyPair } from "../../common/keys";
-import { fetchIntegrationConfig } from "../../drivers/api";
 import { getContactMessage } from "../../drivers/config";
+import { doc } from "../../drivers/firestore";
 import { print2 } from "../../drivers/stdio";
 import { awsSshProvider } from "../../plugins/aws/ssh";
 import { azureSshProvider } from "../../plugins/azure/ssh";
@@ -28,6 +28,7 @@ import {
   SupportedSshProviders,
 } from "../../types/ssh";
 import { request } from "./request";
+import { getDoc } from "firebase/firestore";
 import { pick } from "lodash";
 import { sys } from "typescript";
 import yargs from "yargs";
@@ -96,11 +97,11 @@ const validateSshInstall = async (
   authn: Authn,
   args: yargs.ArgumentsCamelCase<BaseSshCommandArgs>
 ) => {
-  const configDoc = await fetchIntegrationConfig<{ config: SshConfig }>(
-    authn,
-    "ssh"
+  const configDoc = await getDoc<SshConfig, object>(
+    doc(`o/${authn.identity.org.tenantId}/integrations/ssh`)
   );
-  const configItems = configDoc?.config["iam-write"];
+
+  const configItems = configDoc.data()?.["iam-write"];
 
   const providersToCheck = args.provider
     ? [args.provider]

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -24,12 +24,24 @@ import {
   signInWithCredential,
   UserCredential,
 } from "firebase/auth";
+import {
+  DocumentReference,
+  Firestore,
+  doc as fsDoc,
+  getFirestore,
+} from "firebase/firestore";
 
 let app: FirebaseApp;
+let firestore: Firestore;
 
 export async function initializeFirebase() {
   const tenantConfig = await loadConfig();
   app = initializeApp(tenantConfig.fs, "authFirebase");
+  if (!firestore) {
+    const tenantConfig = await loadConfig();
+    app = initializeApp(tenantConfig.fs, "authFirebase");
+    firestore = getFirestore(app);
+  }
 }
 
 const findProviderId = (org: OrgData) => {
@@ -47,7 +59,9 @@ const findProviderId = (org: OrgData) => {
       return org.providerId;
   }
 };
-
+export const doc = <T>(path: string) => {
+  return fsDoc(firestore, path) as DocumentReference<T>;
+};
 export const signInToTenant = async (
   org: OrgData,
   firebaseCredential: EmailAuthCredential | OAuthCredential,

--- a/src/plugins/aws/config.ts
+++ b/src/plugins/aws/config.ts
@@ -8,17 +8,18 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { fetchIntegrationConfig } from "../../drivers/api";
+import { doc } from "../../drivers/firestore";
 import { Authn } from "../../types/identity";
 import { AwsConfig } from "./types";
+import { getDoc } from "firebase/firestore";
 import { sortBy } from "lodash";
 
 export const getFirstAwsConfig = async (authn: Authn) => {
   const { identity } = authn;
-  const { config } = await fetchIntegrationConfig<{ config: AwsConfig }>(
-    authn,
-    "aws"
+  const snapshot = await getDoc<AwsConfig, object>(
+    doc(`o/${identity.org.tenantId}/integrations/aws`)
   );
+  const config = snapshot.data();
 
   const item = Object.entries(config?.["iam-write"] ?? {}).find(
     ([_id, { state }]) => state === "installed"
@@ -34,10 +35,10 @@ export const getAwsConfig = async (
   account: string | undefined
 ) => {
   const { identity } = authn;
-  const { config } = await fetchIntegrationConfig<{ config: AwsConfig }>(
-    authn,
-    "aws"
+  const snapshot = await getDoc<AwsConfig, object>(
+    doc(`o/${identity.org.tenantId}/integrations/aws`)
   );
+  const config = snapshot.data();
   // TODO: Support alias lookup
   const allItems = sortBy(
     Object.entries(config?.["iam-write"] ?? {}).filter(


### PR DESCRIPTION
Potential fix for https://linear.app/p0-security/issue/ENG-5980/splunk-ssh-request-is-unexpectedly-failing#comment-fec29203

More context https://p0security.slack.com/archives/C08BAJD97EG/p1757032499827069?thread_ts=1757002897.444239&cid=C08BAJD97EG

I have tested this and confirmed, I can now make requests with no RBAC roles. However, I'm not sure at all if this is the fix we want to make.