### PR TITLE
Increase Keychain Auto-Lock timeout

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -35,6 +35,8 @@ jobs:
           security import codesign_certificate.p12 -k build.keychain -P "${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
           security import installer_certificate.p12 -k build.keychain -P "${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}" -T /usr/bin/pkgbuild
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+          security set-keychain-settings -lut 3600 build.keychain
       - name: Cache FIPS-compliant Node.js
         id: cache-fips-node
         uses: actions/cache@v4


### PR DESCRIPTION
Currently FIPs builds of NodeJS take too long on MacOS, such that it exceeds the default auto-locking timeout (5 mins). This increases that limit to 1 hour.