### PR TITLE
Retry 429 HTTP errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/aws/index.ts
+++ b/src/commands/aws/index.ts
@@ -34,6 +34,10 @@ const awsArgs = async (yargs: yargs.Argv) => {
         describe: "Reason access is needed",
         type: "string",
       })
+      .option("debug", {
+        type: "boolean",
+        describe: "Print debug information.",
+      })
       .env("P0_AWS");
 
     const withCommand =

--- a/src/commands/aws/permission-set.ts
+++ b/src/commands/aws/permission-set.ts
@@ -43,7 +43,7 @@ const oktaAwsAssumePermissionSet = async (
   authn: Authn
 ) => {
   const { account, permissionSet } = argv;
-  const { config } = await getAwsConfig(authn, account);
+  const { config } = await getAwsConfig(authn, account, argv.debug);
 
   if (config.login?.type !== "idc") {
     throw new Error(

--- a/src/commands/aws/role.ts
+++ b/src/commands/aws/role.ts
@@ -59,10 +59,14 @@ const oktaAwsAssumeRole = async (
 
   await provisionRequest(requestCommand, authn);
 
-  const awsCredential = await assumeRoleWithOktaSaml(authn, {
-    accountId: argv.account,
-    role: argv.role,
-  });
+  const awsCredential = await assumeRoleWithOktaSaml(
+    authn,
+    {
+      accountId: argv.account,
+      role: argv.role,
+    },
+    argv.debug
+  );
 
   const command = `p0 aws${argv.account ? ` --account ${argv.account}` : ""} role assume ${argv.role}`;
   printAwsCredentials(awsCredential, command);

--- a/src/commands/aws/types.ts
+++ b/src/commands/aws/types.ts
@@ -11,6 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 export type AssumeCommandArgs = {
   account?: string;
   reason?: string;
+  debug?: boolean;
 };
 
 export type AssumePermissionSetCommandArgs = AssumeCommandArgs & {

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -31,6 +31,7 @@ export type KubeconfigCommandArgs = {
   resource?: string;
   reason?: string;
   requestedDuration?: string;
+  debug?: boolean;
 };
 
 // The P0 backend must be updated if this CLI command changes!
@@ -66,6 +67,10 @@ export const kubeconfigCommand = (yargs: yargs.Argv) =>
           // Copied from the P0 backend
           describe:
             "Requested duration for access (format like '10 minutes', '2 hours', '5 days', or '1 week')",
+        })
+        .option("debug", {
+          type: "boolean",
+          describe: "Print debug information.",
         }),
     kubeconfigAction
   );
@@ -83,7 +88,8 @@ const kubeconfigAction = async (
 
   const { clusterConfig, awsLoginType } = await getAndValidateK8sIntegration(
     authn,
-    args.cluster
+    args.cluster,
+    args.debug
   );
   const { clusterId, awsAccountId, awsClusterArn } = clusterConfig;
 
@@ -98,7 +104,8 @@ const kubeconfigAction = async (
     authn,
     awsAccountId,
     request,
-    awsLoginType
+    awsLoginType,
+    args.debug
   );
 
   const profile = profileName(clusterId);

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -144,22 +144,24 @@ const kubeconfigAction = async (
       "Waiting for AWS resources to be provisioned and updating kubeconfig for EKS",
       retryWithSleep(
         async () => await exec("aws", updateKubeconfigArgs, { check: true }),
-        (error: any) => {
-          if (error?.stderr) {
-            if (
-              error.stderr.includes("Unknown options") ||
-              error.stderr.includes("--user-alias")
-            ) {
-              print2(
-                "\nThe AWS CLI version is not compatible with the p0 kubeconfig command. Please update to at least version 2.11.6."
-              );
-              return false; // Stop retrying if the CLI version is incompatible
+        {
+          shouldRetry: (error: any) => {
+            if (error?.stderr) {
+              if (
+                error.stderr.includes("Unknown options") ||
+                error.stderr.includes("--user-alias")
+              ) {
+                print2(
+                  "\nThe AWS CLI version is not compatible with the p0 kubeconfig command. Please update to at least version 2.11.6."
+                );
+                return false; // Stop retrying if the CLI version is incompatible
+              }
             }
-          }
-          return true;
-        },
-        8,
-        2500
+            return true;
+          },
+          retries: 8,
+          delayMs: 2500,
+        }
       )
     );
     print2(awsResult.stdout);

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -9,7 +9,13 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { fetchAccountInfo } from "../drivers/api";
-import { authenticate, deleteIdentity, loadCredentials, remainingTokenTime, writeIdentity } from "../drivers/auth";
+import {
+  authenticate,
+  deleteIdentity,
+  loadCredentials,
+  remainingTokenTime,
+  writeIdentity,
+} from "../drivers/auth";
 import { saveConfig } from "../drivers/config";
 import { initializeFirebase } from "../drivers/firestore";
 import { getOrgData } from "../drivers/org";
@@ -17,9 +23,7 @@ import { print2 } from "../drivers/stdio";
 import { pluginLoginMap } from "../plugins/login";
 import { Authn } from "../types/identity";
 import { OrgData } from "../types/org";
-import { debug } from "node:console";
 import yargs from "yargs";
-
 
 const MIN_REMAINING_TOKEN_TIME_SECONDS = 5 * 60;
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -9,13 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { fetchAccountInfo } from "../drivers/api";
-import {
-  authenticate,
-  deleteIdentity,
-  loadCredentials,
-  remainingTokenTime,
-  writeIdentity,
-} from "../drivers/auth";
+import { authenticate, deleteIdentity, loadCredentials, remainingTokenTime, writeIdentity } from "../drivers/auth";
 import { saveConfig } from "../drivers/config";
 import { initializeFirebase } from "../drivers/firestore";
 import { getOrgData } from "../drivers/org";
@@ -23,7 +17,9 @@ import { print2 } from "../drivers/stdio";
 import { pluginLoginMap } from "../plugins/login";
 import { Authn } from "../types/identity";
 import { OrgData } from "../types/org";
+import { debug } from "node:console";
 import yargs from "yargs";
+
 
 const MIN_REMAINING_TOKEN_TIME_SECONDS = 5 * 60;
 
@@ -110,7 +106,7 @@ export const login = async (
 
   if (!options?.skipAuthenticate) {
     const authn = await authenticate({ debug: options?.debug });
-    await validateTenantAccess(authn);
+    await validateTenantAccess(authn, options?.debug);
   }
 
   if (!loggedIn) {
@@ -149,9 +145,9 @@ export const loginCommand = (yargs: yargs.Argv) =>
     ) => login(args, args)
   );
 
-const validateTenantAccess = async (authn: Authn) => {
+const validateTenantAccess = async (authn: Authn, debug?: boolean) => {
   try {
-    await fetchAccountInfo(authn);
+    await fetchAccountInfo(authn, debug);
     return true;
   } catch (e) {
     await deleteIdentity();

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -16,6 +16,7 @@ import { max, orderBy, slice } from "lodash";
 import pluralize from "pluralize";
 import yargs from "yargs";
 
+
 const DEFAULT_RESPONSE_SIZE = 15;
 
 type LsResponse = {
@@ -49,10 +50,14 @@ const lsArgs = <T>(yargs: yargs.Argv<T>) =>
       type: "boolean",
       default: false,
       description: "Output in JSON format",
+    })
+    .option("debug", {
+      type: "boolean",
+      describe: "Print debug information.",
     });
 
 export const lsCommand = (yargs: yargs.Argv) =>
-  yargs.command<{ arguments: string[]; json: boolean; size: number }>(
+  yargs.command<{ arguments: string[]; json: boolean; size: number; debug: boolean }>(
     "ls [arguments..]",
     "List request-command arguments",
     lsArgs,
@@ -64,6 +69,7 @@ const ls = async (
     arguments: string[];
     json: boolean;
     size: number;
+    debug: boolean;
   }>
 ) => {
   const authn = await authenticate();

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -16,7 +16,6 @@ import { max, orderBy, slice } from "lodash";
 import pluralize from "pluralize";
 import yargs from "yargs";
 
-
 const DEFAULT_RESPONSE_SIZE = 15;
 
 type LsResponse = {
@@ -57,12 +56,12 @@ const lsArgs = <T>(yargs: yargs.Argv<T>) =>
     });
 
 export const lsCommand = (yargs: yargs.Argv) =>
-  yargs.command<{ arguments: string[]; json: boolean; size: number; debug: boolean }>(
-    "ls [arguments..]",
-    "List request-command arguments",
-    lsArgs,
-    ls
-  );
+  yargs.command<{
+    arguments: string[];
+    json: boolean;
+    size: number;
+    debug: boolean;
+  }>("ls [arguments..]", "List request-command arguments", lsArgs, ls);
 
 const ls = async (
   args: yargs.ArgumentsCamelCase<{

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -103,7 +103,8 @@ const validateSshInstall = async (
 ) => {
   const configDoc = await fetchIntegrationConfig<{ config: SshConfig }>(
     authn,
-    "ssh"
+    "ssh",
+    args.debug
   );
   const configItems = configDoc?.config["iam-write"];
 
@@ -234,7 +235,8 @@ export const prepareRequest = async (
     authn,
     provisionedRequest,
     requestId,
-    publicKey
+    publicKey,
+    args.debug
   );
 
   await sshProvider.ensureInstall();

--- a/src/common/retry.ts
+++ b/src/common/retry.ts
@@ -48,7 +48,8 @@ export async function retryWithSleep<T>(
           shouldRetry,
           retries - 1,
           delayMs * multiplier,
-          multiplier
+          multiplier,
+          debug
         );
       }
     }
@@ -80,7 +81,8 @@ export async function* regenerateWithSleep<T>(
           shouldRetry,
           retries - 1,
           delayMs * multiplier,
-          multiplier
+          multiplier,
+          debug
         );
       }
     }

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -334,7 +334,6 @@ const baseFetch = async <T>(args: {
       ...(headers ?? {}),
       "Content-Type": "application/json",
       "User-Agent": `P0 CLI/${version}`,
-      Host: "teal-copper-hound.ngrok.app",
     },
     body,
     keepalive: true,

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -18,7 +18,7 @@ import * as path from "node:path";
 import yargs from "yargs";
 
 // We retry with these delays: 1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s
-// for a total of 121s wait time over 8 retries
+// for a total of 121s wait time over 8 retries (ignoring jitter)
 const RETRY_OPTIONS = {
   shouldRetry: (error: unknown) =>
     error === "HTTP Error: 429 Too Many Requests",

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -382,7 +382,7 @@ const authFetch = async <T>(
 };
 
 const handleResponse = (response: Response, responseText: string) => {
-  if (!response.ok) {
+  if ("ok" in response && !response.ok) {
     throw `HTTP Error: ${response.status} ${response.statusText}`;
   }
   const data = JSON.parse(responseText);

--- a/src/plugins/aws/config.ts
+++ b/src/plugins/aws/config.ts
@@ -13,11 +13,12 @@ import { Authn } from "../../types/identity";
 import { AwsConfig } from "./types";
 import { sortBy } from "lodash";
 
-export const getFirstAwsConfig = async (authn: Authn) => {
+export const getFirstAwsConfig = async (authn: Authn, debug?: boolean) => {
   const { identity } = authn;
   const { config } = await fetchIntegrationConfig<{ config: AwsConfig }>(
     authn,
-    "aws"
+    "aws",
+    debug
   );
 
   const item = Object.entries(config?.["iam-write"] ?? {}).find(
@@ -31,12 +32,14 @@ export const getFirstAwsConfig = async (authn: Authn) => {
 
 export const getAwsConfig = async (
   authn: Authn,
-  account: string | undefined
+  account: string | undefined,
+  debug?: boolean
 ) => {
   const { identity } = authn;
   const { config } = await fetchIntegrationConfig<{ config: AwsConfig }>(
     authn,
-    "aws"
+    "aws",
+    debug
   );
   // TODO: Support alias lookup
   const allItems = sortBy(

--- a/src/plugins/aws/idc/index.ts
+++ b/src/plugins/aws/idc/index.ts
@@ -104,36 +104,32 @@ const awsIdcHelpers = (
     // There is a delay in between aws issuing the sso token and it being available for exchange for AWS credentials
     // When exchanging token immediately, an "unauthorized" may will be thrown, so retry with sleep.
 
-    return await retryWithSleep(
-      async () => {
-        const init = {
-          method: "GET",
-          headers: {
-            "x-amz-sso_bearer_token": oidcResponse.accessToken,
-          },
-        };
-        const { accountId, permissionSet } = request;
-        if (accountId === undefined)
-          throw new Error(
-            "Could not find an AWS account ID for this access request"
-          );
-
-        const params = new URLSearchParams();
-        params.append("account_id", accountId);
-        params.append("role_name", permissionSet);
-        const response = await fetch(
-          `https://portal.sso.${region}.amazonaws.com/federation/credentials?${params.toString()}`,
-          init
+    return await retryWithSleep(async () => {
+      const init = {
+        method: "GET",
+        headers: {
+          "x-amz-sso_bearer_token": oidcResponse.accessToken,
+        },
+      };
+      const { accountId, permissionSet } = request;
+      if (accountId === undefined)
+        throw new Error(
+          "Could not find an AWS account ID for this access request"
         );
-        if (!response.ok)
-          throw new Error(
-            `Failed to fetch AWS credentials: ${response.statusText}: ${await response.text()}`
-          );
-        return await response.json();
-      },
-      () => true,
-      3
-    );
+
+      const params = new URLSearchParams();
+      params.append("account_id", accountId);
+      params.append("role_name", permissionSet);
+      const response = await fetch(
+        `https://portal.sso.${region}.amazonaws.com/federation/credentials?${params.toString()}`,
+        init
+      );
+      if (!response.ok)
+        throw new Error(
+          `Failed to fetch AWS credentials: ${response.statusText}: ${await response.text()}`
+        );
+      return await response.json();
+    });
   };
 
   return {

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -61,8 +61,8 @@ export const awsSshProvider: SshProvider<
   AwsSshRequest,
   AwsCredentials
 > = {
-  cloudProviderLogin: async (authn, request) => {
-    const { config } = await getAwsConfig(authn, request.accountId);
+  cloudProviderLogin: async (authn, request, debug) => {
+    const { config } = await getAwsConfig(authn, request.accountId, debug);
     if (!config.login?.type || config.login?.type === "iam") {
       throw "This account is not configured for SSH access via the P0 CLI";
     }
@@ -70,7 +70,11 @@ export const awsSshProvider: SshProvider<
     return config.login?.type === "idc"
       ? await assumeRoleWithIdc(request as AwsSshIdcRequest)
       : config.login?.type === "federated"
-        ? await assumeRoleWithOktaSaml(authn, request as AwsSshRoleRequest)
+        ? await assumeRoleWithOktaSaml(
+            authn,
+            request as AwsSshRoleRequest,
+            debug
+          )
         : throwAssertNever(config.login);
   },
 
@@ -86,13 +90,13 @@ export const awsSshProvider: SshProvider<
 
   preTestAccessPropagationArgs: () => undefined,
 
-  async submitPublicKey(authn, request, requestId, publicKey) {
+  async submitPublicKey(authn, request, requestId, publicKey, debug) {
     if (request.generated.publicKey) {
       if (request.generated.publicKey !== publicKey) {
         throw "Public key mismatch. Please revoke the request and try again.";
       }
     } else {
-      await submitPublicKey(authn, { publicKey, requestId });
+      await submitPublicKey(authn, { publicKey, requestId }, debug);
     }
   },
 

--- a/src/plugins/azure/tunnel.ts
+++ b/src/plugins/azure/tunnel.ts
@@ -20,7 +20,6 @@ import { AzureSshRequest } from "./types";
 import { spawn } from "node:child_process";
 
 const TUNNEL_READY_STRING = "Tunnel is ready";
-const SPAWN_TUNNEL_TRIES = 3;
 
 // Ignore these debug messages from the tunnel process; they are far too noisy and spam the terminal with useless info
 // anytime the SSH/SCP session has network activity.
@@ -205,10 +204,7 @@ export const trySpawnBastionTunnel = async (
   // Attempt to spawn the tunnel SPAWN_TUNNEL_TRIES times, picking a new port each time. If we fail
   // too many times, then the problem is likely not the port, but something else.
 
-  return await retryWithSleep(
-    () => spawnBastionTunnelInBackground(request, selectRandomPort(), options),
-    () => true,
-    SPAWN_TUNNEL_TRIES,
-    1000
+  return await retryWithSleep(() =>
+    spawnBastionTunnelInBackground(request, selectRandomPort(), options)
   );
 };

--- a/src/plugins/okta/aws.ts
+++ b/src/plugins/okta/aws.ts
@@ -50,8 +50,12 @@ const isFederatedLogin = (
  * If no account is passed, and the organization only has one account configured,
  * assumes that account.
  */
-const initOktaSaml = async (authn: Authn, account: string | undefined) => {
-  const { identity, config } = await getAwsConfig(authn, account);
+const initOktaSaml = async (
+  authn: Authn,
+  account: string | undefined,
+  debug?: boolean
+) => {
+  const { identity, config } = await getAwsConfig(authn, account, debug);
   if (!isFederatedLogin(config))
     throw `Account ${config.label ?? config.id} is not configured for Okta SAML login.`;
   const samlResponse = await getSamlResponse(identity, config.login);
@@ -64,14 +68,16 @@ const initOktaSaml = async (authn: Authn, account: string | undefined) => {
 
 export const assumeRoleWithOktaSaml = async (
   authn: Authn,
-  args: { accountId?: string; role: string }
+  args: { accountId?: string; role: string },
+  debug?: boolean
 ) =>
   await cached(
     `aws-okta-${args.accountId}-${args.role}`,
     async () => {
       const { account, config, samlResponse } = await initOktaSaml(
         authn,
-        args.accountId
+        args.accountId,
+        debug
       );
       const { roles } = rolesFromSaml(account, samlResponse);
       if (!roles.includes(args.role))

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -476,7 +476,7 @@ export const sshOrScp = async (args: {
   const abortController = new AbortController();
 
   const credential: AwsCredentials | undefined =
-    await sshProvider.cloudProviderLogin(authn, request);
+    await sshProvider.cloudProviderLogin(authn, request, debug);
 
   const setupData = await sshProvider.setup?.(authn, request, {
     requestId,

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -73,7 +73,7 @@ export type SshProvider<
   C extends object | undefined = undefined, // credentials object
 > = {
   /** Logs in the user to the cloud provider */
-  cloudProviderLogin: (authn: Authn, request: SR) => Promise<C>;
+  cloudProviderLogin: (authn: Authn, request: SR, debug?: boolean) => Promise<C>;
 
   /** Callback to ensure that this provider's CLI utils are installed */
   ensureInstall: () => Promise<void>;
@@ -130,7 +130,8 @@ export type SshProvider<
     authn: Authn,
     request: PR,
     requestId: string,
-    publicKey: string
+    publicKey: string,
+    debug?: boolean
   ) => Promise<void>;
 
   generateKeys?: (

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -73,7 +73,11 @@ export type SshProvider<
   C extends object | undefined = undefined, // credentials object
 > = {
   /** Logs in the user to the cloud provider */
-  cloudProviderLogin: (authn: Authn, request: SR, debug?: boolean) => Promise<C>;
+  cloudProviderLogin: (
+    authn: Authn,
+    request: SR,
+    debug?: boolean
+  ) => Promise<C>;
 
   /** Callback to ensure that this provider's CLI utils are installed */
   ensureInstall: () => Promise<void>;


### PR DESCRIPTION
Adds retries when the p0 backend returns a `429 Too Many Requests` error. The primary case when that can happen is executing `p0 ssh` or other commands from automated scripts that loop a number of instances.

Since these scripts themselves may be difficult to make fault-tolerant, this change adds internal retries to all calls to the p0 backend.

Changes to enable this:
- Improve `retryWithSleep` utility:
  - Add arguments `multiplier`, to allow exponential backoff, and `debug` to allow printing retry information
  - Turn argument list into `options` object with defaults
- Unify error handling on streaming and regular API call path with `parseResponseText`

Other changes:
- Add / remove space to have one space between words
- Make `tryParseHtmlError` to capture errors that originate from the load-balancer vs. application firewall
- Add debug log for `Network error`, we used to mask the original error with `Network error: Unable to reach the server.`
- Add `debug` options to all commands that did not have it and propagate the `debug` option all the way to the p0 backend calls


Example debug output of retries with jitter:
<img width="675" height="253" alt="image" src="https://github.com/user-attachments/assets/560dbbea-3de2-48a4-9385-628f9550e46c" />
