### PR TITLE
Fix gcloud resolution for proxy command

### DIFF
--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -12,6 +12,7 @@ import { asyncSpawn } from "../../common/subprocess";
 import { print2 } from "../../drivers/stdio";
 import { getOperatingSystem } from "../../util";
 import { ImportSshPublicKeyResponse } from "./types";
+import { gcloudCommandArgs } from "./util";
 
 /**
  * Adds an ssh public key to the user object's sshPublicKeys array in Google Workspace.
@@ -36,17 +37,13 @@ export const importSshKey = async (
   const accessToken = await asyncSpawn(
     { debug: false },
     cmd,
-    isWindows
-      ? ["/d", "/s", "/c", "gcloud", "auth", "print-access-token"]
-      : ["auth", "print-access-token"]
+    gcloudCommandArgs(["auth", "print-access-token"])
   );
 
   const account = await asyncSpawn(
     { debug },
     cmd,
-    isWindows
-      ? ["/d", "/s", "/c", "gcloud", "config", "get-value", "account"]
-      : ["config", "get-value", "account"]
+    gcloudCommandArgs(["config", "get-value", "account"])
   );
 
   if (debug) {

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -14,6 +14,7 @@ import { SshProvider } from "../../types/ssh";
 import { ensureGcpSshInstall } from "./install";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
+import { gcloudCommandArgs } from "./util";
 
 // It typically takes < 1 minute for access to propagate on GCP, so set the time limit to 2 minutes.
 const PROPAGATION_TIMEOUT_LIMIT_MS = 2 * 60 * 1000;
@@ -95,8 +96,7 @@ export const gcpSshProvider: SshProvider<
   },
 
   proxyCommand: (request, port) => {
-    return [
-      "gcloud",
+    return gcloudCommandArgs([
       "compute",
       "start-iap-tunnel",
       request.id,
@@ -108,7 +108,7 @@ export const gcpSshProvider: SshProvider<
       "--listen-on-stdin",
       `--zone=${request.zone}`,
       `--project=${request.projectId}`,
-    ];
+    ]);
   },
 
   reproCommands: () => undefined,

--- a/src/plugins/google/util.ts
+++ b/src/plugins/google/util.ts
@@ -1,0 +1,29 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { getOperatingSystem } from "../../util";
+
+/**
+ * Prepends with the operating-system specific method of
+ * running a gcloud command.
+ * @param args the arguments to be passed to gcloud (excluding "gcloud" itself)
+ */
+export const gcloudCommandArgs = (args: string[]) => {
+  const isWindows = getOperatingSystem() === "win";
+
+  // On Windows, when installing the Google Cloud tools, the main gcloud file is
+  // a .cmd (shell script) file rather than a .exe (binary executable) file,
+  // so when calling spawn, it cannot be located except via cmd.exe
+  // Unlike in MacOS, the underlying Windows OS API that spawn uses doesn't
+  // resolve .CMD files by default
+  return isWindows
+    ? ["cmd.exe", "/d", "/s", "/c", "gcloud", ...args]
+    : ["gcloud", ...args];
+};


### PR DESCRIPTION
Fixes gcloud resolution for the proxy command.

Validated on: Windows 11 Pro, 24H2 on powershell and command prompt

Note: this can be thought of as a follow-up to #233. This makes the same change to the proxy command