### PR TITLE
Manually specify SSH MAC algorithms on Windows

### DIFF
--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -27,7 +27,7 @@ import {
   SshRequest,
   SupportedSshProvider,
 } from "../../types/ssh";
-import { delay } from "../../util";
+import { delay, getOperatingSystem } from "../../util";
 import { AwsCredentials } from "../aws/types";
 import {
   ChildProcessByStdio,
@@ -355,6 +355,10 @@ const addCommonArgs = (
 
   if (sshHostKeys && !hostKeyAliasOptionExists)
     sshOptions.push("-o", `HostKeyAlias=${sshHostKeys.alias}`);
+
+  if (getOperatingSystem() === "win") {
+    sshOptions.push("-o", "MACs=hmac-sha2-256-etm@openssh.com,hmac-sha2-256");
+  }
 
   // Force verbose output from SSH so we can parse the output
   const verboseOptionExists = sshOptions.some((opt) => opt === "-v");

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -357,6 +357,8 @@ const addCommonArgs = (
     sshOptions.push("-o", `HostKeyAlias=${sshHostKeys.alias}`);
 
   if (getOperatingSystem() === "win") {
+    // Explicitly set the MAC algorithms to avoid certain MACs whose
+    // Windows OpenSSH implementation is unreliable (e.g. umacs-128-etm@openssh.com)
     sshOptions.push("-o", "MACs=hmac-sha2-256-etm@openssh.com,hmac-sha2-256");
   }
 


### PR DESCRIPTION
Set default MACs on Windows when using `p0 ssh`. One of the MACs that OpenSSH on Windows ships with (`umac-128-etm@openssh.com`) appears to work unreliably, and using it may lead to a "Corrupted MAC on input" error. With this change, `p0 ssh <instance>` on Windows will only choose one of our specified MACs by default: `hmac-sha2-256-etm@openssh.com` or `hmac-sha2-256`.

Notes:

- the user can still explicitly specify a different MAC if they prefer by running `p0 ssh <instance> -- -o MACs=<other mac>`, which will override these defaults
- if the user explicitly specifies the broken MAC by running `p0 ssh <instance> -- -o MACs=umac-128-etm@openssh.com`, this will override our defaults and they will still see the Corrupted MAC error
- the ETM variant is more secure than the plain HMAC, so it is prioritized first
- the previous bullet points only apply if the cipher doesn't provide authenticated encryption (AEAD). AEAD ciphers include AES-GCM modes and chacha20-poly1305. If an AEAD cipher is negotiated, no separate MAC is used, regardless of whether `-o MACs=<mac-list>` is explicitly passed in

