### PR TITLE
Fix CLI double login bug, improve debug logging

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -66,7 +66,7 @@ const buildArgv = async () => {
 // Skip the version check for these non-interactive commands
 const skipVersionCheckFor = ["ssh-proxy", "ssh-resolve"];
 
-function conditionalCheckVersion(argv: yargs.ArgumentsCamelCase) {
+async function conditionalCheckVersion(argv: yargs.ArgumentsCamelCase) {
   const invokedCommand = argv._[0];
 
   if (typeof invokedCommand !== "string") {
@@ -76,7 +76,7 @@ function conditionalCheckVersion(argv: yargs.ArgumentsCamelCase) {
   if (skipVersionCheckFor.includes(invokedCommand)) {
     return;
   } else {
-    return checkVersion(argv);
+    return await checkVersion(argv);
   }
 }
 

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -163,7 +163,9 @@ export const authenticate = async (options?: {
   const identity = await loadCredentialsWithAutoLogin(options);
   if (options?.debug) {
     print2(`Loaded identity for user for org ${identity.org.slug}`);
-    print2(`Token expires in ${remainingTokenTime(identity)} seconds`);
+    print2(
+      `Token expires in ${Math.floor(remainingTokenTime(identity))} seconds`
+    );
   }
   let authn: Authn;
 

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -104,7 +104,7 @@ export const loadCredentials = async (): Promise<Identity> => {
 };
 
 export const remainingTokenTime = (identity: Identity) =>
-  identity.credential.expires_at - Date.now() * 1e-3;
+  Math.floor(identity.credential.expires_at - Date.now() * 1e-3);
 
 const loadCredentialsWithAutoLogin = async (options?: {
   noRefresh?: boolean;
@@ -164,9 +164,7 @@ export const authenticate = async (options?: {
   const identity = await loadCredentialsWithAutoLogin(options);
   if (options?.debug) {
     print2(`Loaded identity for user for org ${identity.org.slug}`);
-    print2(
-      `Token expires in ${Math.floor(remainingTokenTime(identity))} seconds`
-    );
+    print2(`Token expires in ${remainingTokenTime(identity)} seconds`);
   }
   let authn: Authn;
 

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { print2 } from "../drivers/stdio";
-import { P0_PATH, exec, timeout } from "../util";
+import { P0_PATH, exec, getOperatingSystem, timeout } from "../util";
 import { p0VersionInfo } from "../version";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -21,9 +21,15 @@ const LATEST_VERSION_FILE = "last-version-check";
 
 // We don't want to add any significant overhead to p0 commands with the version check,
 // so just give up if it takes too long.
-const VERSION_CHECK_TIMEOUT_MILLIS = 1e3;
+const VERSION_CHECK_TIMEOUT_MILLIS = 2e3;
 
 const VERSION_CHECK_INTERVAL_MILLIS = 86400e3; // 1 day
+
+type NpmPackageOutput = {
+  "dist-tags": {
+    latest: string;
+  };
+};
 
 /** Checks if there is a new version of the CLI
  *
@@ -31,29 +37,63 @@ const VERSION_CHECK_INTERVAL_MILLIS = 86400e3; // 1 day
  *
  * If there is no new version, or if version lookup errors, just pass silently.
  */
-export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
+export const checkVersion = async (yargs: yargs.ArgumentsCamelCase) => {
+  const isDebug = Boolean(yargs["debug"]);
+
   try {
     const latestFile = path.join(P0_PATH, LATEST_VERSION_FILE);
     try {
       const stat = await fs.stat(latestFile);
-      if (Date.now() - stat.mtime.getTime() <= VERSION_CHECK_INTERVAL_MILLIS)
+      const msSinceLastCheck = Date.now() - stat.mtime.getTime();
+      if (msSinceLastCheck <= VERSION_CHECK_INTERVAL_MILLIS) {
+        if (isDebug) {
+          print2(
+            "Skipping version check; last checked " +
+              Math.round(msSinceLastCheck / (1000 * 60)) +
+              " minutes ago."
+          );
+        }
         return;
+      }
     } catch (error: any) {
       if (error.code !== "ENOENT") throw error;
     }
 
     // Write the version-check file first to avoid retrying errors
+    // Ensure that the directory exists beforehand
+    const dirname = path.dirname(latestFile);
+    await fs.mkdir(dirname, { recursive: true });
     await fs.writeFile(latestFile, "");
 
-    const { name, version } = p0VersionInfo;
+    const { name, version: current } = p0VersionInfo;
 
-    const npmResult = exec("npm", ["view", name, "--json"], { check: true });
-    const npmPackage = await timeout(npmResult, VERSION_CHECK_TIMEOUT_MILLIS);
-    const {
-      "dist-tags": { latest },
-    } = JSON.parse(npmPackage.stdout);
+    if (isDebug) {
+      print2("Checking that your CLI is up to date with the latest version...");
+    }
 
-    if (semver.lt(version, latest)) {
+    // On Windows, the main npm file is not an .exe (binary executable) file,
+    // so when calling spawn, it cannot be located except via cmd.exe
+    const isWindows = getOperatingSystem() === "win";
+    const npmCmd = isWindows ? "cmd.exe" : "npm";
+    const commonNpmArgs = ["view", name, "--json"];
+    const npmArgs = isWindows
+      ? ["/d", "/s", "/c", "npm", ...commonNpmArgs]
+      : commonNpmArgs;
+
+    const processResult = await timeout(
+      exec(npmCmd, npmArgs, { check: true }),
+      VERSION_CHECK_TIMEOUT_MILLIS
+    );
+    const npmPackage: NpmPackageOutput = JSON.parse(processResult.stdout);
+    const { latest } = npmPackage["dist-tags"];
+
+    if (isDebug) {
+      print2("Package info successfully retrieved.");
+      print2("Latest version: " + latest.padStart(15));
+      print2("Your version:   " + current.padStart(15));
+    }
+
+    if (semver.lt(current, latest)) {
       if (isSea()) {
         print2(
           `╔═══════════════════════════════════════════════╗
@@ -76,8 +116,15 @@ export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
 `
         );
       }
+    } else if (isDebug) {
+      print2("Your version of the P0 CLI is up to date.");
     }
   } catch (error: any) {
+    if (isDebug) {
+      print2(`Version check failed: ${error.message}`);
+      print2("Ignoring this error and continuing...");
+    }
+
     // Silently pass errors
     // TODO: log to ~/.p0
   }

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -117,7 +117,7 @@ export const checkVersion = async (yargs: yargs.ArgumentsCamelCase) => {
         );
       }
     } else if (isDebug) {
-      print2("Your version of the P0 CLI is up to date.");
+      print2("Your version of the CLI is up to date.");
     }
   } catch (error: any) {
     if (isDebug) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -80,7 +80,11 @@ export const exec = async (
         });
         child.stdout.on("data", (d) => out.push(d));
         child.stderr.on("data", (d) => err.push(d));
-        child.on("exit", (code) => {
+
+        // The close event is emitted after the child process has exited (the 'exit' event) and all of its
+        // stdio (standard input, standard output, and standard error) streams have been closed.
+        // See https://nodejs.org/api/child_process.html#event-close
+        child.on("close", (code) => {
           const stdout = out.join("\n");
           const stderr = err.join("\n");
           const result = { code, stdout, stderr };
@@ -89,6 +93,13 @@ export const exec = async (
               Object.assign(new Error("Sub-process exited with code"), result)
             );
           resolve(result);
+        });
+
+        // without a handler for the "error" event, an uncaught exception will be thrown that will crash
+        // the process entirely. This can happen if the process fails to spawn, for example, due to the
+        // command not being found
+        child.on("error", (error) => {
+          reject(error);
         });
       } catch (error) {
         reject(error);


### PR DESCRIPTION
On Windows, the NPM version check was broken, which led to the end user sometimes needing to run the login command twice. This fixes the core issues at play, but also improves debug logging for easier traceability.

- Adjusts the spawn of the NPM version check to account for the fact that NPM isn't a .exe file.
- Adds a .on("error") check to the `exec` implementation to explicitly handle errors (required to prevent uncaught exceptions)
- Adds global process error handlers to improve logging when uncaught errors or unhandled rejections occur (without this change, nothing printed to the terminal; with this change, it would have made it much easier to debug this particular issue)
- Improves overall debug logging of the NPM version checking code paths
- Adjusts `.on("exit")` to `.on("close")` to allow stdio/stderr to cleanly finish
- Bump NPM version check timeout from 1s to 2s to improve reliability (it took generally longer on my local Virtualized Windows hardware - could be either due to the Virtualization or Windows itself being slower)

I tested this on both Windows and MacOS to test the login flows, debug logging, and that SSH functionality still works