### PR TITLE
ENG-6034 Use $0 to identify the name of the executable

### DIFF
--- a/src/commands/__tests__/login.test.ts
+++ b/src/commands/__tests__/login.test.ts
@@ -27,6 +27,10 @@ jest.mock("../../drivers/auth/path", () => ({
 jest.mock("../../drivers/stdio");
 jest.mock("../../plugins/login");
 jest.mock("../../drivers/api");
+jest.mock("../../util", () => ({
+  ...jest.requireActual("../../util"),
+  getAppName: () => "p0",
+}));
 
 const mockIdentity: Identity = {
   // @ts-expect-error credential has more fields, this is enough for tests
@@ -57,7 +61,7 @@ describe("login", () => {
 
   it("prints a friendly error if the org is not provided", async () => {
     await expect(login({} as any)).rejects.toMatchInlineSnapshot(
-      `"The P0 organization ID is required. Please provide it as an argument or set the P0_ORG environment variable."`
+      `"The organization ID is required. Please provide it as an argument or set the P0_ORG environment variable."`
     );
   });
 
@@ -100,7 +104,7 @@ describe("login", () => {
 
     it("it should ask user to log in", async () => {
       await expect(login({ org: "test-org" })).rejects.toMatchInlineSnapshot(
-        `"Please run \`p0 login <organization>\` to use the P0 CLI."`
+        `"Please run \`p0 login <organization>\`."`
       );
     });
   });

--- a/src/commands/aws/__tests__/role.test.ts
+++ b/src/commands/aws/__tests__/role.test.ts
@@ -29,6 +29,10 @@ jest.mock("typescript", () => ({
 jest.mock("../../shared/request", () => ({
   provisionRequest: jest.fn(),
 }));
+jest.mock("../../../util", () => ({
+  ...jest.requireActual("../../../util"),
+  getAppName: () => "p0",
+}));
 
 const mockFetch = jest.spyOn(global, "fetch");
 const mockPrint1 = print1 as jest.Mock;

--- a/src/commands/aws/permission-set.ts
+++ b/src/commands/aws/permission-set.ts
@@ -11,6 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { getAwsConfig } from "../../plugins/aws/config";
 import { assumeRoleWithIdc } from "../../plugins/aws/idc";
 import { Authn } from "../../types/identity";
+import { getAppName } from "../../util";
 import { provisionRequest } from "../shared/request";
 import { AssumeCommandArgs, AssumePermissionSetCommandArgs } from "./types";
 import { printAwsCredentials } from "./util";
@@ -63,7 +64,7 @@ const oktaAwsAssumePermissionSet = async (
     idc: { id: login.identityStoreId, region: login.idcRegion },
   });
 
-  const command = `p0 aws${argv.account ? ` --account ${argv.account}` : ""} permission-set assume ${argv.permissionSet}`;
+  const command = `${getAppName()} aws${argv.account ? ` --account ${argv.account}` : ""} permission-set assume ${argv.permissionSet}`;
   printAwsCredentials(awsCredential, command);
 };
 

--- a/src/commands/aws/role.ts
+++ b/src/commands/aws/role.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { assumeRoleWithOktaSaml } from "../../plugins/okta/aws";
 import { Authn } from "../../types/identity";
+import { getAppName } from "../../util";
 import { provisionRequest } from "../shared/request";
 import { AssumeRoleCommandArgs } from "./types";
 import { printAwsCredentials } from "./util";
@@ -68,7 +69,7 @@ const oktaAwsAssumeRole = async (
     argv.debug
   );
 
-  const command = `p0 aws${argv.account ? ` --account ${argv.account}` : ""} role assume ${argv.role}`;
+  const command = `${getAppName()} aws${argv.account ? ` --account ${argv.account}` : ""} role assume ${argv.role}`;
   printAwsCredentials(awsCredential, command);
 };
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -82,7 +82,7 @@ export const login = async (
         `The current session expires in ${formatTimeLeft(tokenTimeRemaining)}.`
       );
     } else {
-      throw "The P0 organization ID is required. Please provide it as an argument or set the P0_ORG environment variable.";
+      throw "The organization ID is required. Please provide it as an argument or set the P0_ORG environment variable.";
     }
   } else {
     if (identity && loggedIn) {
@@ -140,12 +140,12 @@ export const login = async (
 export const loginCommand = (yargs: yargs.Argv) =>
   yargs.command<{ org: string }>(
     "login [org]",
-    "Log in to p0 using a web browser",
+    "Log in using a web browser",
     (yargs) =>
       yargs
         .positional("org", {
           type: "string",
-          describe: "Your P0 organization ID",
+          describe: "Your organization ID",
         })
         .option("refresh", {
           type: "boolean",

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -12,6 +12,7 @@ import { AnsiSgr } from "../drivers/ansi";
 import { fetchAdminLsCommand, fetchCommand } from "../drivers/api";
 import { authenticate } from "../drivers/auth";
 import { print1, print2, spinUntil } from "../drivers/stdio";
+import { getAppName } from "../util";
 import { max, orderBy, slice } from "lodash";
 import pluralize from "pluralize";
 import yargs from "yargs";
@@ -117,7 +118,7 @@ const ls = async (
     const postfixPart = data.term
       ? ` matching '${data.term}'`
       : data.isTruncated
-        ? ` (use \`p0 ${allArguments.join(" ")} <like>\` to narrow results)`
+        ? ` (use \`${getAppName()} ${allArguments.join(" ")} <like>\` to narrow results)`
         : "";
 
     print2(

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -119,7 +119,7 @@ const validateSshInstall = async (
   );
 
   if (items.length === 0) {
-    throw "This organization is not configured for SSH access via the P0 CLI";
+    throw "This organization is not configured for SSH access";
   }
 };
 

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -12,7 +12,12 @@ import { sanitizeAsFileName } from "../common/destination";
 import { PRIVATE_KEY_PATH } from "../common/keys";
 import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
-import { conditionalAbortBeforeThrow, getAppPath, P0_PATH } from "../util";
+import {
+  conditionalAbortBeforeThrow,
+  getAppPath,
+  getAppName,
+  P0_PATH,
+} from "../util";
 import {
   prepareRequest,
   SshResolveCommandArgs,
@@ -83,7 +88,7 @@ const sshResolveAction = async (
       err.toLowerCase().includes("reason is required")
     ) {
       print2(
-        `Please set the ${ENV_PREFIX}_REASON environment variable or request access with "p0 request ssh ... --reason ..." to the destination first.`
+        `Please set the ${ENV_PREFIX}_REASON environment variable or request access with "${getAppName()} request ssh ... --reason ..." to the destination first.`
       );
     }
 

--- a/src/commands/ssh.ts
+++ b/src/commands/ssh.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { authenticate } from "../drivers/auth";
 import { sshOrScp } from "../plugins/ssh";
+import { getAppName } from "../util";
 import { prepareRequest, SshCommandArgs } from "./shared/ssh";
 import yargs from "yargs";
 
@@ -66,7 +67,7 @@ export const sshCommand = (yargs: yargs.Argv) =>
   Options passed to the underlying ssh implementation.
   The '--' argument must be specified between P0-specific args on the left and SSH_ARGS on the right. Example;
 
-  $ p0 ssh example-instance --provider gcloud -- -NR '*:8080:localhost:8088' -o 'GatewayPorts yes'`
+  $ ${getAppName()} ssh example-instance --provider gcloud -- -NR '*:8080:localhost:8088' -o 'GatewayPorts yes'`
         ),
 
     sshAction

--- a/src/common/install.ts
+++ b/src/common/install.ts
@@ -76,7 +76,7 @@ const queryInteractive = async () => {
       type: "confirm",
       name: "isGuided",
       message:
-        "Do you want P0 to install these for you (sudo access required)?",
+        "Do you want to install these automatically? (sudo access required)",
     },
   ]);
   print2("");

--- a/src/drivers/auth/index.ts
+++ b/src/drivers/auth/index.ts
@@ -13,10 +13,11 @@ import { setExporterAfterLogin } from "../../opentelemetry/instrumentation";
 import { Authn, Identity } from "../../types/identity";
 import { TokenResponse } from "../../types/oidc";
 import { OrgData } from "../../types/org";
+import { getAppName } from "../../util";
 import { tracesUrl } from "../api";
 import { authenticateToFirebase } from "../firestore";
 import { print2 } from "../stdio";
-import { EXPIRED_CREDENTIALS_MESSAGE } from "../util";
+import { getExpiredCredentialsMessage } from "../util";
 import { getIdentityCachePath, getIdentityFilePath } from "./path";
 import * as fs from "fs/promises";
 import * as path from "path";
@@ -96,7 +97,7 @@ export const loadCredentials = async (): Promise<Identity> => {
     return JSON.parse(buffer.toString());
   } catch (error: any) {
     if (error?.code === "ENOENT") {
-      throw "Please run `p0 login <organization>` to use the P0 CLI.";
+      throw `Please run \`${getAppName()} login <organization>\`.`;
     }
     throw error;
   }
@@ -115,7 +116,7 @@ const loadCredentialsWithAutoLogin = async (options?: {
   }
 
   if (options?.noRefresh) {
-    throw EXPIRED_CREDENTIALS_MESSAGE;
+    throw getExpiredCredentialsMessage();
   }
 
   await login(

--- a/src/drivers/firestore.ts
+++ b/src/drivers/firestore.ts
@@ -13,7 +13,7 @@ import { Identity } from "../types/identity";
 import { OrgData } from "../types/org";
 import { getContactMessage, loadConfig } from "./config";
 import { print2 } from "./stdio";
-import { EXPIRED_CREDENTIALS_MESSAGE } from "./util";
+import { getExpiredCredentialsMessage } from "./util";
 import { FirebaseApp, FirebaseError, initializeApp } from "firebase/app";
 import {
   EmailAuthCredential,
@@ -70,7 +70,7 @@ export const signInToTenant = async (
       error instanceof FirebaseError &&
       error.code === "auth/invalid-credential"
     ) {
-      throw EXPIRED_CREDENTIALS_MESSAGE;
+      throw getExpiredCredentialsMessage();
     } else {
       if (options?.debug) {
         if (error instanceof Error) {

--- a/src/drivers/util.ts
+++ b/src/drivers/util.ts
@@ -8,5 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-export const EXPIRED_CREDENTIALS_MESSAGE =
-  "Your credentials have expired. Please run `p0 login <organization>` to refresh your credentials.";
+import { getAppName } from "../util";
+
+export const getExpiredCredentialsMessage = () =>
+  `Your credentials have expired. Please run \`${getAppName()} login <organization>\` to refresh your credentials.`;

--- a/src/middlewares/version.ts
+++ b/src/middlewares/version.ts
@@ -57,7 +57,7 @@ export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
       if (isSea()) {
         print2(
           `╔═══════════════════════════════════════════════╗
-║ A new version of P0 CLI is available          ║
+║ A new version is available                    ║
 ║                                               ║
 ║ To install, download the latest version       ║
 ║ from the GitHub releases page:                ║
@@ -68,7 +68,7 @@ export const checkVersion = async (_yargs: yargs.ArgumentsCamelCase) => {
       } else {
         print2(
           `╔══════════════════════════════════════╗
-║ A new version of P0 CLI is available ║
+║ A new version is available           ║
 ║                                      ║
 ║ To install, run                      ║
 ║   npm -g update ${name.padEnd(20)} ║

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { PRIVATE_KEY_PATH, saveHostKeys } from "../../common/keys";
 import { submitPublicKey } from "../../drivers/api";
 import { SshProvider } from "../../types/ssh";
-import { throwAssertNever } from "../../util";
+import { getAppName, throwAssertNever } from "../../util";
 import { assumeRoleWithOktaSaml } from "../okta/aws";
 import { getAwsConfig } from "./config";
 import { assumeRoleWithIdc } from "./idc";
@@ -64,7 +64,7 @@ export const awsSshProvider: SshProvider<
   cloudProviderLogin: async (authn, request, debug) => {
     const { config } = await getAwsConfig(authn, request.accountId, debug);
     if (!config.login?.type || config.login?.type === "iam") {
-      throw "This account is not configured for SSH access via the P0 CLI";
+      throw "This account is not configured for SSH access";
     }
 
     return config.login?.type === "idc"
@@ -120,7 +120,7 @@ export const awsSshProvider: SshProvider<
     // TODO: Add manual commands for IDC login
     if (request.access !== "idc") {
       return [
-        `eval $(p0 aws role assume ${request.role} --account ${request.accountId})`,
+        `eval $(${getAppName()} aws role assume ${request.role} --account ${request.accountId})`,
       ];
     }
     return undefined;

--- a/src/plugins/kubeconfig/index.ts
+++ b/src/plugins/kubeconfig/index.ts
@@ -14,7 +14,7 @@ import { request } from "../../commands/shared/request";
 import { fetchIntegrationConfig } from "../../drivers/api";
 import { Authn } from "../../types/identity";
 import { PermissionRequest } from "../../types/request";
-import { assertNever } from "../../util";
+import { assertNever, getAppName } from "../../util";
 import { getAwsConfig } from "../aws/config";
 import { assumeRoleWithIdc } from "../aws/idc";
 import { AwsCredentials } from "../aws/types";
@@ -60,7 +60,7 @@ export const getAndValidateK8sIntegration = async (
   if (hosting.type !== "aws") {
     throw (
       `This command currently only supports AWS EKS clusters, and ${clusterId} is not configured as one.\n` +
-      "You can request access to the cluster using the `p0 request k8s` command."
+      `You can request access to the cluster using the \`${getAppName()} request k8s\` command.`
     );
   }
 
@@ -71,7 +71,7 @@ export const getAndValidateK8sIntegration = async (
 
   // Verify that the AWS auth type is supported before issuing the requests
   if (!awsLogin?.type || awsLogin?.type === "iam") {
-    throw "This AWS account is not configured for kubectl access via the P0 CLI.\nYou can request access to the cluster using the `p0 request k8s` command.";
+    throw `This AWS account is not configured for kubectl access.\nYou can request access to the cluster using the \`${getAppName()} request k8s\` command.`;
   }
 
   return {

--- a/src/plugins/oidc/login.ts
+++ b/src/plugins/oidc/login.ts
@@ -112,7 +112,7 @@ export const oidcLoginSteps = (
 ) => {
   const { deviceAuthorizationUrl, tokenUrl } = urls();
   if (org.providerType === undefined) {
-    throw "Your organization's login configuration does not support this access. Your P0 admin will need to install a supported OIDC provider in order for you to use this command.";
+    throw "Your organization's login configuration does not support this access. Your admin will need to install a supported OIDC provider in order for you to use this command.";
   }
   const buildOidcAuthorizeRequest = () => {
     validateProviderDomain(org);

--- a/src/plugins/self-hosted/ssh.ts
+++ b/src/plugins/self-hosted/ssh.ts
@@ -11,6 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { isSudoCommand } from "../../commands/shared/ssh";
 import { createKeyPair } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
+import { getAppName } from "../../util";
 import { createTempDirectoryForKeys } from "../ssh/shared";
 import { generateSelfHostedCertificate } from "./keygen";
 import { SelfHostedSshPermissionSpec, SelfHostedSshRequest } from "./types";
@@ -40,7 +41,9 @@ export const selfHostedSshProvider: SshProvider<
 
   friendlyName: "Self-hosted",
 
-  loginRequiredMessage: "Please login to P0 CLI with 'p0 login'",
+  get loginRequiredMessage() {
+    return `Please login with '${getAppName()} login'`;
+  },
 
   propagationTimeoutMs: PROPAGATION_TIMEOUT_LIMIT_MS,
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,10 +12,13 @@ import { defaultConfig } from "./drivers/env";
 import child_process from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { env } from "node:process";
+import process from "node:process";
 import { sys } from "typescript";
 
-export const getAppPath = () => env.P0_APP_PATH ?? "p0";
+export const getAppPath = () =>
+  process.env.P0_APP_PATH ?? process.argv[1] ?? "p0";
+
+export const getAppName = () => path.basename(getAppPath());
 
 export const P0_PATH = path.join(
   os.homedir(),


### PR DESCRIPTION
- Clean up messaging, using a dynamic name for the executable, instead of a hard-coded `p0`.`