### PR TITLE
Gcloud SSH: Fallback to local SSH public key for OS Login Import

### DIFF
--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -209,7 +209,7 @@ export const provisionRequest = async (
 
 const pluginToCliRequest = async (
   request: PermissionRequest<PluginSshRequest>,
-  options?: { debug?: boolean }
+  options: { debug?: boolean; publicKey: string }
 ): Promise<PermissionRequest<CliSshRequest>> =>
   await SSH_PROVIDERS[request.permission.provider].toCliRequest(
     request as any,
@@ -241,7 +241,10 @@ export const prepareRequest = async (
 
   await sshProvider.ensureInstall();
 
-  const cliRequest = await pluginToCliRequest(provisionedRequest, args);
+  const cliRequest = await pluginToCliRequest(provisionedRequest, {
+    ...args,
+    publicKey,
+  });
 
   const request = sshProvider.requestToSsh(cliRequest);
 

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -50,6 +50,13 @@ export const importSshKey = async (
     print2(
       `Retrieved access token ${accessToken.slice(0, 10)}... for account ${account}`
     );
+    print2(
+      `Importing public key: ${publicKey || "<invalid>"} for account ${account}`
+    );
+  }
+
+  if (!publicKey) {
+    throw "Missing SSH public key. Import failed.";
   }
 
   const url = `https://oslogin.googleapis.com/v1/users/${account}:importSshPublicKey`;

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -129,12 +129,7 @@ export const gcpSshProvider: SshProvider<
   toCliRequest: async (request, options) => ({
     ...request,
     cliLocalData: {
-      linuxUserName: await importSshKey(
-        // fallback to the local public key if the one in the request object is missing, which
-        // can happen if, for example, the request was created using the Slack modal or web app
-        request.permission.publicKey ?? options.publicKey,
-        options
-      ),
+      linuxUserName: await importSshKey(options.publicKey, options),
     },
   }),
 };

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -129,7 +129,12 @@ export const gcpSshProvider: SshProvider<
   toCliRequest: async (request, options) => ({
     ...request,
     cliLocalData: {
-      linuxUserName: await importSshKey(request.permission.publicKey, options),
+      linuxUserName: await importSshKey(
+        // fallback to the local public key if the one in the request object is missing, which
+        // can happen if, for example, the request was created using the Slack modal or web app
+        request.permission.publicKey ?? options.publicKey,
+        options
+      ),
     },
   }),
 };

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -173,7 +173,7 @@ export type SshProvider<
   /** Converts a backend request to a CLI request */
   toCliRequest: (
     request: PermissionRequest<PR>,
-    options?: { debug?: boolean }
+    options: { debug?: boolean; publicKey: string }
   ) => Promise<PermissionRequest<CliSshRequest>>;
 };
 


### PR DESCRIPTION
This change fixes a bug where in some circumstances, the request object won't contain a public key due to the manner in which it was originally requested. In those situations, the public key won't get imported into the user's Google account, preventing them from SSH-ing into gcloud VMs.

This change resolves this issue by instead using whichever SSH public key is currently on the user's machine (in the `~/.p0/ssh` folder).

Additionally, to improve error handling by failing more quickly, `importSshKey` throws if the public key is missing.

