### PR TITLE
Fix SSH hanging on exit by killing orphaned child processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {


### PR DESCRIPTION
When SSH spawns with a ProxyCommand (e.g., aws ssm start-session), the ProxyCommand spawns session-manager-plugin. On SSH exit, especially during the access propagation retry loop, these child processes may not terminate properly, leaving them holding the stderr pipe and preventing the CLI from exiting.

Solution: Spawn SSH in a detached process group on Unix, then explicitly kill the entire process tree when retrying failed attempts and on parent termination signals. This ensures aws ssm start-session and session-manager-plugin are properly terminated.

See: https://github.com/aws/amazon-ssm-agent/issues/173

🤖 Generated with [Claude Code](https://claude.com/claude-code)