### PR TITLE
respect the --size argument when using --json

### DIFF
--- a/src/commands/__tests__/ls.test.ts
+++ b/src/commands/__tests__/ls.test.ts
@@ -107,6 +107,68 @@ describe("ls", () => {
     });
   });
 
+  describe("when --json flag is used", () => {
+    const makeItems = (count: number) =>
+      Array.from({ length: count }, (_, i) => ({
+        key: `instance-${i + 1}`,
+        value: `Resource ${i + 1}`,
+      }));
+
+    const parseJsonOutput = () => {
+      expect(mockPrint1).toHaveBeenCalledTimes(1);
+      return JSON.parse(mockPrint1.mock.calls[0]![0]);
+    };
+
+    it("should truncate items to the requested --size", async () => {
+      const items = makeItems(10);
+      mockItems(items);
+      await lsCommand(yargs())
+        .exitProcess(false)
+        .parse("ls ssh destination --json --size 3");
+
+      const parsed = parseJsonOutput();
+      expect(parsed.ok).toBe(true);
+      expect(parsed.term).toBe("");
+      expect(parsed.arg).toBe("destination");
+      expect(parsed.items).toEqual(items.slice(0, 3));
+      expect(mockPrint2).not.toHaveBeenCalled();
+    });
+
+    it("should cap items at the default size (15) when --size is omitted", async () => {
+      mockItems(makeItems(20));
+      await lsCommand(yargs())
+        .exitProcess(false)
+        .parse("ls ssh destination --json");
+
+      const parsed = parseJsonOutput();
+      expect(parsed.items).toHaveLength(15);
+    });
+
+    it("should request double the requested size from the backend", async () => {
+      mockItems(makeItems(10));
+      await lsCommand(yargs())
+        .exitProcess(false)
+        .parse("ls ssh destination --json --size 4");
+
+      expect(mockFetchCommand).toHaveBeenCalledTimes(1);
+      const allArguments = mockFetchCommand.mock.calls[0]![2];
+      const sizeIdx = allArguments.indexOf("--size");
+      expect(sizeIdx).toBeGreaterThanOrEqual(0);
+      expect(allArguments[sizeIdx + 1]).toBe("8");
+    });
+
+    it("should not pad items when fewer items than --size are returned", async () => {
+      const items = makeItems(2);
+      mockItems(items);
+      await lsCommand(yargs())
+        .exitProcess(false)
+        .parse("ls ssh destination --json --size 10");
+
+      const parsed = parseJsonOutput();
+      expect(parsed.items).toEqual(items);
+    });
+  });
+
   describe("when error", () => {
     const command = "ls foo";
 

--- a/src/commands/ls.ts
+++ b/src/commands/ls.ts
@@ -113,8 +113,10 @@ const ls = async (
   const data = await spinUntil("Listing accessible resources", responsePromise);
 
   if (data && "ok" in data && data.ok) {
+    const truncated = slice(data.items, 0, args.size);
+
     if (args.json) {
-      print1(JSON.stringify(data, null, 2));
+      print1(JSON.stringify({ ...data, items: truncated }, null, 2));
       return;
     }
 
@@ -138,7 +140,6 @@ const ls = async (
       ? "" // do not show who they are accessible to because we are displaying all items
       : `\nResources labeled with * are already accessible to ${accessibleTo}:`;
     print2(`Showing${truncationPart} ${label}${postfixPart}.${accessiblePart}`);
-    const truncated = slice(data.items, 0, args.size);
     const sortedItems = orderBy(truncated, "isPreexisting", "desc");
     const isSameValue = sortedItems.every((i) => !i.group && i.key === i.value);
     const maxLength = max(sortedItems.map((i) => i.key.length)) || 0;


### PR DESCRIPTION
**Problem**

Using the `--json` flag with `--size` returns roughly double the # of results. This is happening because our `--json` output finishes early without respecting the `--size` flag. 

**Change**

When returning values from `--json` use the `truncated` list of items which respects the argument provided in `--size`

**Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Manually testing

**Tracking (optional)**

https://linear.app/p0-security/issue/ENG-7030/size-argument-shows-2x-results-when-used-with-json

**Attachments (optional)**

[test.json](https://github.com/user-attachments/files/26616675/test.json)

**Follow-up Work (optional)**

None