### PR TITLE
Update cli to retry polling for request status in case of connection termination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.26.7",
+  "version": "0.26.8",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/__tests__/request.test.ts
+++ b/src/commands/__tests__/request.test.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { fetchCommand, fetchStreamingCommand } from "../../drivers/api";
+import { fetchCommand, fetchStreamingStatus } from "../../drivers/api";
 import { print1, print2 } from "../../drivers/stdio";
 import { failure } from "../../testing/yargs";
 import { RequestResponse } from "../../types/request";
@@ -20,7 +20,7 @@ import yargs from "yargs";
 vi.mock("../../drivers/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../drivers/api")>()),
   fetchCommand: vi.fn(),
-  fetchStreamingCommand: vi.fn(), // Add this
+  fetchStreamingStatus: vi.fn(), // Add this
   streamingApiFetch: vi.fn(),
 }));
 vi.mock("../../drivers/auth");
@@ -31,7 +31,7 @@ vi.mock("../../drivers/stdio", async (importOriginal) => ({
 }));
 
 const mockFetchCommand = fetchCommand as Mock;
-const mockFetchStreamingCommand = fetchStreamingCommand as Mock;
+const mockFetchStreamingStatus = fetchStreamingStatus as Mock;
 const mockPrint1 = print1 as Mock;
 const mockPrint2 = print2 as Mock;
 
@@ -75,16 +75,15 @@ describe("request", () => {
        * This test checks that the request command waits for access to be granted
        * before resolving the promise.
        */
-      mockFetchStreamingCommand.mockImplementation(async function* () {
-        yield {
-          ok: true,
-          message: "a message",
-          id: "abcefg",
-          isPreexisting: false,
-          isPersistent: false,
-          request: { status: "NEW" },
-        };
-        await sleep(200);
+      mockFetchCommand.mockImplementation(() => ({
+        ok: true,
+        message: "a message",
+        id: "abcefg",
+        isPreexisting: false,
+        isPersistent: false,
+        request: { status: "NEW" },
+      }));
+      mockFetchStreamingStatus.mockImplementation(async function* () {
         yield {
           ok: true,
           message: "Request approved",
@@ -131,16 +130,16 @@ Unknown argument: foo`,
     });
 
     it("should handle stream errors", async () => {
-      mockFetchStreamingCommand.mockImplementation(async function* () {
-        yield {
-          ok: true,
-          message: "a message",
-          id: "abcefg",
-          isPreexisting: false,
-          isPersistent: false,
-          request: { status: "NEW" },
-        };
-        await sleep(200);
+      mockFetchCommand.mockImplementation(() => ({
+        ok: true,
+        message: "a message",
+        id: "abcefg",
+        isPreexisting: false,
+        isPersistent: false,
+        request: { status: "NEW" },
+      }));
+      mockFetchStreamingStatus.mockImplementation(async function* () {
+        await sleep(100);
         throw new TypeError("terminated");
       });
       const command = "request gcloud role viewer --wait";

--- a/src/commands/__tests__/ssh.test.ts
+++ b/src/commands/__tests__/ssh.test.ts
@@ -10,9 +10,10 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { TEST_PUBLIC_KEY } from "../../common/__mocks__/keys";
 import {
+  fetchCommand,
   fetchIntegrationConfig,
   fetchSshHostKeys,
-  fetchStreamingCommand,
+  fetchStreamingStatus,
 } from "../../drivers/api";
 import { print1, print2 } from "../../drivers/stdio";
 import { AwsSshGenerated, AwsSshPermission } from "../../plugins/aws/types";
@@ -36,8 +37,9 @@ vi.mock("../../common/keys");
 const mockSshOrScp = sshOrScp as Mock;
 const mockPrint1 = print1 as Mock;
 const mockPrint2 = print2 as Mock;
+const mockFetchCommand = fetchCommand as Mock;
 const mockIntegrationConfig = fetchIntegrationConfig as Mock;
-const mockFetchStreamingCommand = fetchStreamingCommand as Mock;
+const mockFetchStreamingStatus = fetchStreamingStatus as Mock;
 const mockFetchSshHostKeys = fetchSshHostKeys as Mock;
 
 const MOCK_PERMISSION: AwsSshPermission = {
@@ -90,15 +92,15 @@ describe("ssh", () => {
     isPersistent: boolean,
     sleep?: () => Promise<void>
   ) => {
-    mockFetchStreamingCommand.mockImplementationOnce(async function* () {
-      yield {
-        ok: true,
-        message: "a message",
-        id: "abcefg",
-        isPreexisting: false,
-        isPersistent,
-        request: { status: "NEW" },
-      };
+    mockFetchCommand.mockImplementationOnce(() => ({
+      ok: true,
+      message: "a message",
+      id: "abcefg",
+      isPreexisting: false,
+      isPersistent,
+      request: { status: "NEW" },
+    }));
+    mockFetchStreamingStatus.mockImplementationOnce(async function* () {
       await sleep?.();
       yield {
         ok: true,
@@ -125,7 +127,8 @@ describe("ssh", () => {
     });
 
     afterEach(() => {
-      mockFetchStreamingCommand.mockReset();
+      mockFetchCommand.mockReset();
+      mockFetchStreamingStatus.mockReset();
     });
     it("should call p0 request with reason arg", async () => {
       mockStreaming(isPersistent);
@@ -135,7 +138,7 @@ describe("ssh", () => {
       // await for the first response to yield
       await sleep(10);
       const hiddenFilenameRequestArgs = omit(
-        mockFetchStreamingCommand.mock.calls[0]?.[1],
+        mockFetchCommand.mock.calls[0]?.[1],
         "$0"
       );
       expect(hiddenFilenameRequestArgs).toMatchSnapshot("args");

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -20,6 +20,7 @@ import {
   PluginRequest,
   RequestResponse,
 } from "../../types/request";
+import { sleep } from "../../util";
 import { trace } from "@opentelemetry/api";
 import { sys } from "typescript";
 import yargs from "yargs";
@@ -29,6 +30,12 @@ export const PROVISIONING_ACCESS_MESSAGE =
 export const EXISTING_ACCESS_MESSAGE = "Existing access found.";
 export const ACCESS_EXISTS_ERROR_MESSAGE =
   "This principal already has this access";
+
+export const ACCESS_WAIT_TIMEOUT_ERROR_MESSAGE =
+  "Failed waiting for access to be resolved";
+
+// 10 minutes of max request timeout including retries
+const MAX_REQUEST_TIMEOUT = 10 * 60 * 1000;
 
 const APPROVED = { message: "Your request was approved", code: 0 };
 const DENIED = { message: "Your request was denied", code: 2 };
@@ -122,6 +129,7 @@ export const request =
     options?: {
       accessMessage?: string;
       message?: "all" | "approval-required" | "none" | "quiet";
+      timeOut?: number;
     }
   ): Promise<RequestResponse<T> | undefined> => {
     const resolvedAuthn = authn ?? (await authenticate());
@@ -204,8 +212,16 @@ export const request =
       throw data;
     };
 
+    const timeoutOperation = async () => {
+      await sleep(options?.timeOut ?? MAX_REQUEST_TIMEOUT);
+      throw ACCESS_WAIT_TIMEOUT_ERROR_MESSAGE;
+    };
+
     try {
-      return await (!args.wait ? invokeRequest() : executeStreamingRequest());
+      return await Promise.race([
+        !args.wait ? invokeRequest() : executeStreamingRequest(),
+        timeoutOperation(),
+      ]);
     } catch (error: any) {
       if (error instanceof Error && error.name === "TimeoutError") {
         print2("Connection to P0 timed out.");

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -8,8 +8,10 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { fetchCommand, fetchStreamingCommand } from "../../drivers/api";
+import { retryWithSleep } from "../../common/retry";
+import { fetchCommand, fetchStreamingStatus } from "../../drivers/api";
 import { authenticate } from "../../drivers/auth";
+import { RETRY_OPTIONS } from "../../drivers/constants";
 import { print2, spinUntil } from "../../drivers/stdio";
 import { markSpanError } from "../../opentelemetry/otel-helpers";
 import { Authn } from "../../types/identity";
@@ -158,38 +160,34 @@ export const request =
       }
     };
 
-    const invokeRequest = async () => {
-      const fetchCommandPromise = fetchCommand<RequestResponse<T>>(
-        resolvedAuthn,
-        args,
-        [command, ...args.arguments]
+    const executeAndProcessApiRequest = async () => {
+      const fetchCommandPromise = retryWithSleep(
+        () =>
+          fetchCommand<RequestResponse<T>>(resolvedAuthn, args, [
+            command,
+            ...args.arguments,
+          ]),
+        RETRY_OPTIONS
       );
-      const response = await executeApiRequest(fetchCommandPromise);
-      const { data, shouldLogMessage } = processResponse(response);
+      return processResponse(await executeApiRequest(fetchCommandPromise));
+    };
+
+    const invokeRequest = async () => {
+      const { data, shouldLogMessage } = await executeAndProcessApiRequest();
       if (shouldLogMessage) print2(data.message);
       return data;
     };
 
     const executeStreamingRequest = async () => {
-      const fetchStreamingCommandGenerator = fetchStreamingCommand<
-        RequestResponse<T>
-      >(resolvedAuthn, args, [command, ...args.arguments], args.debug);
-      const getNextPermissionRequestChunk = async () => {
-        const generatedValue = await fetchStreamingCommandGenerator.next();
-        if (generatedValue.done) {
-          return undefined;
-        }
-        return generatedValue.value;
-      };
-      const firstChunk = await executeApiRequest(
-        getNextPermissionRequestChunk()
-      );
-      const { data, shouldLogMessage } = processResponse(firstChunk);
+      const { data, shouldLogMessage } = await executeAndProcessApiRequest();
       if (shouldLogMessage) {
         print2(data.message);
         print2("Will wait up to 5 minutes for this request to complete...");
       }
-      for await (const chunkData of fetchStreamingCommandGenerator) {
+      const fetchStreamingStatusGenerator = fetchStreamingStatus<
+        RequestResponse<T>
+      >(resolvedAuthn, data.id, args.debug);
+      for await (const chunkData of fetchStreamingStatusGenerator) {
         if (!chunkData) {
           throw new Error("Errored waiting for request to complete");
         }

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -12,24 +12,11 @@ import { regenerateWithSleep, retryWithSleep } from "../common/retry";
 import { Authn } from "../types/identity";
 import { getUserAgent } from "../version";
 import { getAppUrl, getTenantConfig } from "./config";
+import { RETRY_OPTIONS } from "./constants";
 import { print2 } from "./stdio";
+import { isNetworkError } from "./util";
 import * as path from "node:path";
 import yargs from "yargs";
-
-const isNetworkError = (error: unknown) =>
-  error instanceof TypeError &&
-  (error.message === "fetch failed" || error.message === "terminated");
-
-// We retry with these delays: 1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s
-// for a total of 121s wait time over 8 retries (ignoring jitter)
-const RETRY_OPTIONS = {
-  shouldRetry: (error: unknown) =>
-    error === "HTTP Error: 429 Too Many Requests" || isNetworkError(error),
-  retries: 8,
-  delayMs: 1_000,
-  multiplier: 2.0,
-  maxDelayMs: 30_000,
-};
 
 const tenantOrgUrl = (tenant: string) => `${getAppUrl()}/orgs/${tenant}`;
 const tenantUrl = (tenant: string) => `${getTenantConfig().appUrl}/o/${tenant}`;
@@ -43,6 +30,8 @@ const sshAuditUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/audit`;
 
 const commandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/`;
+const requestStatusUrl = (tenant: string, requestId: string) =>
+  `${commandUrl(tenant)}/${requestId}/poll`;
 const adminLsCommandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/ls`;
 export const tracesUrl = (tenant: string) => `${tenantUrl(tenant)}/traces`;
 
@@ -67,22 +56,16 @@ export const fetchIntegrationConfig = async <T>(
     debug,
   });
 
-export const fetchStreamingCommand = async function* <T>(
+export const fetchStreamingStatus = async function* <T>(
   authn: Authn,
-  args: yargs.ArgumentsCamelCase,
-  argv: string[],
+  requestId: string,
   debug?: boolean
 ) {
   yield* fetchWithStreaming<T>(
     authn,
     {
-      url: commandUrl(authn.identity.org.slug),
-      method: "POST",
-      body: JSON.stringify({
-        argv,
-        scriptName: path.basename(args.$0),
-        wait: true,
-      }),
+      url: requestStatusUrl(authn.identity.org.slug, requestId),
+      method: "GET",
     },
     debug
   );

--- a/src/drivers/constants.ts
+++ b/src/drivers/constants.ts
@@ -8,11 +8,15 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { getAppName } from "../util";
+import { isNetworkError } from "./util";
 
-export const getExpiredCredentialsMessage = () =>
-  `Your credentials have expired. Please run \`${getAppName()} login <organization>\` to refresh your credentials.`;
-
-export const isNetworkError = (error: unknown) =>
-  error instanceof TypeError &&
-  (error.message === "fetch failed" || error.message === "terminated");
+// We retry with these delays: 1s, 2s, 4s, 8s, 16s, 30s, 30s, 30s
+// for a total of 121s wait time over 8 retries (ignoring jitter)
+export const RETRY_OPTIONS = {
+  shouldRetry: (error: unknown) =>
+    error === "HTTP Error: 429 Too Many Requests" || isNetworkError(error),
+  retries: 8,
+  delayMs: 1_000,
+  multiplier: 2.0,
+  maxDelayMs: 30_000,
+};


### PR DESCRIPTION
## Problem

When a CLI command requires waiting for a request to complete (e.g. SSH access), the previous implementation used a single streaming connection that combined request submission and status polling into one long-lived HTTP POST. If that connection was interrupted due to a transient network error, the entire flow would fail — requiring the user to re-run the command, which would submit a duplicate request.

## Change

This PR decouples request submission from status polling and adds retry logic to the status polling phase:

- Replaces `fetchStreamingCommand` (a single streaming POST that both created and polled the request) with two distinct steps:
  1. `fetchCommand` — submits the request once, returns a request ID
  2. `fetchStreamingStatus` — polls the request status by ID via a separate GET endpoint
- Adds `retryWithSleep` around `fetchCommand` so transient network errors during submission are also retried
- Adds an outer retry loop around `fetchStreamingStatus` that retries on `"Network error: Unable to reach the server."` for up to 5 minutes, without re-submitting the original request
- Extracts `RETRY_OPTIONS` and `isNetworkError` into shared modules (`constants.ts`, `util.ts`) for reuse across `api.ts` and `request.ts`

Affected areas: **workflow**

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (code changes that neither fix bugs nor add features)

## Validation

Validated manually by:
1. Running a command that waits for request approval (e.g. `p0 request ssh ... --wait`)
2. Once status polling begins, killing the backend service briefly
3. Confirming `"Network error encountered. Retrying..."` is printed
4. Restoring the backend and confirming the CLI resumes polling the same request ID and resolves normally without creating a duplicate request

No duplicate requests are created during retry because `fetchCommand` is called only once, before the retry loop begins.

## Implementation

The two-layer retry design is intentional:

- **Inner layer** (`regenerateWithSleep` in `fetchWithStreaming`): handles low-level TCP errors (`TypeError: terminated`, `fetch failed`) with exponential backoff up to ~121s
- **Outer layer** (`retryWithSleep` wrapping `pollStatus`): kicks in after the inner layer exhausts its retries, retrying the entire poll attempt for up to 5 minutes from first failure

## Tracking

ENG-7707