### PR TITLE
SSH: return the complete data in request instead of status chunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.26.8",
+  "version": "0.26.9",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -207,7 +207,10 @@ export const request =
           sys.exit(code);
           return undefined;
         }
-        return chunkData;
+        return {
+          ...data,
+          ...chunkData,
+        };
       }
       throw data;
     };


### PR DESCRIPTION
**Problem**:

Customers were not able to ssh into new instances with v0.26.8. 

**Change**:

The status api does not return the complete request object that was returned in v0.26.7. This fix imitates the old behaviour.

**Tracking**:

Cus-121


