### PR TITLE
display debug cli repro commands on every ssh provider

### DIFF
--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -596,16 +596,14 @@ export const sshOrScp = async (args: {
     );
 
     if (debug) {
-      const reproCommands = sshProvider.reproCommands(request, setupData);
-      if (reproCommands) {
-        const repro = [
-          ...reproCommands,
-          `${command} ${transformForShell(commandArgs).join(" ")}`,
-        ].join("\n");
-        print2(
-          `Execute the following commands to create a similar SSH/SCP session:\n*** COMMANDS BEGIN ***\n${repro}\n*** COMMANDS END ***"\n`
-        );
-      }
+      const reproCommands = sshProvider.reproCommands(request, setupData) ?? [];
+      const repro = [
+        ...reproCommands,
+        `${command} ${transformForShell(commandArgs).join(" ")}`,
+      ].join("\n");
+      print2(
+        `Execute the following commands to create a similar SSH/SCP session:\n*** COMMANDS BEGIN ***\n${repro}\n*** COMMANDS END ***"\n`
+      );
     }
 
     const endTime = Date.now() + sshProvider.propagationTimeoutMs;
@@ -718,6 +716,10 @@ export const sshProxy = async (args: {
   }
 
   const proxyArgs = proxyCommand.slice(1);
+
+  if (debug) {
+    print2(`Executing proxy command: ${command} ${proxyArgs.join(" ")}`);
+  }
 
   const endTime = Date.now() + sshProvider.propagationTimeoutMs;
 


### PR DESCRIPTION
This is a small PR that prints more debug statements for SSH requests. This makes it easier to troubleshoot any issues with GCP/Azure because AWS currently has some output:

Sample output
```
Picked linux user name: miguel_campos_p0_dev
Execute the following commands to create a similar SSH/SCP session:
*** COMMANDS BEGIN ***
ssh -o PreferredAuthentications=publickey -o PasswordAuthentication=no -i /Users/miguelcampos/.p0-dev/ssh/id_rsa -o IdentitiesOnly=yes -o ProxyCommand='gcloud compute start-iap-tunnel test-micro2 %p --listen-on-stdin --zone=us-west1-a --project=p0-gcp-project' -v miguel_campos_p0_dev@test-micro2
*** COMMANDS END ***"

Waiting for access to propagate. Trying SSH session... (will wait up to 120.0 seconds)
debug1: OpenSSH_10.2p1, LibreSSL 3.3.6

debug1: Reading configuration data /Users/miguelcampos/.ssh/config
debug1: /Users/miguelcampos/.ssh/config line 7: Applying options for *

debug1: Executing command: 'p0 ssh-resolve test-micro2'

Checking for access in P0
```