### PR TITLE
google: Use select_account login prompt

### DIFF
--- a/src/plugins/google/login.ts
+++ b/src/plugins/google/login.ts
@@ -35,6 +35,9 @@ const requestAuth = async () => {
     client_id: tenantConfig.google.clientId,
     code_challenge: pkce.code_challenge,
     code_challenge_method: "S256",
+    // If the user has multiple Google logins on the device, they'll need to select
+    // which account to use. Force this with the "select_account" prompt.
+    prompt: "select_account",
     redirect_uri: GOOGLE_OIDC_REDIRECT_URL,
     response_type: "code",
     scope: "openid email",

--- a/src/plugins/oidc/login.ts
+++ b/src/plugins/oidc/login.ts
@@ -146,6 +146,7 @@ export const oidcLoginSteps = (
       url: deviceAuthorizationUrl,
     };
   };
+
   const buildOidcTokenRequest = (authorize: AuthorizeResponse) => {
     validateProviderDomain(org);
 

--- a/src/plugins/okta/login.ts
+++ b/src/plugins/okta/login.ts
@@ -28,6 +28,7 @@ import {
 } from "../oidc/login";
 import * as cheerio from "cheerio";
 import { omit } from "lodash";
+import assert from "node:assert";
 
 const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 const ID_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:id_token";
@@ -138,9 +139,14 @@ export const oktaLogin = async (org: OrgData) =>
       const providerType = getProviderType(org);
       const providerDomain = getProviderDomain(org);
 
-      if (providerType !== "okta" || !providerDomain) {
-        throw `Invalid provider configuration (expected okta OIDC provider)`;
-      }
+      assert(
+        providerType === "okta",
+        "Invalid provider configuration (expected okta OIDC provider)"
+      );
+      assert(
+        providerDomain,
+        "Invalid provider configuration (missing Okta domain)"
+      );
       return {
         deviceAuthorizationUrl: `https://${providerDomain}/oauth2/v1/device/authorize`,
         tokenUrl: `https://${providerDomain}/oauth2/v1/token`,

--- a/src/types/oidc.ts
+++ b/src/types/oidc.ts
@@ -12,13 +12,14 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 export type AuthorizeRequest = {
   client_id: string;
-  code_challenge: string;
   code_challenge_method: "plain" | "S256";
+  code_challenge: string;
+  login_hint?: string;
+  prompt?: string;
   redirect_uri: string;
   response_type: "code";
   scope: string;
   state?: string;
-  login_hint?: string;
 };
 
 export type AuthorizeResponse = {


### PR DESCRIPTION
**Problem**

Currently, logins via Google Workspace will use whatever selected account exists in the opened browser window.

This can inadvertently lead to login with the incorrect account if the account does not match user intention. This happens, for instance, if the user has a personal profile window logged in to their personal account, rather than their employee account.

**Change**

To prevent this, always force the user to select an account. If the auth is opened in the incorrect window they can follow the OIDC URL in the correct browser window prior to proceeding.

Check off any of the following areas of code that are modified:

- [x] authentication / authorization

**Type of Change**

- [x] New feature (non-breaking change that adds functionality)

**Validation**

Validated via manual login with Google Workspace.

