### PR TITLE
Improvements to rds subcommand logic

### DIFF
--- a/src/commands/aws/rds.ts
+++ b/src/commands/aws/rds.ts
@@ -15,7 +15,7 @@ import { parseArn } from "../../plugins/aws/utils";
 import { DbPermissionSpec } from "../../plugins/db/types";
 import { Authn } from "../../types/identity";
 import { PermissionRequest } from "../../types/request";
-import { exec, throwAssertNever } from "../../util";
+import { exec, osSafeCommand, throwAssertNever } from "../../util";
 import { decodeProvisionStatus } from "../shared";
 import { request } from "../shared/request";
 import { writeAwsConfigProfile, writeAwsTempCredentials } from "./files";
@@ -39,10 +39,10 @@ type DbConfig = {
   "iam-write": Record<string, DatabaseConfig>;
 };
 
-type DbResourceKey = "mysql" | "pg2";
+type DbResourceKey = "mysql" | "postgres";
 
 type RdsArgs = yargs.ArgumentsCamelCase<{
-  arch: "mysql" | "pg";
+  arch: DbResourceKey;
   database?: string;
   debug?: boolean;
   instance?: string;
@@ -66,7 +66,7 @@ export const rds = (
           y
             .option("arch", {
               type: "string",
-              choices: ["mysql", "pg"] as const,
+              choices: ["mysql", "postgres"] as const,
               demandOption: true,
               describe: "Database architecture; use 'mysql' for MariaDB",
             })
@@ -92,15 +92,8 @@ export const rds = (
       )
   );
 
-const argvToResource = (argv: RdsArgs): DbResourceKey =>
-  argv.arch === "mysql"
-    ? "mysql"
-    : argv.arch === "pg"
-      ? "pg2"
-      : throwAssertNever(argv.arch);
-
 const requestRdsAccess = async (argv: RdsArgs, authn: Authn) => {
-  const integration = argvToResource(argv);
+  const integration = argv.arch;
 
   const response = await request("request")<
     PermissionRequest<DbPermissionSpec>
@@ -143,7 +136,7 @@ const fetchConfig = async (
   const { instanceId } = access.permission;
   const install = await fetchIntegrationConfig<{ config: DbConfig }>(
     authn,
-    argvToResource(argv),
+    argv.arch,
     argv.debug
   );
   const config = install.config["iam-write"]?.[instanceId];
@@ -168,7 +161,7 @@ const rdsGenerateDbAuthToken = async (argv: RdsArgs, authn: Authn) => {
     dbConfig.port ??
     (argv.arch === "mysql"
       ? 3306
-      : argv.arch === "pg"
+      : argv.arch === "postgres"
         ? 5432
         : throwAssertNever(argv.arch));
 
@@ -205,9 +198,11 @@ const rdsGenerateDbAuthToken = async (argv: RdsArgs, authn: Authn) => {
     profileName,
   ];
 
-  const result = await exec("aws", generateTokenArgs, { check: true });
+  const { command, args } = osSafeCommand("aws", generateTokenArgs);
 
-  const pgInstructions = `export PGPASSWORD="${result.stdout}"
+  const result = await exec(command, args, { check: true });
+
+  const pgInstructions = `export PGPASSWORD="${result.stdout.trim()}"
   
   psql "host=$\{RDS_HOST} port=${port} sslmode=verify-full sslrootcert=$\{RDS_SSL_CA} ${database ? `dbname=${database} ` : ""}user=${userName}"`;
 
@@ -226,7 +221,7 @@ On CloudShell, you can execute:
 
   export RDS_SSL_CA='/certs/global-bundle.pem'
   export RDS_HOST='${dbConfig.hostname}'
-  ${argv.arch === "mysql" ? mysqlInstructions : argv.arch === "pg" ? pgInstructions : throwAssertNever(argv.arch)}
+  ${argv.arch === "mysql" ? mysqlInstructions : argv.arch === "postgres" ? pgInstructions : throwAssertNever(argv.arch)}
 
 `);
 

--- a/src/commands/aws/rds.ts
+++ b/src/commands/aws/rds.ts
@@ -39,7 +39,9 @@ type DbConfig = {
   "iam-write": Record<string, DatabaseConfig>;
 };
 
-type DbResourceKey = "mysql" | "postgres";
+const DbResourceKeys = ["mysql", "postgres"] as const;
+
+type DbResourceKey = (typeof DbResourceKeys)[number];
 
 type RdsArgs = yargs.ArgumentsCamelCase<{
   arch: DbResourceKey;
@@ -66,7 +68,7 @@ export const rds = (
           y
             .option("arch", {
               type: "string",
-              choices: ["mysql", "postgres"] as const,
+              choices: DbResourceKeys,
               demandOption: true,
               describe: "Database architecture; use 'mysql' for MariaDB",
             })

--- a/src/plugins/db/types.ts
+++ b/src/plugins/db/types.ts
@@ -19,5 +19,5 @@ export type DbPermissionSpec = {
   };
   generated: object;
   permission: { instanceId: string };
-  type: "mysql" | "pg2";
+  type: "mysql" | "postgres";
 };


### PR DESCRIPTION
**Problem**

We are preparing to release a new implementation of the postgres integration. However, there are some existing gaps that need to be addressed before we do so. 

**Change**

- Changes the resource key from "pg2" (old internal name for in-progress work) to "postgres" (new permanent resource key)
- Uses `osSafeCommand` for running AWS CLI (generic Windows-compatible wrapper for running terminal commands)
- Adds a `.trim()` to the `PGPASSWORD` output for postgres

**Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (code changes that neither fix bugs nor add features)

**Validation**

The RDS subcommands are currently not in use by any known customer, so we don't need to worry too much about backwards compatibility. Tested manually that this works with the new postgres implementation
