### PR TITLE
clean up timer blocking the access request from terminating

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.26.11",
+  "version": "0.26.12",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/commands/shared/request.ts
+++ b/src/commands/shared/request.ts
@@ -215,8 +215,10 @@ export const request =
       throw data;
     };
 
+    const timeoutSleep = sleep(options?.timeOut ?? MAX_REQUEST_TIMEOUT);
+
     const timeoutOperation = async () => {
-      await sleep(options?.timeOut ?? MAX_REQUEST_TIMEOUT);
+      await timeoutSleep;
       throw ACCESS_WAIT_TIMEOUT_ERROR_MESSAGE;
     };
 
@@ -236,6 +238,8 @@ export const request =
         print2("Disconnected from server. Retry after 1 minutes.");
       }
       throw error;
+    } finally {
+      timeoutSleep.cancel();
     }
   };
 


### PR DESCRIPTION


**Problem**

Making an access request hangs while waiting for approval.
Steps to reproduce:
1. Make an access request
2. Notice that the access requested just hangs and you have the ctrl + c


**Change**

This PR cleans up the dangling timeout operation, used to make sure we are not retrying/waiting for access request creation, from preventing the cli to close.

Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [x] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [x] Bug fix: cleans up the timeout operations

**Validation**

Manually testing by creating an access request

**Tracking (optional)**

CUS-264

**Attachments (optional)**

https://github.com/user-attachments/assets/c420913c-f7a1-4d27-a148-dc6764fcde22

