### PR TITLE
cli p0 cli 404 not found on p0 ssh due to empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -31,7 +31,7 @@ const sshAuditUrl = (tenant: string) =>
 
 const commandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/`;
 const requestStatusUrl = (tenant: string, requestId: string) =>
-  `${commandUrl(tenant)}/${requestId}/poll`;
+  `${commandUrl(tenant)}${requestId}/poll`;
 const adminLsCommandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/ls`;
 export const tracesUrl = (tenant: string) => `${tenantUrl(tenant)}/traces`;
 


### PR DESCRIPTION


**Problem**

P0 Ssh fails with 404 not found for polling endpoint. This is due to additional slash being appended in the request polling url.


**Change**

Fix the Url building method to use single slash instead of two.

**Type of Change**


- [x] Bug fix (non-breaking change that fixes an issue)


**Validation**

Build and manually tested the SSH.

**Tracking (optional)**

Cx-444


