### PR TITLE
Fix issue were additional slash is added to polling endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.26.12",
+  "version": "0.26.13",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/drivers/__tests__/api.test.ts
+++ b/src/drivers/__tests__/api.test.ts
@@ -34,6 +34,7 @@ describe("fetchWithStreaming", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(mockAuthn.getToken).mockResolvedValue("mock-token");
     vi.spyOn(config, "getTenantConfig").mockReturnValue(defaultConfig);
   });
   afterEach(() => {

--- a/src/drivers/__tests__/api.test.ts
+++ b/src/drivers/__tests__/api.test.ts
@@ -8,8 +8,10 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import * as config from "../../drivers/config";
+import { defaultConfig } from "../../drivers/env";
 import { Authn } from "../../types/identity";
-import { fetchWithStreaming } from "../api";
+import { fetchWithStreaming, requestStatusUrl } from "../api";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies
@@ -32,6 +34,7 @@ describe("fetchWithStreaming", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(config, "getTenantConfig").mockReturnValue(defaultConfig);
   });
   afterEach(() => {
     // Clear all mocks after each test
@@ -63,7 +66,11 @@ describe("fetchWithStreaming", () => {
       },
     };
   };
-
+  it("should validate request polling url", async () => {
+    expect(requestStatusUrl("test", "temp1")).toMatchInlineSnapshot(
+      `"http://localhost:8088/o/test/command/temp1/poll"`
+    );
+  });
   it("should yield data from streaming response", async () => {
     const mockFetch = vi.spyOn(global, "fetch").mockResolvedValue(
       createMockStreamingResponse([

--- a/src/drivers/__tests__/api.test.ts
+++ b/src/drivers/__tests__/api.test.ts
@@ -68,7 +68,7 @@ describe("fetchWithStreaming", () => {
   };
   it("should validate request polling url", async () => {
     expect(requestStatusUrl("test", "temp1")).toMatchInlineSnapshot(
-      `"http://localhost:8088/o/test/command/temp1/poll"`
+      `"${defaultConfig.appUrl}/o/test/command/temp1/poll"`
     );
   });
   it("should yield data from streaming response", async () => {

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -30,8 +30,8 @@ const sshAuditUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/audit`;
 
 const commandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/`;
-const requestStatusUrl = (tenant: string, requestId: string) =>
-  `${commandUrl(tenant)}/${requestId}/poll`;
+export const requestStatusUrl = (tenant: string, requestId: string) =>
+  `${commandUrl(tenant)}${requestId}/poll`;
 const adminLsCommandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/ls`;
 export const tracesUrl = (tenant: string) => `${tenantUrl(tenant)}/traces`;
 


### PR DESCRIPTION


**Problem**

P0 Ssh fails with 404 not found for polling endpoint. This is due to additional slash being appended in the request polling url.


**Change**

Fix the Url building method to use single slash instead of two.

**Type of Change**


- [x] Bug fix (non-breaking change that fixes an issue)


**Validation**

1. Built and manually tested the SSH.
2. Add unit test

**Tracking (optional)**

CUS-267


