### PR TITLE
Avoid Reading HTTP Response Stream Twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.26.13",
+  "version": "0.26.14",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -17,8 +17,14 @@ export const urlEncode = (data: Record<string, string>) =>
 /** Validates an HTTP response, throwing a friendly error message if invalid */
 export const validateResponse = async (response: Response) => {
   if (response.ok) return response;
-  throw new Error(`Error in fetch request to ${response.url.split("?")[0]}:
-${response.status} ${response.statusText}
 
-${await response.text()}`);
+  throw new Error(fetchErrorMessage(
+    response.url.split("?")[0], 
+    response.status, 
+    response.statusText, 
+    await response.text()))
 };
+
+export const fetchErrorMessage = (url:string|undefined,status:number, statusText:string, body:string) => {
+  return `Error in fetch request to ${url}:\n${status} ${statusText}\n\n${body}`
+}

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -18,13 +18,21 @@ export const urlEncode = (data: Record<string, string>) =>
 export const validateResponse = async (response: Response) => {
   if (response.ok) return response;
 
-  throw new Error(fetchErrorMessage(
-    response.url.split("?")[0], 
-    response.status, 
-    response.statusText, 
-    await response.text()))
+  throw new Error(
+    fetchErrorFormatter(
+      response.url.split("?")[0],
+      response.status,
+      response.statusText,
+      await response.text()
+    )
+  );
 };
 
-export const fetchErrorMessage = (url:string|undefined,status:number, statusText:string, body:string) => {
-  return `Error in fetch request to ${url}:\n${status} ${statusText}\n\n${body}`
-}
+export const fetchErrorFormatter = (
+  url: string | undefined,
+  status: number,
+  statusText: string,
+  body: string
+) => {
+  return `Error in fetch request to ${url}:\n${status} ${statusText}\n\n${body}`;
+};

--- a/src/plugins/okta/__tests__/login.test.ts
+++ b/src/plugins/okta/__tests__/login.test.ts
@@ -1,0 +1,79 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import {
+  getClientId,
+  getProviderDomain,
+  getProviderType,
+} from "../../../types/authUtils";
+import { Identity } from "../../../types/identity";
+import { AwsFederatedLogin } from "../../aws/types";
+import { fetchSamlAssertionForAws } from "../login";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../types/authUtils");
+vi.mock("../../oidc/login");
+vi.mock("../../../drivers/auth");
+vi.mock("../../../drivers/stdio");
+
+const mockIdentity = {
+  org: {},
+  credential: {
+    access_token: "mock-access-token",
+    id_token: "mock-id-token",
+    expires_at: Date.now() + 3600000,
+  },
+} as unknown as Identity;
+
+const mockConfig: AwsFederatedLogin = {
+  type: "federated",
+  provider: {
+    type: "okta",
+    appId: "mock-app-id",
+    identityProvider: "mock-idp",
+    method: { type: "saml" },
+  },
+};
+
+describe("fetchSsoWebToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getProviderType).mockReturnValue("okta");
+    vi.mocked(getProviderDomain).mockReturnValue("example.okta.com");
+    vi.mocked(getClientId).mockReturnValue("mock-client-id");
+  });
+
+  it("does not read response body twice on 400 with non-invalid_grant error", async () => {
+    const mockJson = vi.fn().mockResolvedValue({
+      error: "access_denied",
+      error_description: "Access to this application is denied.",
+    });
+    const mockText = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        url: "https://example.okta.com/oauth2/v1/token",
+        json: mockJson,
+        text: mockText,
+      })
+    );
+
+    await expect(
+      fetchSamlAssertionForAws(mockIdentity, mockConfig)
+    ).rejects.toThrow("400 Bad Request");
+
+    expect(mockJson).toHaveBeenCalledOnce();
+    expect(mockText).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/okta/login.ts
+++ b/src/plugins/okta/login.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { OIDC_HEADERS } from "../../common/auth/oidc";
-import { urlEncode, validateResponse } from "../../common/fetch";
+import { fetchErrorMessage, urlEncode, validateResponse } from "../../common/fetch";
 import { deleteIdentity } from "../../drivers/auth";
 import { print2 } from "../../drivers/stdio";
 import {
@@ -97,9 +97,11 @@ const fetchSsoWebToken = async (
           throw "Your Okta session has expired. Please log out of Okta in your browser, and re-execute your p0 command to reauthenticate.";
         }
       }
+      // Handle all other 400s
+      throw new Error(fetchErrorMessage(response.url.split("?")[0], response.status, response.statusText, JSON.stringify(data)))
     }
 
-    // Throw a friendly error message if response is invalid
+    // Handle all other non-ok responses
     await validateResponse(response);
   }
 

--- a/src/plugins/okta/login.ts
+++ b/src/plugins/okta/login.ts
@@ -9,7 +9,11 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { OIDC_HEADERS } from "../../common/auth/oidc";
-import { fetchErrorMessage, urlEncode, validateResponse } from "../../common/fetch";
+import {
+  fetchErrorFormatter,
+  urlEncode,
+  validateResponse,
+} from "../../common/fetch";
 import { deleteIdentity } from "../../drivers/auth";
 import { print2 } from "../../drivers/stdio";
 import {
@@ -98,7 +102,14 @@ const fetchSsoWebToken = async (
         }
       }
       // Handle all other 400s
-      throw new Error(fetchErrorMessage(response.url.split("?")[0], response.status, response.statusText, JSON.stringify(data)))
+      throw new Error(
+        fetchErrorFormatter(
+          response.url.split("?")[0],
+          response.status,
+          response.statusText,
+          JSON.stringify(data)
+        )
+      );
     }
 
     // Handle all other non-ok responses


### PR DESCRIPTION
**Problem**

In certain error-handling situations, the code can attempt to read from an HTTP response body twice; this results in an error being thrown, since the response body is a read-once stream.

**Change**

This PR corrects the specific error-handling code to avoid reading the response body twice. It also extracts the formatting used by the validateResponse method so that it can be used to generate similar error messages when the response's body has already been read.

Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Added unit test to cover error-handling case.

**Tracking (optional)**

https://linear.app/p0-security/issue/CUS-268/ssh-do-not-consume-body-twice-in-okta-login-step
