### PR TITLE
add support for aws-gov-cloud to saml assertions

### DIFF
--- a/src/plugins/aws/__tests__/api.test.ts
+++ b/src/plugins/aws/__tests__/api.test.ts
@@ -34,7 +34,7 @@ describe("stsEndpoint()", () => {
 
   it("returns a GovCloud STS endpoint for aws-us-gov", () => {
     expect(stsEndpoint("aws-us-gov")).toBe(
-      "https://sts.us-gov-west-1.amazonaws.com"
+      "https://sts.us-gov-east-1.amazonaws.com"
     );
   });
 

--- a/src/plugins/aws/__tests__/api.test.ts
+++ b/src/plugins/aws/__tests__/api.test.ts
@@ -17,9 +17,7 @@ describe("arnPrefix()", () => {
   });
 
   it("uses the commercial partition explicitly", () => {
-    expect(arnPrefix("123456789012", "aws")).toBe(
-      "arn:aws:iam::123456789012"
-    );
+    expect(arnPrefix("123456789012", "aws")).toBe("arn:aws:iam::123456789012");
   });
 
   it("emits a GovCloud ARN prefix", () => {
@@ -41,8 +39,6 @@ describe("stsEndpoint()", () => {
   });
 
   it("falls back to the commercial endpoint for unknown partitions", () => {
-    expect(stsEndpoint("aws-iso")).toBe(
-      "https://sts.us-east-1.amazonaws.com"
-    );
+    expect(stsEndpoint("aws-iso")).toBe("https://sts.us-east-1.amazonaws.com");
   });
 });

--- a/src/plugins/aws/__tests__/api.test.ts
+++ b/src/plugins/aws/__tests__/api.test.ts
@@ -1,0 +1,48 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { arnPrefix, stsEndpoint } from "../api";
+import { describe, expect, it } from "vitest";
+
+describe("arnPrefix()", () => {
+  it("defaults to the commercial partition when none is given", () => {
+    expect(arnPrefix("123456789012")).toBe("arn:aws:iam::123456789012");
+  });
+
+  it("uses the commercial partition explicitly", () => {
+    expect(arnPrefix("123456789012", "aws")).toBe(
+      "arn:aws:iam::123456789012"
+    );
+  });
+
+  it("emits a GovCloud ARN prefix", () => {
+    expect(arnPrefix("145302212528", "aws-us-gov")).toBe(
+      "arn:aws-us-gov:iam::145302212528"
+    );
+  });
+});
+
+describe("stsEndpoint()", () => {
+  it("returns the regional commercial endpoint for aws", () => {
+    expect(stsEndpoint("aws")).toBe("https://sts.us-east-1.amazonaws.com");
+  });
+
+  it("returns a GovCloud STS endpoint for aws-us-gov", () => {
+    expect(stsEndpoint("aws-us-gov")).toBe(
+      "https://sts.us-gov-west-1.amazonaws.com"
+    );
+  });
+
+  it("falls back to the commercial endpoint for unknown partitions", () => {
+    expect(stsEndpoint("aws-iso")).toBe(
+      "https://sts.us-east-1.amazonaws.com"
+    );
+  });
+});

--- a/src/plugins/aws/__tests__/assumeRole.test.ts
+++ b/src/plugins/aws/__tests__/assumeRole.test.ts
@@ -90,5 +90,4 @@ describe("assumeRoleWithSaml()", () => {
       "arn:aws-us-gov:iam::145302212528:saml-provider/P0GovStg"
     );
   });
-
 });

--- a/src/plugins/aws/__tests__/assumeRole.test.ts
+++ b/src/plugins/aws/__tests__/assumeRole.test.ts
@@ -1,0 +1,94 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { assumeRoleWithSaml } from "../assumeRole";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../common/fetch", () => ({
+  validateResponse: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../common/xml", () => ({
+  parseXml: vi.fn(() => ({
+    AssumeRoleWithSAMLResponse: {
+      AssumeRoleWithSAMLResult: {
+        Credentials: {
+          AccessKeyId: "AKIAEXAMPLE",
+          SecretAccessKey: "secret",
+          SessionToken: "session",
+        },
+      },
+    },
+  })),
+}));
+
+describe("assumeRoleWithSaml()", () => {
+  const fetchMock = vi.fn();
+
+  const baseArgs = {
+    account: "123456789012",
+    role: "MyRole",
+    saml: { providerName: "okta", response: "base64-saml" },
+  };
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("<xml/>"),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const captureCall = () => {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    const params = Object.fromEntries(
+      new URLSearchParams((init as RequestInit).body as string)
+    );
+    return { url: url as string, params };
+  };
+
+  it("uses the commercial partition by default", async () => {
+    await assumeRoleWithSaml(baseArgs);
+
+    const { url, params } = captureCall();
+    expect(url).toBe("https://sts.us-east-1.amazonaws.com");
+    expect(params.RoleArn).toBe("arn:aws:iam::123456789012:role/MyRole");
+    expect(params.PrincipalArn).toBe(
+      "arn:aws:iam::123456789012:saml-provider/okta"
+    );
+    expect(params.SAMLAssertion).toBe("base64-saml");
+  });
+
+  it("targets GovCloud STS and emits aws-us-gov ARNs", async () => {
+    await assumeRoleWithSaml({
+      ...baseArgs,
+      account: "145302212528",
+      partition: "aws-us-gov",
+      role: "p0-grants/P0GrantsRole12",
+      saml: { providerName: "P0GovStg", response: "base64-saml" },
+    });
+
+    const { url, params } = captureCall();
+    expect(url).toBe("https://sts.us-gov-west-1.amazonaws.com");
+    expect(params.RoleArn).toBe(
+      "arn:aws-us-gov:iam::145302212528:role/p0-grants/P0GrantsRole12"
+    );
+    expect(params.PrincipalArn).toBe(
+      "arn:aws-us-gov:iam::145302212528:saml-provider/P0GovStg"
+    );
+  });
+
+});

--- a/src/plugins/aws/__tests__/assumeRole.test.ts
+++ b/src/plugins/aws/__tests__/assumeRole.test.ts
@@ -82,7 +82,7 @@ describe("assumeRoleWithSaml()", () => {
     });
 
     const { url, params } = captureCall();
-    expect(url).toBe("https://sts.us-gov-west-1.amazonaws.com");
+    expect(url).toBe("https://sts.us-gov-east-1.amazonaws.com");
     expect(params.RoleArn).toBe(
       "arn:aws-us-gov:iam::145302212528:role/p0-grants/P0GrantsRole12"
     );

--- a/src/plugins/aws/api.ts
+++ b/src/plugins/aws/api.ts
@@ -20,7 +20,7 @@ export const arnPrefix = (account: string, partition: string = "aws") =>
 export const stsEndpoint = (partition: string): string => {
   switch (partition) {
     case "aws-us-gov":
-      return "https://sts.us-gov-west-1.amazonaws.com";
+      return "https://sts.us-gov-east-1.amazonaws.com";
     case "aws":
     default:
       return "https://sts.us-east-1.amazonaws.com";

--- a/src/plugins/aws/api.ts
+++ b/src/plugins/aws/api.ts
@@ -10,4 +10,19 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 export const AWS_API_VERSION = "2011-06-15";
 
-export const arnPrefix = (account: string) => `arn:aws:iam::${account}`;
+export const arnPrefix = (account: string, partition: string = "aws") =>
+  `arn:${partition}:iam::${account}`;
+
+/** Returns a regional STS endpoint for the given AWS partition.
+ *
+ * Regional endpoints issue v2 tokens valid in all regions of the partition.
+ * Falls back to commercial us-east-1 for unknown partitions. */
+export const stsEndpoint = (partition: string): string => {
+  switch (partition) {
+    case "aws-us-gov":
+      return "https://sts.us-gov-west-1.amazonaws.com";
+    case "aws":
+    default:
+      return "https://sts.us-east-1.amazonaws.com";
+  }
+};

--- a/src/plugins/aws/assumeRole.ts
+++ b/src/plugins/aws/assumeRole.ts
@@ -10,14 +10,15 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { validateResponse } from "../../common/fetch";
 import { parseXml } from "../../common/xml";
-import { arnPrefix } from "./api";
+import { arnPrefix, stsEndpoint } from "./api";
 import { AWS_API_VERSION } from "./api";
 import { AwsCredentials } from "./types";
 
-const roleArn = (args: { account: string; role: string }) =>
-  `${arnPrefix(args.account)}:role/${args.role}`;
+const roleArn = (args: { account: string; partition: string; role: string }) =>
+  `${arnPrefix(args.account, args.partition)}:role/${args.role}`;
 
 const stsAssume = async (
+  partition: string,
   params: Record<string, string>
 ): Promise<AwsCredentials> => {
   // Regional endpoints issue version-2 tokens, which are valid in all AWS regions.
@@ -25,7 +26,7 @@ const stsAssume = async (
   // Use the us-east-1 as it should be closer to most users.
   // Calling the global endpoints issues version-1 tokens, which are only valid in default regions.
   // See https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_region-endpoints.html
-  const url = `https://sts.us-east-1.amazonaws.com`;
+  const url = stsEndpoint(partition);
   const response = await fetch(url, {
     method: "POST",
     body: new URLSearchParams(params),
@@ -47,6 +48,8 @@ const stsAssume = async (
 export const assumeRoleWithSaml = async (args: {
   /** An AWS account identifier */
   account: string;
+  /** AWS partition for the role (e.g. "aws", "aws-us-gov", "aws-cn"). Defaults to "aws". */
+  partition?: string;
   /** The account-specific role name requested */
   role: string;
   saml: {
@@ -56,15 +59,16 @@ export const assumeRoleWithSaml = async (args: {
     response: string;
   };
 }): Promise<AwsCredentials> => {
+  const partition = args.partition ?? "aws";
   const params = {
     Version: AWS_API_VERSION,
     Action: "AssumeRoleWithSAML",
-    RoleArn: roleArn(args),
-    PrincipalArn: `${arnPrefix(args.account)}:saml-provider/${
+    RoleArn: roleArn({ ...args, partition }),
+    PrincipalArn: `${arnPrefix(args.account, partition)}:saml-provider/${
       args.saml.providerName
     }`,
     // Note that, despite the name, AWS actually expects a SAML Response
     SAMLAssertion: args.saml.response,
   };
-  return await stsAssume(params);
+  return await stsAssume(partition, params);
 };

--- a/src/plugins/okta/__tests__/aws.test.ts
+++ b/src/plugins/okta/__tests__/aws.test.ts
@@ -52,7 +52,10 @@ describe("assumeRoleWithOktaSaml retry logic", () => {
     },
   };
 
-  const createMockSamlWithRoles = (roles: string[]) => ({
+  const createMockSamlWithRoles = (
+    roles: string[],
+    partition: string = "aws"
+  ) => ({
     "saml2p:Response": {
       "saml2:Assertion": {
         "saml2:AttributeStatement": {
@@ -63,7 +66,7 @@ describe("assumeRoleWithOktaSaml retry logic", () => {
               },
               "saml2:AttributeValue": roles.map(
                 (r) =>
-                  `arn:aws:iam::${MOCK_ACCOUNT_ID}:saml-provider/test,arn:aws:iam::${MOCK_ACCOUNT_ID}:role/${r}`
+                  `arn:${partition}:iam::${MOCK_ACCOUNT_ID}:saml-provider/test,arn:${partition}:iam::${MOCK_ACCOUNT_ID}:role/${r}`
               ),
             },
           ],
@@ -124,4 +127,45 @@ describe("assumeRoleWithOktaSaml retry logic", () => {
     expect(fetchSamlAssertionForAws).toHaveBeenCalledTimes(2);
     expect(parseXml).toHaveBeenCalledTimes(2);
   });
+
+  it("should pass the commercial partition to assumeRoleWithSaml", async () => {
+    vi.mocked(parseXml).mockReturnValue(
+      createMockSamlWithRoles(["p0-grants/P0GrantsRole1"], "aws")
+    );
+
+    await assumeRoleWithOktaSaml(
+      mockAuthn,
+      { role: "p0-grants/P0GrantsRole1" },
+      false
+    );
+
+    expect(assumeRoleWithSaml).toHaveBeenCalledWith(
+      expect.objectContaining({ partition: "aws" })
+    );
+  });
+
+  it("should detect the GovCloud partition from the SAML and pass it through", async () => {
+    vi.mocked(parseXml).mockReturnValue(
+      createMockSamlWithRoles(
+        ["p0-grants/P0GrantsRole12"],
+        "aws-us-gov"
+      )
+    );
+
+    const result = await assumeRoleWithOktaSaml(
+      mockAuthn,
+      { role: "p0-grants/P0GrantsRole12" },
+      false
+    );
+
+    expect(result).toBeDefined();
+    expect(assumeRoleWithSaml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: MOCK_ACCOUNT_ID,
+        partition: "aws-us-gov",
+        role: "p0-grants/P0GrantsRole12",
+      })
+    );
+  });
+
 });

--- a/src/plugins/okta/__tests__/aws.test.ts
+++ b/src/plugins/okta/__tests__/aws.test.ts
@@ -146,10 +146,7 @@ describe("assumeRoleWithOktaSaml retry logic", () => {
 
   it("should detect the GovCloud partition from the SAML and pass it through", async () => {
     vi.mocked(parseXml).mockReturnValue(
-      createMockSamlWithRoles(
-        ["p0-grants/P0GrantsRole12"],
-        "aws-us-gov"
-      )
+      createMockSamlWithRoles(["p0-grants/P0GrantsRole12"], "aws-us-gov")
     );
 
     const result = await assumeRoleWithOktaSaml(
@@ -167,5 +164,4 @@ describe("assumeRoleWithOktaSaml retry logic", () => {
       })
     );
   });
-
 });

--- a/src/plugins/okta/aws.ts
+++ b/src/plugins/okta/aws.ts
@@ -26,6 +26,10 @@ const INITIAL_RETRY_DELAY_MS = 1000;
 const RETRY_MULTIPLIER = 2.0;
 const MAX_RETRY_DELAY_MS = 30000;
 
+// Matches IAM role ARNs in any AWS partition (commercial, GovCloud, China, etc.)
+// Capture group 1: partition; capture group 2: account ID.
+const ROLE_ARN_PATTERN = /^arn:(aws[\w-]*):iam::([^:]+):role\//;
+
 /** Extracts all roles from a SAML assertion */
 const rolesFromSaml = (account: string, saml: string) => {
   const samlText = Buffer.from(saml, "base64").toString("ascii");
@@ -43,10 +47,16 @@ const rolesFromSaml = (account: string, saml: string) => {
   const arns = (
     flatten([roleAttribute?.["saml2:AttributeValue"]]) as string[]
   )?.map((r) => r.split(",")[1]!);
-  const roles = arns
-    .filter((r) => r.startsWith(`arn:aws:iam::${account}:role/`))
-    .map((r) => r.split("/").slice(1).join("/"));
-  return { arns, roles };
+  const matched = arns
+    .map((arn) => ({ arn, match: ROLE_ARN_PATTERN.exec(arn) }))
+    .filter(
+      (x): x is { arn: string; match: RegExpExecArray } =>
+        x.match !== null && x.match[2] === account
+    );
+  // Partition must flow to STS so we hit the right endpoint and emit ARNs in the matching partition.
+  const partition = matched[0]?.match[1] ?? "aws";
+  const roles = matched.map(({ arn }) => arn.split("/").slice(1).join("/"));
+  return { arns, roles, partition };
 };
 
 const isFederatedLogin = (
@@ -97,12 +107,13 @@ export const assumeRoleWithOktaSaml = async (
             args.accountId,
             debug
           );
-          const { roles } = rolesFromSaml(account, samlResponse);
+          const { roles, partition } = rolesFromSaml(account, samlResponse);
           if (!roles.includes(args.role)) {
             throw `Role ${args.role} not available. Available roles:\n${roles.map((r) => `  ${r}`).join("\n")}`;
           }
           return await assumeRoleWithSaml({
             account,
+            partition,
             role: args.role,
             saml: {
               providerName: config.login.provider.identityProvider,

--- a/src/plugins/okta/aws.ts
+++ b/src/plugins/okta/aws.ts
@@ -26,9 +26,9 @@ const INITIAL_RETRY_DELAY_MS = 1000;
 const RETRY_MULTIPLIER = 2.0;
 const MAX_RETRY_DELAY_MS = 30000;
 
-// Matches IAM role ARNs in any AWS partition (commercial, GovCloud, China, etc.)
+// Matches IAM role ARNs in known AWS partitions (commercial or GovCloud).
 // Capture group 1: partition; capture group 2: account ID.
-const ROLE_ARN_PATTERN = /^arn:(aws[\w-]*):iam::([^:]+):role\//;
+const ROLE_ARN_PATTERN = /^arn:(aws|aws-us-gov):iam::([^:]+):role\//;
 
 /** Extracts all roles from a SAML assertion */
 const rolesFromSaml = (account: string, saml: string) => {


### PR DESCRIPTION

**Problem**

Plumb the AWS partition through the Okta → SAML → STS flow so GovCloud accounts can assume roles via the CLI.
Previously, rolesFromSaml filtered SAML role ARNs with a hardcoded arn:aws:iam:: prefix and assumeRoleWithSaml always hit the commercial STS endpoint — both of which silently dropped GovCloud (arn:aws-us-gov:...) ARNs and surfaced as a misleading "Role X not available. Available roles:" with an empty list.

**Change**

- src/plugins/aws/api.ts — arnPrefix(account, partition?) accepts an optional partition (defaults to "aws"); new stsEndpoint(partition) returns sts.us-east-1.amazonaws.com for aws and sts.us-gov-west-1.amazonaws.com for aws-us-gov. Unknown partitions fall back to commercial.
- src/plugins/aws/assumeRole.ts — assumeRoleWithSaml accepts an optional partition and uses it to build RoleArn / PrincipalArn and pick the STS endpoint.
- src/plugins/okta/aws.ts — rolesFromSaml now matches role ARNs in any AWS partition (^arn:(aws[\w-]*):iam::([^:]+):role/), detects the partition from the first matching ARN, and returns it alongside roles. The caller passes it to assumeRoleWithSaml.

**Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

- yarn vitest run for the three affected test files
- yarn tsc --noEmit clean
- New unit tests cover commercial + GovCloud for arnPrefix, stsEndpoint, assumeRoleWithSaml (verifies STS URL + ARN partition + SAMLAssertion body), and end-to-end partition flow from assumeRoleWithOktaSaml
- Manual:Sstaging GovCloud tenant successfully runs p0 aws role assume against an arn:aws-us-gov role
- Manual: existing commercial-AWS users see no behavioral change

**Tracking (optional)**

https://linear.app/p0-security/issue/CUS-276/cli-add-support-for-aws-gov-cloud-to-saml-assertions

**Implementation (optional)**

- China (aws-cn) is intentionally not supported in this PR; stsEndpoint falls back to the commercial endpoint for any partition other than aws-us-gov. Easy to extend later by adding a case to stsEndpoint.
- The partition is detected from the SAML response itself rather than from config, so no AWS config schema changes are required.
