### PR TITLE
Add `claude` command suite

### DIFF
--- a/src/commands/claude/index.ts
+++ b/src/commands/claude/index.ts
@@ -1,0 +1,24 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { mcpCommand } from "./mcp";
+import yargs from "yargs";
+
+export const claudeCommand = (yargs: yargs.Argv) =>
+  yargs.command("claude", "Interact with Claude Code", (yargs) =>
+    yargs
+      .option("debug", {
+        type: "boolean",
+        default: false,
+        description: "Emit debug logs",
+      })
+      .demandCommand(1)
+      .command("mcp", "Configure Claude MCP servers", mcpCommand)
+  );

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -1,0 +1,168 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { authFetch, tenantUrl } from "../../drivers/api";
+import { authenticate } from "../../drivers/auth";
+import { postfixPath } from "../../drivers/auth/path";
+import { debug } from "../../drivers/stdio";
+import { Authn } from "../../types/identity";
+import assert from "node:assert";
+import { exec, spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import yargs from "yargs";
+
+type CreateMcpClientReq = {
+  platform: string;
+  redirectUri: string;
+  version: string;
+};
+
+type CreateMcpClientResp = {
+  client: { id: string; redirectUri: string; secret: string };
+  server: { id: string; url: string };
+};
+
+type GetMcpServerResp = {
+  server: {
+    id: string;
+    url: string;
+  };
+};
+
+type AddMcpServerArgs = yargs.ArgumentsCamelCase<{
+  debug?: boolean;
+  callbackPort: number | undefined;
+  scope: string | undefined;
+  server: string;
+}>;
+
+const CLIENT_PATH = postfixPath("claude/mcp-client.json");
+
+const REDIRECT_PORT = 8080;
+
+export const mcpCommand = (yargs: yargs.Argv<{ debug?: boolean }>) =>
+  yargs.command(
+    "add <server>",
+    "Add an MCP server",
+    (y) =>
+      y
+        .positional("server", {
+          type: "string",
+          describe: "MCP server key",
+          demand: true,
+        })
+        .option("callbackPort", {
+          describe: "Authentication callback port",
+          type: "number",
+          default: REDIRECT_PORT,
+        })
+        .option("scope", {
+          alias: "s",
+          describe:
+            'Configuration scope (local, user, or project) (default: "local")',
+          type: "string",
+          choices: ["local", "user", "project"],
+        }),
+    async (argv) => {
+      assert(argv.server);
+      await handleAddMcpServer({ ...argv, server: argv.server });
+    }
+  );
+
+const handleAddMcpServer = async (argv: AddMcpServerArgs) => {
+  const authn = await authenticate();
+
+  if (!argv.server) {
+    throw "'server' is required";
+  }
+
+  const client = await ensureClient(authn, argv);
+  const server = await getServer(authn, argv);
+
+  await provisionServer(argv, client, server);
+};
+
+const createClient = async (authn: Authn, argv: AddMcpServerArgs) => {
+  const version = (await promisify(exec)("claude --version")).stdout;
+
+  const clientData = await authFetch<CreateMcpClientResp>(authn, {
+    url: `${tenantUrl(authn.identity.org.slug)}/mcp/clients`,
+    method: "POST",
+    body: JSON.stringify({
+      platform: "claude-code",
+      version,
+      redirectUri: `http://localhost:${argv.callbackPort ?? REDIRECT_PORT}`,
+    } satisfies CreateMcpClientReq),
+    debug: argv.debug,
+  });
+
+  await fs.mkdir(path.dirname(CLIENT_PATH), { recursive: true });
+  await fs.writeFile(CLIENT_PATH, JSON.stringify(clientData, null, 2), {
+    mode: "400",
+  });
+
+  return clientData;
+};
+
+const ensureClient = async (authn: Authn, argv: AddMcpServerArgs) => {
+  try {
+    const cachedClientData = await fs.readFile(CLIENT_PATH, {
+      encoding: "utf-8",
+    });
+
+    if (cachedClientData) {
+      const client = JSON.parse(cachedClientData) as CreateMcpClientResp;
+      return client;
+    }
+  } catch (error: unknown) {
+    debug(argv, `Could not read client data file: String(error)`);
+  }
+
+  return await createClient(authn, argv);
+};
+
+const getServer = async (authn: Authn, argv: AddMcpServerArgs) =>
+  await authFetch<GetMcpServerResp>(authn, {
+    url: `${tenantUrl(authn.identity.org.slug)}/mcp/servers/${argv.server}`,
+    method: "GET",
+  });
+
+const provisionServer = async (
+  argv: AddMcpServerArgs,
+  { client }: CreateMcpClientResp,
+  { server }: GetMcpServerResp
+) => {
+  const claudeFile = (await promisify(exec)("which claude")).stdout.trim();
+  assert(client.secret, "No client secret");
+  const args = [
+    "mcp",
+    "add-json",
+    server.id,
+    JSON.stringify({
+      type: "http",
+      url: server.url,
+      oauth: {
+        clientId: client.id,
+        clientSecret: client.secret,
+        callbackPort: Number(client.redirectUri.split(":").at(-1)!),
+      },
+    }),
+    ...(argv.scope ? ["--scope", argv.scope] : []),
+    "--client-secret",
+  ];
+  debug(argv, "Client secret", client.secret);
+  debug(argv, ["claude", ...args].join(" "));
+  await promisify(spawn)(claudeFile, args, {
+    env: { MCP_CLIENT_SECRET: client.secret },
+    stdio: "inherit",
+  });
+};

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -11,7 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { authFetch, tenantUrl } from "../../drivers/api";
 import { authenticate } from "../../drivers/auth";
 import { postfixPath } from "../../drivers/auth/path";
-import { debug } from "../../drivers/stdio";
+import { debug, print2 } from "../../drivers/stdio";
 import { Authn } from "../../types/identity";
 import assert from "node:assert";
 import { exec, spawn } from "node:child_process";
@@ -19,6 +19,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import yargs from "yargs";
+
+type ListMcpServersResp = {
+  servers: { id: string; url: string }[];
+};
 
 type CreateMcpClientReq = {
   hostname: string;
@@ -39,6 +43,10 @@ type GetMcpServerResp = {
   };
 };
 
+type ListMcpServerArgs = yargs.ArgumentsCamelCase<{
+  debug?: boolean;
+}>;
+
 type AddMcpServerArgs = yargs.ArgumentsCamelCase<{
   debug?: boolean;
   callbackPort: number | undefined;
@@ -51,33 +59,53 @@ const CLIENT_PATH = postfixPath("claude/mcp-client.json");
 const REDIRECT_PORT = 8080;
 
 export const mcpCommand = (yargs: yargs.Argv<{ debug?: boolean }>) =>
-  yargs.command(
-    "add <server>",
-    "Add an MCP server",
-    (y) =>
-      y
-        .positional("server", {
-          type: "string",
-          describe: "MCP server key",
-          demand: true,
-        })
-        .option("callbackPort", {
-          describe: "Authentication callback port",
-          type: "number",
-          default: REDIRECT_PORT,
-        })
-        .option("scope", {
-          alias: "s",
-          describe:
-            'Configuration scope (local, user, or project) (default: "local")',
-          type: "string",
-          choices: ["local", "user", "project"],
-        }),
-    async (argv) => {
-      assert(argv.server);
-      await handleAddMcpServer({ ...argv, server: argv.server });
-    }
-  );
+  yargs
+    .command(
+      "add <server>",
+      "Add an MCP server",
+      (y) =>
+        y
+          .positional("server", {
+            type: "string",
+            describe: "MCP server key",
+            demand: true,
+          })
+          .option("callbackPort", {
+            describe: "Authentication callback port",
+            type: "number",
+            default: REDIRECT_PORT,
+          })
+          .option("scope", {
+            alias: "s",
+            describe:
+              'Configuration scope (local, user, or project) (default: "local")',
+            type: "string",
+            choices: ["local", "user", "project"],
+          }),
+      async (argv) => {
+        assert(argv.server);
+        await handleAddMcpServer({ ...argv, server: argv.server });
+      }
+    )
+    .command(
+      "list",
+      "List available MCP servers",
+      (y) => y,
+      async (argv) => {
+        await handleListMcpServers(argv);
+      }
+    );
+
+const handleListMcpServers = async (argv: ListMcpServerArgs) => {
+  const authn = await authenticate();
+
+  const result = await authFetch<ListMcpServersResp>(authn, {
+    url: `${tenantUrl(authn.identity.org.slug)}/mcp/servers`,
+    method: "GET",
+    debug: argv.debug,
+  });
+  print2(result);
+};
 
 const handleAddMcpServer = async (argv: AddMcpServerArgs) => {
   const authn = await authenticate();
@@ -141,7 +169,7 @@ const ensureClient = async (authn: Authn, argv: AddMcpServerArgs) => {
 
 const getServer = async (authn: Authn, argv: AddMcpServerArgs) =>
   await authFetch<GetMcpServerResp>(authn, {
-    url: `${tenantUrl(authn.identity.org.slug)}/mcp/servers/${argv.server}`,
+    url: `${tenantUrl(authn.identity.org.slug)}/mcp/servers/${encodeURIComponent(argv.server)}`,
     method: "GET",
   });
 
@@ -152,6 +180,7 @@ const provisionServer = async (
 ) => {
   const claudeFile = (await promisify(exec)("which claude")).stdout.trim();
   assert(client.secret, "No client secret");
+  debug(argv, "Server", server);
   const args = [
     "mcp",
     "add-json",

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -21,6 +21,7 @@ import { promisify } from "node:util";
 import yargs from "yargs";
 
 type CreateMcpClientReq = {
+  hostname: string;
   platform: string;
   redirectUri: string;
   version: string;
@@ -93,11 +94,13 @@ const handleAddMcpServer = async (argv: AddMcpServerArgs) => {
 
 const createClient = async (authn: Authn, argv: AddMcpServerArgs) => {
   const version = (await promisify(exec)("claude --version")).stdout;
+  const hostname = (await promisify(exec)("scutil --get LocalHostName")).stdout;
 
   const clientData = await authFetch<CreateMcpClientResp>(authn, {
     url: `${tenantUrl(authn.identity.org.slug)}/mcp/clients`,
     method: "POST",
     body: JSON.stringify({
+      hostname,
       platform: "claude-code",
       version,
       redirectUri: `http://localhost:${argv.callbackPort ?? REDIRECT_PORT}`,
@@ -121,6 +124,12 @@ const ensureClient = async (authn: Authn, argv: AddMcpServerArgs) => {
 
     if (cachedClientData) {
       const client = JSON.parse(cachedClientData) as CreateMcpClientResp;
+      debug(
+        argv,
+        "Using cached client at",
+        CLIENT_PATH,
+        "(remove this file to use a new MCP client)"
+      );
       return client;
     }
   } catch (error: unknown) {

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -189,12 +189,32 @@ const getServer = async (authn: Authn, argv: AddMcpServerArgs) =>
     method: "GET",
   });
 
+const getClaudeFile = async () => {
+  const os = getOperatingSystem();
+  switch (os) {
+    case "mac":
+      return (await promisify(exec)("which claude")).stdout.trim();
+    case "win": {
+      const lines = (await promisify(exec)("where.exe claude")).stdout
+        .split("\r\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      return lines.find((l) => l.endsWith(".cmd")) ?? lines[0] ?? "";
+    }
+    case "linux":
+    case "unknown":
+      throw `Unsupported operating system: ${os}`;
+    default:
+      throw assertNever(os);
+  }
+};
+
 const provisionServer = async (
   argv: AddMcpServerArgs,
   { client }: CreateMcpClientResp,
   { server }: GetMcpServerResp
 ) => {
-  const claudeFile = (await promisify(exec)("which claude")).stdout.trim();
+  const claudeFile = await getClaudeFile();
   assert(client.secret, "No client secret");
   debug(argv, "Server", server);
   const args = [

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -13,6 +13,7 @@ import { authenticate } from "../../drivers/auth";
 import { postfixPath } from "../../drivers/auth/path";
 import { debug, print2 } from "../../drivers/stdio";
 import { Authn } from "../../types/identity";
+import { assertNever, getOperatingSystem } from "../../util";
 import assert from "node:assert";
 import { exec, spawn } from "node:child_process";
 import fs from "node:fs/promises";
@@ -120,9 +121,24 @@ const handleAddMcpServer = async (argv: AddMcpServerArgs) => {
   await provisionServer(argv, client, server);
 };
 
+const getHostname = async () => {
+  const os = getOperatingSystem();
+  switch (os) {
+    case "mac":
+      return (await promisify(exec)("scutil --get LocalHostName")).stdout;
+    case "win":
+      return (await promisify(exec)("hostname")).stdout;
+    case "linux":
+    case "unknown":
+      throw `Unsupported operating system: ${os}`;
+    default:
+      throw assertNever(os);
+  }
+};
+
 const createClient = async (authn: Authn, argv: AddMcpServerArgs) => {
   const version = (await promisify(exec)("claude --version")).stdout;
-  const hostname = (await promisify(exec)("scutil --get LocalHostName")).stdout;
+  const hostname = await getHostname();
 
   const clientData = await authFetch<CreateMcpClientResp>(authn, {
     url: `${tenantUrl(authn.identity.org.slug)}/mcp/clients`,

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -221,7 +221,7 @@ const provisionServer = async (
     "mcp",
     "add-json",
     server.id,
-    JSON.stringify({
+    `'${JSON.stringify({
       type: "http",
       url: server.url,
       oauth: {
@@ -229,7 +229,7 @@ const provisionServer = async (
         clientSecret: client.secret,
         callbackPort: Number(client.redirectUri.split(":").at(-1)!),
       },
-    }),
+    })}'`,
     ...(argv.scope ? ["--scope", argv.scope] : []),
     "--client-secret",
   ];

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -57,7 +57,9 @@ type AddMcpServerArgs = yargs.ArgumentsCamelCase<{
 
 const CLIENT_PATH = postfixPath("claude/mcp-client.json");
 
-const REDIRECT_PORT = 8080;
+// In dev use cases the default port (=8080) is likely to be consumed by another listening service.
+// Avoid by defaulting to a random port valid for both Windows and *nix architectures.
+const REDIRECT_PORT = 52566;
 
 export const mcpCommand = (yargs: yargs.Argv<{ debug?: boolean }>) =>
   yargs
@@ -126,9 +128,8 @@ const getHostname = async () => {
   switch (os) {
     case "mac":
       return (await promisify(exec)("scutil --get LocalHostName")).stdout;
-    case "win":
-      return (await promisify(exec)("hostname")).stdout;
     case "linux":
+    case "win":
       return (await promisify(exec)("hostname")).stdout;
     case "unknown":
       throw `Unsupported operating system: ${os}`;

--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -129,6 +129,7 @@ const getHostname = async () => {
     case "win":
       return (await promisify(exec)("hostname")).stdout;
     case "linux":
+      return (await promisify(exec)("hostname")).stdout;
     case "unknown":
       throw `Unsupported operating system: ${os}`;
     default:
@@ -192,6 +193,7 @@ const getServer = async (authn: Authn, argv: AddMcpServerArgs) =>
 const getClaudeFile = async () => {
   const os = getOperatingSystem();
   switch (os) {
+    case "linux":
     case "mac":
       return (await promisify(exec)("which claude")).stdout.trim();
     case "win": {
@@ -201,7 +203,6 @@ const getClaudeFile = async () => {
         .filter(Boolean);
       return lines.find((l) => l.endsWith(".cmd")) ?? lines[0] ?? "";
     }
-    case "linux":
     case "unknown":
       throw `Unsupported operating system: ${os}`;
     default:

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,6 +15,7 @@ import { exitProcess, markSpanError } from "../opentelemetry/otel-helpers";
 import { p0VersionInfo, stringifyVersionInfo } from "../version";
 import { allowCommand } from "./allow";
 import { awsCommand } from "./aws";
+import { claudeCommand } from "./claude";
 import { grantCommand } from "./grant";
 import { kubeconfigCommand } from "./kubeconfig";
 import { loginCommand } from "./login";
@@ -33,6 +34,7 @@ import { hideBin } from "yargs/helpers";
 
 const commands = [
   awsCommand,
+  claudeCommand,
   grantCommand,
   loginCommand,
   logoutCommand,

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -19,7 +19,8 @@ import * as path from "node:path";
 import yargs from "yargs";
 
 const tenantOrgUrl = (tenant: string) => `${getAppUrl()}/orgs/${tenant}`;
-const tenantUrl = (tenant: string) => `${getTenantConfig().appUrl}/o/${tenant}`;
+export const tenantUrl = (tenant: string) =>
+  `${getTenantConfig().appUrl}/o/${tenant}`;
 const publicKeysUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/public-keys`;
 const sshHostKeysUrl = (tenant: string) =>
@@ -356,7 +357,7 @@ const baseFetch = async <T>(args: {
   }
 };
 
-const authFetch = async <T>(
+export const authFetch = async <T>(
   authn: Authn,
   args: {
     url: string;

--- a/src/drivers/auth/path.ts
+++ b/src/drivers/auth/path.ts
@@ -9,22 +9,24 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { P0_PATH } from "../../util";
+import { compact } from "lodash";
 import * as path from "path";
 
-export const getIdentityFilePath = () =>
-  process.env.P0_ORG
-    ? path.join(P0_PATH, `identity-${process.env.P0_ORG}.json`)
-    : path.join(P0_PATH, "identity.json");
+export const postfixPath = (fname: string) => {
+  const parts = fname.split(".");
+  return path.join(
+    P0_PATH,
+    process.env.P0_ORG
+      ? compact([`${parts[0]}-${process.env.P0_ORG}`, parts[1]]).join(".")
+      : fname
+  );
+};
 
-export const getIdentityCachePath = () =>
-  process.env.P0_ORG
-    ? path.join(P0_PATH, `cache-${process.env.P0_ORG}`)
-    : path.join(P0_PATH, "cache");
+export const getIdentityFilePath = () => postfixPath("identity.json");
 
-export const getConfigFilePath = () =>
-  process.env.P0_ORG
-    ? path.join(P0_PATH, `config.json-${process.env.P0_ORG}`)
-    : path.join(P0_PATH, "config.json");
+export const getIdentityCachePath = () => postfixPath("cache");
+
+export const getConfigFilePath = () => postfixPath("config.json");
 
 export const getBootstrapOrgDataPath = (orgId: string): string => {
   const safeOrgId = path.basename(orgId);

--- a/src/drivers/stdio.ts
+++ b/src/drivers/stdio.ts
@@ -18,6 +18,21 @@ You should have received a copy of the GNU General Public License along with @p0
 import { sleep } from "../util";
 import { Ansi, AnsiSgr } from "./ansi";
 import { stderr } from "process";
+import yargs from "yargs";
+
+/** Log with debugging
+ *
+ * Debug logs are written to stderr
+ */
+export function debug(
+  argv: yargs.ArgumentsCamelCase<{ debug?: boolean }>,
+  message: string,
+  ...rest: any
+) {
+  if (!argv.debug) return;
+  // eslint-disable-next-line no-console
+  console.error(message, ...rest);
+}
 
 /** Used to output machine-readable text to stdout
  *


### PR DESCRIPTION
**Problem**

P0 is adding support for registering Claude MCP clients with P0, allowing Claude to be used to call MCP servers hosted within P0's agentic gateway.

Currently the P0 controller hosts REST endpoints for client registration and server discovery. However, use of these REST endpoints requires manual cURL.

**Change**

Adds:

`p0 claude mcp add :server -s :scope`

This command:
1. Uses a previously registered MCP client, or registers a new MCP client if none exists on the local user account
2. Installs the referenced server in the local Claude installation, under the appropriate scope

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

With a MCP gateway `local` installed, install the built-in P0 MCP server:

`p0 claude mcp add p0-local -s user`
