### PR TITLE
add support for multiple delegates

### DIFF
--- a/src/commands/__tests__/kubeconfig.test.ts
+++ b/src/commands/__tests__/kubeconfig.test.ts
@@ -1,0 +1,183 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { spinUntil } from "../../drivers/stdio";
+import { awsCloudAuth } from "../../plugins/aws/auth";
+import { AwsResourcePermissionSpec } from "../../plugins/aws/types";
+import {
+  getAndValidateK8sIntegration,
+  requestAccessToCluster,
+} from "../../plugins/kubeconfig";
+import { ensureEksInstall } from "../../plugins/kubeconfig/install";
+import { K8sPermissionSpec } from "../../plugins/kubeconfig/types";
+import { PermissionRequest } from "../../types/request";
+import { exec } from "../../util";
+import { writeAwsConfigProfile, writeAwsTempCredentials } from "../aws/files";
+import { kubeconfigCommand } from "../kubeconfig";
+import { noop } from "lodash";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import yargs from "yargs";
+
+vi.mock("../../drivers/auth", () => ({
+  authenticate: vi.fn(async () => ({ identity: { email: "u@p0.app" } })),
+}));
+vi.mock("../../drivers/stdio", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../drivers/stdio")>()),
+  print2: vi.fn(),
+  spinUntil: vi.fn(async (_msg, action) => action),
+}));
+vi.mock("../../plugins/aws/auth");
+vi.mock("../../plugins/kubeconfig");
+vi.mock("../../plugins/kubeconfig/install");
+vi.mock("../aws/files");
+vi.mock("../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../util")>()),
+  exec: vi.fn(async () => ({ stdout: "ok", stderr: "", code: 0 })),
+}));
+
+const mockAwsCloudAuth = awsCloudAuth as Mock;
+const mockGetAndValidateK8sIntegration = getAndValidateK8sIntegration as Mock;
+const mockEnsureEksInstall = ensureEksInstall as Mock;
+const mockRequestAccessToCluster = requestAccessToCluster as Mock;
+const mockWriteAwsTempCredentials = writeAwsTempCredentials as Mock;
+const mockWriteAwsConfigProfile = writeAwsConfigProfile as Mock;
+const mockSpinUntil = spinUntil as unknown as Mock;
+const mockExec = exec as Mock;
+
+const AWS_DELEGATE: AwsResourcePermissionSpec = {
+  type: "aws",
+  permission: {
+    account: "acct",
+    accountId: "111111111111",
+    arn: "arn:aws:iam::111111111111:role/foo",
+    idcId: undefined,
+    idcRegion: undefined,
+    name: "p0-role",
+  },
+  generated: { name: "p0-role" },
+  delegation: {},
+};
+
+const buildRequest = (
+  delegation: K8sPermissionSpec["delegation"]
+): PermissionRequest<K8sPermissionSpec> => ({
+  type: "k8s",
+  permission: {
+    resource: { name: "*", namespace: "*", kind: "Pod" },
+    role: "ClusterRole / view",
+    clusterId: "c-1",
+    type: "resource",
+  },
+  generated: { role: "p0-generated-role" },
+  delegation,
+  status: "DONE",
+  principal: "u@p0.app",
+});
+
+const runKubeconfig = async () =>
+  kubeconfigCommand(yargs())
+    .fail(noop)
+    .parse(
+      "kubeconfig --cluster c-1 --role ClusterRole/view"
+    ) as unknown as Promise<unknown>;
+
+describe("kubeconfigAction", () => {
+  beforeEach(() => {
+    mockGetAndValidateK8sIntegration.mockResolvedValue({
+      clusterConfig: {
+        clusterId: "c-1",
+        awsAccountId: "111111111111",
+        awsClusterArn: "arn:aws:eks:us-east-1:111111111111:cluster/my-cluster",
+      },
+      awsLoginType: "federated",
+    });
+    mockEnsureEksInstall.mockResolvedValue(true);
+    mockAwsCloudAuth.mockResolvedValue({
+      AWS_ACCESS_KEY_ID: "k",
+      AWS_SECRET_ACCESS_KEY: "s",
+      AWS_SESSION_TOKEN: "t",
+      AWS_SECURITY_TOKEN: "t",
+    });
+    mockSpinUntil.mockImplementation(async (_msg: string, action: any) => action);
+    mockExec.mockResolvedValue({ stdout: "ok", stderr: "", code: 0 });
+    mockWriteAwsTempCredentials.mockResolvedValue(undefined);
+    mockWriteAwsConfigProfile.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the aws delegate to awsCloudAuth when delegation is in legacy record form", async () => {
+    mockRequestAccessToCluster.mockResolvedValue(
+      buildRequest({ aws: AWS_DELEGATE })
+    );
+
+    await runKubeconfig();
+
+    expect(mockAwsCloudAuth).toHaveBeenCalledOnce();
+    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
+  });
+
+  it("passes the aws delegate to awsCloudAuth when delegation is in new array form", async () => {
+    mockRequestAccessToCluster.mockResolvedValue(
+      buildRequest([{ key: "aws", request: AWS_DELEGATE }])
+    );
+
+    await runKubeconfig();
+
+    expect(mockAwsCloudAuth).toHaveBeenCalledOnce();
+    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
+  });
+
+  it("throws when delegation is array-form but has no aws entry", async () => {
+    mockRequestAccessToCluster.mockResolvedValue(buildRequest([]));
+
+    await expect(runKubeconfig()).rejects.toBe(
+      "Backend granted k8s access, but this is not an EKS cluster."
+    );
+    expect(mockAwsCloudAuth).not.toHaveBeenCalled();
+  });
+
+  it("resolves equivalent shapes identically", async () => {
+    mockRequestAccessToCluster.mockResolvedValueOnce(
+      buildRequest({ aws: AWS_DELEGATE })
+    );
+    await runKubeconfig();
+    const recordCallArg = mockAwsCloudAuth.mock.calls[0]?.[1];
+
+    vi.clearAllMocks();
+    mockGetAndValidateK8sIntegration.mockResolvedValue({
+      clusterConfig: {
+        clusterId: "c-1",
+        awsAccountId: "111111111111",
+        awsClusterArn: "arn:aws:eks:us-east-1:111111111111:cluster/my-cluster",
+      },
+      awsLoginType: "federated",
+    });
+    mockEnsureEksInstall.mockResolvedValue(true);
+    mockAwsCloudAuth.mockResolvedValue({
+      AWS_ACCESS_KEY_ID: "k",
+      AWS_SECRET_ACCESS_KEY: "s",
+      AWS_SESSION_TOKEN: "t",
+      AWS_SECURITY_TOKEN: "t",
+    });
+    mockSpinUntil.mockImplementation(async (_msg: string, action: any) => action);
+    mockExec.mockResolvedValue({ stdout: "ok", stderr: "", code: 0 });
+    mockRequestAccessToCluster.mockResolvedValueOnce(
+      buildRequest([{ key: "aws", request: AWS_DELEGATE }])
+    );
+    await runKubeconfig();
+    const arrayCallArg = mockAwsCloudAuth.mock.calls[0]?.[1];
+
+    expect(arrayCallArg).toEqual(recordCallArg);
+  });
+});
+

--- a/src/commands/__tests__/kubeconfig.test.ts
+++ b/src/commands/__tests__/kubeconfig.test.ts
@@ -105,7 +105,9 @@ describe("kubeconfigAction", () => {
       AWS_SESSION_TOKEN: "t",
       AWS_SECURITY_TOKEN: "t",
     });
-    mockSpinUntil.mockImplementation(async (_msg: string, action: any) => action);
+    mockSpinUntil.mockImplementation(
+      async (_msg: string, action: any) => action
+    );
     mockExec.mockResolvedValue({ stdout: "ok", stderr: "", code: 0 });
     mockWriteAwsTempCredentials.mockResolvedValue(undefined);
     mockWriteAwsConfigProfile.mockResolvedValue(undefined);
@@ -169,7 +171,9 @@ describe("kubeconfigAction", () => {
       AWS_SESSION_TOKEN: "t",
       AWS_SECURITY_TOKEN: "t",
     });
-    mockSpinUntil.mockImplementation(async (_msg: string, action: any) => action);
+    mockSpinUntil.mockImplementation(
+      async (_msg: string, action: any) => action
+    );
     mockExec.mockResolvedValue({ stdout: "ok", stderr: "", code: 0 });
     mockRequestAccessToCluster.mockResolvedValueOnce(
       buildRequest([{ key: "aws", request: AWS_DELEGATE }])
@@ -180,4 +184,3 @@ describe("kubeconfigAction", () => {
     expect(arrayCallArg).toEqual(recordCallArg);
   });
 });
-

--- a/src/commands/aws/__tests__/rds.test.ts
+++ b/src/commands/aws/__tests__/rds.test.ts
@@ -12,10 +12,10 @@ import { fetchIntegrationConfig } from "../../../drivers/api";
 import { awsCloudAuth } from "../../../plugins/aws/auth";
 import { AwsResourcePermissionSpec } from "../../../plugins/aws/types";
 import { DbPermissionSpec } from "../../../plugins/db/types";
+import { failure } from "../../../testing/yargs";
 import { Authn } from "../../../types/identity";
 import { PermissionRequest } from "../../../types/request";
 import { exec } from "../../../util";
-import { failure } from "../../../testing/yargs";
 import { decodeProvisionStatus } from "../../shared";
 import { request } from "../../shared/request";
 import { writeAwsConfigProfile, writeAwsTempCredentials } from "../files";
@@ -212,9 +212,7 @@ describe("rds generate-db-auth-token", () => {
       "rds generate-db-auth-token --arch postgres --role admin"
     );
 
-    expect(error).toBe(
-      "P0 granted access, but db-1 is not a RDS instance."
-    );
+    expect(error).toBe("P0 granted access, but db-1 is not a RDS instance.");
     expect(mockAwsCloudAuth).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/aws/__tests__/rds.test.ts
+++ b/src/commands/aws/__tests__/rds.test.ts
@@ -1,0 +1,220 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { fetchIntegrationConfig } from "../../../drivers/api";
+import { awsCloudAuth } from "../../../plugins/aws/auth";
+import { AwsResourcePermissionSpec } from "../../../plugins/aws/types";
+import { DbPermissionSpec } from "../../../plugins/db/types";
+import { Authn } from "../../../types/identity";
+import { PermissionRequest } from "../../../types/request";
+import { exec } from "../../../util";
+import { failure } from "../../../testing/yargs";
+import { decodeProvisionStatus } from "../../shared";
+import { request } from "../../shared/request";
+import { writeAwsConfigProfile, writeAwsTempCredentials } from "../files";
+import { rds } from "../rds";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import yargs from "yargs";
+
+vi.mock("../../../drivers/api");
+vi.mock("../../../drivers/auth");
+vi.mock("../../../drivers/stdio", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../drivers/stdio")>()),
+  print1: vi.fn(),
+  print2: vi.fn(),
+}));
+vi.mock("../../../plugins/aws/auth");
+vi.mock("../files");
+vi.mock("../../shared", () => ({
+  decodeProvisionStatus: vi.fn(),
+}));
+vi.mock("../../shared/request", () => ({
+  request: vi.fn(),
+}));
+vi.mock("../../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../util")>()),
+  exec: vi.fn(),
+}));
+
+const mockRequest = request as unknown as Mock;
+const mockDecodeProvisionStatus = decodeProvisionStatus as Mock;
+const mockAwsCloudAuth = awsCloudAuth as Mock;
+const mockFetchIntegrationConfig = fetchIntegrationConfig as Mock;
+const mockWriteAwsTempCredentials = writeAwsTempCredentials as Mock;
+const mockWriteAwsConfigProfile = writeAwsConfigProfile as Mock;
+const mockExec = exec as Mock;
+
+const AWS_DELEGATE: AwsResourcePermissionSpec = {
+  type: "aws",
+  permission: {
+    account: "acct",
+    accountId: "111111111111",
+    arn: "arn:aws:rds:us-east-1:111111111111:db:my-db",
+    idcId: undefined,
+    idcRegion: undefined,
+    name: "p0-rds-role",
+  },
+  generated: { name: "p0-rds-role" },
+  delegation: {},
+};
+
+const buildAccess = (
+  delegation: DbPermissionSpec["delegation"]
+): PermissionRequest<DbPermissionSpec> => ({
+  type: "postgres",
+  permission: { instanceId: "db-1" },
+  generated: {},
+  delegation,
+  status: "DONE",
+  principal: "user@p0.app",
+});
+
+const FAKE_AUTHN: Authn = {
+  identity: { org: { slug: "test", tenantId: "t" } },
+} as unknown as Authn;
+
+const buildRdsYargs = () => rds(yargs() as any, FAKE_AUTHN);
+
+describe("rds generate-db-auth-token", () => {
+  beforeEach(() => {
+    // request() is curried: request("request")(args, authn, options)
+    mockRequest.mockReturnValue(async () => undefined);
+    mockDecodeProvisionStatus.mockResolvedValue(1);
+    mockAwsCloudAuth.mockResolvedValue({
+      AWS_ACCESS_KEY_ID: "k",
+      AWS_SECRET_ACCESS_KEY: "s",
+      AWS_SESSION_TOKEN: "t",
+      AWS_SECURITY_TOKEN: "t",
+    });
+    mockFetchIntegrationConfig.mockResolvedValue({
+      config: {
+        "iam-write": {
+          "db-1": {
+            hostname: "db.host",
+            port: "5432",
+            hosting: {
+              type: "aws-rds",
+              databaseArn: "arn:aws:rds:us-east-1:111111111111:db:my-db",
+              vpcId: "vpc-1",
+            },
+            state: "installed",
+          },
+        },
+      },
+    });
+    mockWriteAwsTempCredentials.mockResolvedValue(undefined);
+    mockWriteAwsConfigProfile.mockResolvedValue(undefined);
+    mockExec.mockResolvedValue({
+      stdout: "fake-rds-token",
+      stderr: "",
+      code: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const mockAccessResponse = (
+    delegation: DbPermissionSpec["delegation"]
+  ): void => {
+    mockRequest.mockReturnValue(async () => ({
+      ok: true,
+      message: "approved",
+      id: "req-1",
+      isPreexisting: false,
+      isPersistent: false,
+      isPreapproved: false,
+      request: buildAccess(delegation),
+    }));
+  };
+
+  it("passes the inner aws delegate to awsCloudAuth (legacy nested record form)", async () => {
+    mockAccessResponse({
+      "aws-rds": {
+        permission: { vpcId: "vpc-1" },
+        delegation: { aws: AWS_DELEGATE },
+      },
+    });
+
+    await buildRdsYargs().parse(
+      "rds generate-db-auth-token --arch postgres --role admin"
+    );
+
+    expect(mockAwsCloudAuth).toHaveBeenCalledOnce();
+    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
+  });
+
+  it("passes the inner aws delegate to awsCloudAuth (new array form at both levels)", async () => {
+    mockAccessResponse([
+      {
+        key: "aws-rds",
+        request: {
+          permission: { vpcId: "vpc-1" },
+          delegation: [{ key: "aws", request: AWS_DELEGATE }],
+        },
+      },
+    ]);
+
+    await buildRdsYargs().parse(
+      "rds generate-db-auth-token --arch postgres --role admin"
+    );
+
+    expect(mockAwsCloudAuth).toHaveBeenCalledOnce();
+    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
+  });
+
+  it("supports mixed nesting (array outer, record inner)", async () => {
+    mockAccessResponse([
+      {
+        key: "aws-rds",
+        request: {
+          permission: { vpcId: "vpc-1" },
+          delegation: { aws: AWS_DELEGATE },
+        },
+      },
+    ]);
+
+    await buildRdsYargs().parse(
+      "rds generate-db-auth-token --arch postgres --role admin"
+    );
+
+    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
+  });
+
+  it("supports mixed nesting (record outer, array inner)", async () => {
+    mockAccessResponse({
+      "aws-rds": {
+        permission: { vpcId: "vpc-1" },
+        delegation: [{ key: "aws", request: AWS_DELEGATE }],
+      },
+    });
+
+    await buildRdsYargs().parse(
+      "rds generate-db-auth-token --arch postgres --role admin"
+    );
+
+    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
+  });
+
+  it("throws when array-form delegation is missing the aws-rds entry", async () => {
+    mockAccessResponse([]);
+
+    const error = await failure(
+      buildRdsYargs(),
+      "rds generate-db-auth-token --arch postgres --role admin"
+    );
+
+    expect(error).toBe(
+      "P0 granted access, but db-1 is not a RDS instance."
+    );
+    expect(mockAwsCloudAuth).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/aws/rds.ts
+++ b/src/commands/aws/rds.ts
@@ -13,6 +13,7 @@ import { print1, print2 } from "../../drivers/stdio";
 import { awsCloudAuth } from "../../plugins/aws/auth";
 import { parseArn } from "../../plugins/aws/utils";
 import { DbPermissionSpec } from "../../plugins/db/types";
+import { getDelegate } from "../../types/delegation";
 import { Authn } from "../../types/identity";
 import { PermissionRequest } from "../../types/request";
 import { exec, osSafeCommand, throwAssertNever } from "../../util";
@@ -152,7 +153,8 @@ const fetchConfig = async (
 const rdsGenerateDbAuthToken = async (argv: RdsArgs, authn: Authn) => {
   const access = await requestRdsAccess(argv, authn);
 
-  const awsDelegation = access.delegation?.["aws-rds"].delegation?.aws;
+  const awsRdsDelegate = getDelegate(access.delegation, "aws-rds");
+  const awsDelegation = getDelegate(awsRdsDelegate?.delegation, "aws");
   if (!awsDelegation) {
     throw `P0 granted access, but ${access.permission.instanceId} is not a RDS instance.`;
   }
@@ -169,7 +171,7 @@ const rdsGenerateDbAuthToken = async (argv: RdsArgs, authn: Authn) => {
 
   const database = argv.database ?? dbConfig.defaultDb;
 
-  const dbResource = access.delegation["aws-rds"].delegation.aws.permission.arn;
+  const dbResource = awsDelegation.permission.arn;
 
   const { region } = parseArn(dbResource);
   const profileName = `p0_${access.permission.instanceId}`;

--- a/src/commands/kubeconfig.ts
+++ b/src/commands/kubeconfig.ts
@@ -21,6 +21,7 @@ import {
   requestAccessToCluster,
 } from "../plugins/kubeconfig";
 import { ensureEksInstall } from "../plugins/kubeconfig/install";
+import { getDelegate } from "../types/delegation";
 import { ciEquals, exec, osSafeCommand } from "../util";
 import { writeAwsConfigProfile, writeAwsTempCredentials } from "./aws/files";
 import yargs from "yargs";
@@ -100,7 +101,7 @@ const kubeconfigAction = async (
   // No spinUntil(); there is one inside requestAccessToCluster() if needed
   const request = await requestAccessToCluster(authn, args, clusterId, role);
 
-  const awsDelegation = request.delegation.aws;
+  const awsDelegation = getDelegate(request.delegation, "aws");
   if (!awsDelegation) {
     throw "Backend granted k8s access, but this is not an EKS cluster.";
   }

--- a/src/plugins/aws/__tests__/ssh.test.ts
+++ b/src/plugins/aws/__tests__/ssh.test.ts
@@ -179,9 +179,9 @@ describe("awsSshProvider.requestToSsh", () => {
     });
 
     it("throws when neither delegation nor resource provides accountId", () => {
-      expect(() =>
-        awsSshProvider.requestToSsh(buildRequest([]))
-      ).toThrow("Backend did not provide an AWS account ID for SSH session.");
+      expect(() => awsSshProvider.requestToSsh(buildRequest([]))).toThrow(
+        "Backend did not provide an AWS account ID for SSH session."
+      );
     });
   });
 });

--- a/src/plugins/aws/__tests__/ssh.test.ts
+++ b/src/plugins/aws/__tests__/ssh.test.ts
@@ -1,0 +1,187 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { CliPermissionSpec } from "../../../types/ssh";
+import { awsSshProvider } from "../ssh";
+import {
+  AwsResourcePermissionSpec,
+  AwsSshGenerated,
+  AwsSshPermission,
+  AwsSshPermissionSpec,
+} from "../types";
+import { describe, expect, it } from "vitest";
+
+type SshRequest = CliPermissionSpec<AwsSshPermissionSpec, undefined>;
+
+const AWS_DELEGATE_IDC: AwsResourcePermissionSpec = {
+  type: "aws",
+  permission: {
+    account: "acct",
+    accountId: "111111111111",
+    arn: "arn:aws:iam::111111111111:role/foo",
+    idcId: "idc-1",
+    idcRegion: "us-east-1",
+    name: "permset",
+  },
+  generated: { name: "delegated-name" },
+  delegation: {},
+};
+
+const AWS_DELEGATE_ROLE: AwsResourcePermissionSpec = {
+  ...AWS_DELEGATE_IDC,
+  permission: {
+    ...AWS_DELEGATE_IDC.permission,
+    idcId: undefined,
+    idcRegion: undefined,
+  },
+};
+
+const PERMISSION_BASE: AwsSshPermission = {
+  provider: "aws",
+  publicKey: "pub-key",
+  region: "us-east-1",
+  alias: "alias",
+  resource: {
+    instanceId: "i-abc123",
+    userName: "ec2-user",
+  },
+};
+
+const GENERATED: AwsSshGenerated = {
+  hostKeys: ["host-key"],
+  linuxUserName: "linux-user",
+  publicKey: "pub-key",
+  resource: { name: "fallback-name" },
+};
+
+const buildRequest = (
+  delegation: AwsSshPermissionSpec["delegation"],
+  permission: AwsSshPermission = PERMISSION_BASE
+): SshRequest => ({
+  type: "ssh",
+  permission,
+  generated: GENERATED,
+  delegation,
+  cliLocalData: undefined,
+});
+
+describe("awsSshProvider.requestToSsh", () => {
+  describe("legacy record-form delegation", () => {
+    it("builds an IDC request when idc fields are populated", () => {
+      const result = awsSshProvider.requestToSsh(
+        buildRequest({ aws: AWS_DELEGATE_IDC })
+      );
+      expect(result).toEqual({
+        type: "aws",
+        access: "idc",
+        accountId: "111111111111",
+        id: "i-abc123",
+        region: "us-east-1",
+        linuxUserName: "linux-user",
+        hostKeys: ["host-key"],
+        idc: { id: "idc-1", region: "us-east-1" },
+        permissionSet: "delegated-name",
+      });
+    });
+
+    it("builds a role request when idc fields are absent", () => {
+      const result = awsSshProvider.requestToSsh(
+        buildRequest({ aws: AWS_DELEGATE_ROLE })
+      );
+      expect(result).toEqual({
+        type: "aws",
+        access: "role",
+        accountId: "111111111111",
+        id: "i-abc123",
+        region: "us-east-1",
+        linuxUserName: "linux-user",
+        hostKeys: ["host-key"],
+        role: "delegated-name",
+      });
+    });
+  });
+
+  describe("new array-form delegation", () => {
+    it("builds an IDC request when idc fields are populated", () => {
+      const result = awsSshProvider.requestToSsh(
+        buildRequest([{ key: "aws", request: AWS_DELEGATE_IDC }])
+      );
+      expect(result).toEqual({
+        type: "aws",
+        access: "idc",
+        accountId: "111111111111",
+        id: "i-abc123",
+        region: "us-east-1",
+        linuxUserName: "linux-user",
+        hostKeys: ["host-key"],
+        idc: { id: "idc-1", region: "us-east-1" },
+        permissionSet: "delegated-name",
+      });
+    });
+
+    it("builds a role request when idc fields are absent", () => {
+      const result = awsSshProvider.requestToSsh(
+        buildRequest([{ key: "aws", request: AWS_DELEGATE_ROLE }])
+      );
+      expect(result).toEqual({
+        type: "aws",
+        access: "role",
+        accountId: "111111111111",
+        id: "i-abc123",
+        region: "us-east-1",
+        linuxUserName: "linux-user",
+        hostKeys: ["host-key"],
+        role: "delegated-name",
+      });
+    });
+
+    it("produces the same output as the record form for equivalent input", () => {
+      const recordResult = awsSshProvider.requestToSsh(
+        buildRequest({ aws: AWS_DELEGATE_IDC })
+      );
+      const arrayResult = awsSshProvider.requestToSsh(
+        buildRequest([{ key: "aws", request: AWS_DELEGATE_IDC }])
+      );
+      expect(arrayResult).toEqual(recordResult);
+    });
+  });
+
+  describe("fallback to resource", () => {
+    it("falls back to resource when delegation has no aws entry (array form)", () => {
+      const permissionWithFullResource: AwsSshPermission = {
+        ...PERMISSION_BASE,
+        resource: {
+          ...PERMISSION_BASE.resource,
+          account: "fallback-acct",
+          accountId: "999999999999",
+          arn: "arn:aws:iam::999999999999:role/fallback",
+          idcId: undefined,
+          idcRegion: undefined,
+          name: "fallback-role",
+        },
+      };
+      const result = awsSshProvider.requestToSsh(
+        buildRequest([], permissionWithFullResource)
+      );
+      expect(result).toMatchObject({
+        type: "aws",
+        access: "role",
+        accountId: "999999999999",
+        role: "fallback-name",
+      });
+    });
+
+    it("throws when neither delegation nor resource provides accountId", () => {
+      expect(() =>
+        awsSshProvider.requestToSsh(buildRequest([]))
+      ).toThrow("Backend did not provide an AWS account ID for SSH session.");
+    });
+  });
+});

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -15,6 +15,7 @@ import {
 } from "../../common/keys";
 import { fetchSshHostKeys, submitPublicKey } from "../../drivers/api";
 import { print2 } from "../../drivers/stdio";
+import { getDelegate } from "../../types/delegation";
 import { SshProvider } from "../../types/ssh";
 import { getAppName, throwAssertNever } from "../../util";
 import { assumeRoleWithOktaSaml } from "../okta/aws";
@@ -173,11 +174,15 @@ export const awsSshProvider: SshProvider<
     const { resource, region } = permission;
     const { instanceId } = resource;
     const { linuxUserName, hostKeys } = generated;
+    const awsDelegate = getDelegate(delegation, "aws");
     // TODO: Update after P0 backend data-model update
     const { idcId, idcRegion, accountId } =
-      delegation?.aws?.permission ?? resource;
+      awsDelegate?.permission ?? resource;
+    if (!accountId) {
+      throw "Backend did not provide an AWS account ID for SSH session.";
+    }
     const name =
-      delegation?.aws?.generated.name ?? generated?.resource?.name ?? "";
+      awsDelegate?.generated.name ?? generated?.resource?.name ?? "";
     const common = {
       linuxUserName,
       accountId,

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -176,13 +176,11 @@ export const awsSshProvider: SshProvider<
     const { linuxUserName, hostKeys } = generated;
     const awsDelegate = getDelegate(delegation, "aws");
     // TODO: Update after P0 backend data-model update
-    const { idcId, idcRegion, accountId } =
-      awsDelegate?.permission ?? resource;
+    const { idcId, idcRegion, accountId } = awsDelegate?.permission ?? resource;
     if (!accountId) {
       throw "Backend did not provide an AWS account ID for SSH session.";
     }
-    const name =
-      awsDelegate?.generated.name ?? generated?.resource?.name ?? "";
+    const name = awsDelegate?.generated.name ?? generated?.resource?.name ?? "";
     const common = {
       linuxUserName,
       accountId,

--- a/src/plugins/db/types.ts
+++ b/src/plugins/db/types.ts
@@ -8,15 +8,16 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { DelegationField } from "../../types/delegation";
 import { AwsResourcePermissionSpec } from "../aws/types";
 
+type AwsRdsDelegate = {
+  delegation: DelegationField<{ aws: AwsResourcePermissionSpec }>;
+  permission: { vpcId: string };
+};
+
 export type DbPermissionSpec = {
-  delegation: {
-    "aws-rds": {
-      delegation: { aws: AwsResourcePermissionSpec };
-      permission: { vpcId: string };
-    };
-  };
+  delegation: DelegationField<{ "aws-rds": AwsRdsDelegate }>;
   generated: object;
   permission: { instanceId: string };
   type: "mysql" | "postgres";

--- a/src/plugins/kubeconfig/types.ts
+++ b/src/plugins/kubeconfig/types.ts
@@ -29,12 +29,9 @@ export type K8sConfig = {
 export type K8sPermissionSpec = PermissionSpec<
   "k8s",
   K8sResourcePermission,
-  K8sGenerated
-> & {
-  delegation?: {
-    aws?: AwsResourcePermissionSpec;
-  };
-};
+  K8sGenerated,
+  { aws?: AwsResourcePermissionSpec }
+>;
 
 export type K8sResourcePermission = {
   resource: {

--- a/src/types/__tests__/delegation.test.ts
+++ b/src/types/__tests__/delegation.test.ts
@@ -1,0 +1,144 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { DelegationField, getDelegate } from "../delegation";
+import { describe, expect, it } from "vitest";
+
+type AwsDelegate = {
+  permission: { accountId: string; arn: string };
+  generated: { name: string };
+};
+
+type AwsRdsDelegate = {
+  permission: { vpcId: string };
+  delegation: DelegationField<{ aws: AwsDelegate }>;
+};
+
+const AWS_DELEGATE: AwsDelegate = {
+  permission: { accountId: "123456789012", arn: "arn:aws:iam::123:role/Foo" },
+  generated: { name: "Foo" },
+};
+
+describe("getDelegate", () => {
+  describe("legacy record form", () => {
+    it("returns the delegate value when the key is present", () => {
+      const delegation: DelegationField<{ aws: AwsDelegate }> = {
+        aws: AWS_DELEGATE,
+      };
+      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
+    });
+
+    it("returns undefined when the key is absent on an optional field", () => {
+      const delegation: DelegationField<{ aws?: AwsDelegate }> = {};
+      expect(getDelegate(delegation, "aws")).toBeUndefined();
+    });
+
+    it("handles nested delegation by chaining calls", () => {
+      const delegation: DelegationField<{ "aws-rds": AwsRdsDelegate }> = {
+        "aws-rds": {
+          permission: { vpcId: "vpc-1" },
+          delegation: { aws: AWS_DELEGATE },
+        },
+      };
+      const rds = getDelegate(delegation, "aws-rds");
+      expect(getDelegate(rds?.delegation, "aws")).toEqual(AWS_DELEGATE);
+    });
+  });
+
+  describe("new array form", () => {
+    it("returns the request payload of the matching entry", () => {
+      const delegation: DelegationField<{ aws: AwsDelegate }> = [
+        { key: "aws", request: AWS_DELEGATE },
+      ];
+      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
+    });
+
+    it("returns undefined when no entry matches the key", () => {
+      const delegation: DelegationField<{ aws?: AwsDelegate }> = [];
+      expect(getDelegate(delegation, "aws")).toBeUndefined();
+    });
+
+    it("scans past non-matching entries to find the requested key", () => {
+      type Multi = { aws?: AwsDelegate; gcp?: AwsDelegate };
+      const other: AwsDelegate = {
+        permission: { accountId: "other", arn: "arn:gcp" },
+        generated: { name: "gcp" },
+      };
+      const delegation: DelegationField<Multi> = [
+        { key: "gcp", request: other },
+        { key: "aws", request: AWS_DELEGATE },
+      ];
+      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
+    });
+
+    it("returns the first matching entry when keys are duplicated", () => {
+      const first: AwsDelegate = {
+        permission: { accountId: "first", arn: "arn:first" },
+        generated: { name: "first" },
+      };
+      const second: AwsDelegate = {
+        permission: { accountId: "second", arn: "arn:second" },
+        generated: { name: "second" },
+      };
+      const delegation: DelegationField<{ aws: AwsDelegate }> = [
+        { key: "aws", request: first },
+        { key: "aws", request: second },
+      ];
+      expect(getDelegate(delegation, "aws")).toEqual(first);
+    });
+
+    it("handles nested array-form delegation by chaining calls", () => {
+      const delegation: DelegationField<{ "aws-rds": AwsRdsDelegate }> = [
+        {
+          key: "aws-rds",
+          request: {
+            permission: { vpcId: "vpc-1" },
+            delegation: [{ key: "aws", request: AWS_DELEGATE }],
+          },
+        },
+      ];
+      const rds = getDelegate(delegation, "aws-rds");
+      expect(getDelegate(rds?.delegation, "aws")).toEqual(AWS_DELEGATE);
+    });
+
+    it("handles a mixed nesting (array outside, record inside)", () => {
+      const delegation: DelegationField<{ "aws-rds": AwsRdsDelegate }> = [
+        {
+          key: "aws-rds",
+          request: {
+            permission: { vpcId: "vpc-1" },
+            delegation: { aws: AWS_DELEGATE },
+          },
+        },
+      ];
+      const rds = getDelegate(delegation, "aws-rds");
+      expect(getDelegate(rds?.delegation, "aws")).toEqual(AWS_DELEGATE);
+    });
+
+    it("ignores malformed entries (missing key) without throwing", () => {
+      const delegation = [
+        null,
+        undefined,
+        { key: "aws", request: AWS_DELEGATE },
+      ] as any;
+      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
+    });
+  });
+
+  describe("nullish input", () => {
+    it("returns undefined when delegation is undefined", () => {
+      expect(getDelegate(undefined, "aws")).toBeUndefined();
+    });
+
+    it("returns undefined when delegation is null", () => {
+      expect(getDelegate(null, "aws")).toBeUndefined();
+    });
+  });
+});

--- a/src/types/delegation.ts
+++ b/src/types/delegation.ts
@@ -23,11 +23,11 @@ export type DelegationEntry<K extends string, R> = {
 /** Delegation field that tolerates both the legacy record form and the new
  * array form. Callers should not read this directly — use {@link getDelegate}.
  */
-export type DelegationField<Old extends Record<string, any>> =
+export type DelegationField<Spec extends Record<string, any>> =
   | {
-      [K in keyof Old & string]: DelegationEntry<K, Old[K]>;
-    }[keyof Old & string][]
-  | Old;
+      [K in keyof Spec & string]: DelegationEntry<K, Spec[K]>;
+    }[keyof Spec & string][]
+  | Spec;
 
 /** Resolve a delegate by key, accepting either the legacy record-form
  * delegation or the new array-form delegation.
@@ -35,9 +35,9 @@ export type DelegationField<Old extends Record<string, any>> =
  * Returns the underlying delegate value (with `permission`, `generated`,
  * and nested `delegation` fields), or `undefined` if no entry matches.
  *
- * The generic shape (`K`, `V` rather than the full `Old` record) is
- * deliberate: matching the union `DelegationField<Old>` bidirectionally
- * confuses TS's inference and can lock `Old` onto the array branch.
+ * The generic shape (`K`, `V` rather than the full `Spec` record) is
+ * deliberate: matching the union `DelegationField<Spec>` bidirectionally
+ * confuses TS's inference and can lock `Spec` onto the array branch.
  * Pinning `K` to the key argument and inferring `V` from the value avoids
  * that.
  */

--- a/src/types/delegation.ts
+++ b/src/types/delegation.ts
@@ -42,8 +42,7 @@ export type DelegationField<Old extends Record<string, any>> =
  * that.
  */
 export const getDelegate = <K extends string, V>(
-  delegation:
-    DelegationEntry<K, V>[] | { [P in K]?: V } | null | undefined,
+  delegation: DelegationEntry<K, V>[] | { [P in K]?: V } | null | undefined,
   key: K
 ): V | undefined => {
   if (delegation == null) return undefined;

--- a/src/types/delegation.ts
+++ b/src/types/delegation.ts
@@ -1,0 +1,55 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+
+/** An entry in the new array-form delegation shape.
+ *
+ * The backend used to send delegation as a record (`{ aws: { ... } }`); it now
+ * sends it as an array of `{ key, request }` entries. The `request` field holds
+ * what used to be the record's value (permission, generated, nested delegation).
+ */
+export type DelegationEntry<K extends string, R> = {
+  key: K;
+  request: R;
+};
+
+/** Delegation field that tolerates both the legacy record form and the new
+ * array form. Callers should not read this directly — use {@link getDelegate}.
+ */
+export type DelegationField<Old extends Record<string, any>> =
+  | {
+      [K in keyof Old & string]: DelegationEntry<K, Old[K]>;
+    }[keyof Old & string][]
+  | Old;
+
+/** Resolve a delegate by key, accepting either the legacy record-form
+ * delegation or the new array-form delegation.
+ *
+ * Returns the underlying delegate value (with `permission`, `generated`,
+ * and nested `delegation` fields), or `undefined` if no entry matches.
+ *
+ * The generic shape (`K`, `V` rather than the full `Old` record) is
+ * deliberate: matching the union `DelegationField<Old>` bidirectionally
+ * confuses TS's inference and can lock `Old` onto the array branch.
+ * Pinning `K` to the key argument and inferring `V` from the value avoids
+ * that.
+ */
+export const getDelegate = <K extends string, V>(
+  delegation:
+    DelegationEntry<K, V>[] | { [P in K]?: V } | null | undefined,
+  key: K
+): V | undefined => {
+  if (delegation == null) return undefined;
+  if (Array.isArray(delegation)) {
+    const entry = delegation.find((e) => e?.key === key);
+    return entry?.request;
+  }
+  return delegation[key];
+};

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { DbPermissionSpec } from "../plugins/db/types";
 import { K8sPermissionSpec } from "../plugins/kubeconfig/types";
+import { DelegationField } from "./delegation";
 import { AzureRdpRequest } from "./rdp";
 import { PluginSshRequest } from "./ssh";
 
@@ -25,15 +26,15 @@ export type PermissionSpec<
   K extends string,
   P extends Record<string, any>,
   G extends object | undefined = undefined,
-  D extends Record<string, PermissionSpec<any, any, any, any>> = Record<
+  D extends Record<
     string,
-    never
-  >,
+    PermissionSpec<any, any, any, any> | undefined
+  > = Record<string, never>,
 > = {
   type: K;
   permission: P;
   generated: G;
-  delegation: D;
+  delegation?: DelegationField<D>;
 };
 
 export type PluginRequest =


### PR DESCRIPTION
**Problem**

The main app is changing its delegation data model: `request.delegation` will start arriving as an array of `{ key, request }` entries rather than as a record keyed by integration name. Without this change, the CLI's `kubeconfig`, `aws rds generate-db-auth-token`, and AWS SSH flows would silently break the moment the backend rolls out the new shape — `request.delegation.aws` and `access.delegation["aws-rds"]` would return `undefined`, and users would see "not an EKS cluster" / "not a RDS instance" errors despite a valid grant.

**Change**

Introduces a small abstraction over the delegation field so both shapes work during (and after) the backend migration:

- New `src/types/delegation.ts` exports `DelegationField<Old>` (a union of the legacy record form and the new array form) and a `getDelegate(delegation, key)` helper that resolves a delegate by key from either shape.
- `PermissionSpec.delegation` is now `DelegationField<D>` and optional, with `D`'s constraint widened to allow `undefined`-valued entries (lets `K8sPermissionSpec` declare `{ aws?: AwsResourcePermissionSpec }`).
- `K8sPermissionSpec`, `DbPermissionSpec`, and `AwsSshPermissionSpec` updated to accept either shape.
- The four call sites (`commands/kubeconfig.ts`, `commands/aws/rds.ts`, `plugins/aws/ssh.ts`) switched to `getDelegate`. The AWS SSH path also gains an explicit throw when `accountId` is missing — previously implicit, surfaced by the helper's `| undefined` return.

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Automated tests:

- `getDelegate` unit tests covering record form, array form, nested + mixed nesting, malformed entries, nullish input (12 tests).
- Type-level assertions confirming both shapes assign to `K8sPermissionSpec`, `DbPermissionSpec`, `AwsSshPermissionSpec` (8 tests — compile-time check).
- Pure-function tests for `awsSshProvider.requestToSsh` covering both shapes, the `resource` fallback path, and the missing-`accountId` error path (7 tests).
- yargs-driven integration tests for `kubeconfigAction` and `rds generate-db-auth-token` that mock the network/exec/file boundaries and assert `awsCloudAuth` receives the same `AwsResourcePermissionSpec` regardless of which shape the backend sent. RDS covers all four nesting combinations (record/record, array/array, array/record, record/array) — 9 tests.

All 158 tests in the suite pass. `tsc --noEmit` is clean.

Risk: low. The change is additive — the helper accepts either shape, and every consumer that reads delegation already routes through it. Construction sites in tests and any code that builds permission specs still work because assigning a required field to an optional slot is always allowed.

Tested with actual commands

```
./p0 kubeconfig --cluster dev-test-cluster-1 \
 --resource '* / * / *' \
 --role 'ClusterRole / admin' \
 --reason 'miguel said so' \
 --duration '8 hours'

./p0 ssh random-id-goes-here

./p0 aws rds generate-db-auth-token --arch="postgres" --role="pg_read_all_data" --database="postgres" --instance="p0-test-1-aurora-pg"
```

**Tracking (optional)**

https://linear.app/p0-security/issue/CUS-337/cli-support-multiple-delegates

**Implementation (optional)**

- `getDelegate`'s generics are factored as `<K extends string, V>` (with `K` pinned to the key argument and `V` inferred from the value) rather than `<Old, K extends keyof Old>`. The latter caused TS 4.8 to bidirectionally infer `Old` as the array branch when matching the union `DelegationField<Old>`, breaking the key constraint. The current shape avoids that.
- `DbPermissionSpec` still spells out its fields directly rather than extending `PermissionSpec` — the inner `aws-rds` delegate doesn't carry `type` or `generated` in the current type, so wrapping it in `PermissionSpec` would require confirming the backend actually sends those fields.

**Follow-up Work (optional)**

- Once the backend has fully cut over to the array form, the record-form branch of `DelegationField` can be removed.
- Revisit `DbPermissionSpec`/`AwsRdsDelegate` to align with `PermissionSpec` if the backend confirms `type`/`generated` are present on the nested `aws-rds` delegate.
