### PR TITLE
[CUS-54] Added file-transfer cli logic to invoke the download command to ec2 instance

### DIFF
--- a/src/commands/__tests__/index.test.ts
+++ b/src/commands/__tests__/index.test.ts
@@ -74,6 +74,7 @@ vi.mock("../../drivers/stdio", () => ({
 // Mock config to prevent actual config loading
 vi.mock("../../drivers/config", () => ({
   getHelpMessage: vi.fn(() => "For help, visit https://p0.dev"),
+  getContactMessage: vi.fn(() => "Contact P0 for help."),
 }));
 
 // Mock version check middleware

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -89,8 +89,7 @@ const fileTransferAction = async (
       const target = await provisionTransferRequest(authn, args);
       print2(`Access approved for s3://${target.bucket}/${target.prefix}`);
 
-      // target.prefix is the backend-granted prefix (ends in `/`); append the
-      // local file's basename so the S3 object preserves the original filename.
+      // append original basename so the S3 object preserves the original filename.
       const uploadKey = `${target.prefix}${basename(args.source)}`;
 
       print2("Preparing upload credentials...");
@@ -159,14 +158,11 @@ const fileTransferAction = async (
 
       print2("Uploaded.");
 
-      // Step 2: have the destination instance pull the file from S3.
-      // This is a separate approval ticket (SSH provider) — file-transfer
-      // access granted bucket write only, not instance shell access.
+      // TODO we need to remove this second request. it should be included in file transfer delegation. Will be removed in future ticket
       print2(`Requesting download access on ${args.destination}...`);
 
       // Drop `source` (local file path) before passing to SSH plumbing —
-      // `createCommand` uses `"source" in args` to route between scp and ssh,
-      // and we want the ssh branch here.
+      // `createCommand` uses `"source" in args` to branch between scp and ssh path, and we want the ssh branch here.
       const { source: _source, ...sshBaseArgs } = args;
       const sshCmdArgs = {
         ...sshBaseArgs,
@@ -177,7 +173,7 @@ const fileTransferAction = async (
       const { request, requestId, privateKey, sshProvider, sshHostKeys } =
         await prepareRequest(authn, sshCmdArgs, args.destination);
 
-      // Re-sign GET URL now so the 5-min TTL starts after approval clears,
+      // Sign GET URL now so the 5-min TTL starts after approval clears,
       // not before — otherwise long approval waits could expire the URL.
       const { signedUrl: getUrl, expirySeconds: getExpirySeconds } =
         await generateSignedUrl(

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -14,9 +14,8 @@ import { print2 } from "../drivers/stdio";
 import { exitProcess, traceSpan } from "../opentelemetry/otel-helpers";
 import {
   createTransferClient,
-  generateTransferUrls,
+  generateSignedUrl,
   provisionTransferRequest,
-  signGetUrl,
 } from "../plugins/file-transfer";
 import { sshOrScp } from "../plugins/ssh";
 import { prepareRequest } from "./shared/ssh";
@@ -97,17 +96,19 @@ const fileTransferAction = async (
       print2("Preparing upload credentials...");
       const s3 = createTransferClient(authn, target, args.debug);
       // TODO probably can move generating delete URL later and rename this method to be clear it only makes delete url now
-      const { deleteUrl, expirySeconds } = await generateTransferUrls(
-        authn,
-        s3,
-        { ...target, key: uploadKey },
-        args.debug
-      );
+      const { signedUrl: deleteUrl, expirySeconds: deleteExpirySeconds } =
+        await generateSignedUrl(
+          authn,
+          s3,
+          { ...target, key: uploadKey },
+          "delete",
+          args.debug
+        );
 
-      // TODO: remove logging when we remove the launchdarkly file-transfer flag
+      // TODO: remove logging actual credential but log expiry when we remove the launchdarkly file-transfer flag
       if (args.debug) {
         print2(
-          `DELETE (${renderDurationSec(expirySeconds.delete)}): ${deleteUrl}`
+          `DELETE (${renderDurationSec(deleteExpirySeconds)}): ${deleteUrl}`
         );
       }
 
@@ -179,14 +180,16 @@ const fileTransferAction = async (
 
       // Re-sign GET URL now so the 5-min TTL starts after approval clears,
       // not before — otherwise long approval waits could expire the URL.
-      const { url: freshGetUrl, expirySeconds: getExpiry } = await signGetUrl(
-        authn,
-        s3,
-        { bucket: target.bucket, key: uploadKey, awsSpec: target.awsSpec },
-        args.debug
-      );
+      const { signedUrl: getUrl, expirySeconds: getExpirySeconds } =
+        await generateSignedUrl(
+          authn,
+          s3,
+          { bucket: target.bucket, key: uploadKey, awsSpec: target.awsSpec },
+          "get",
+          args.debug
+        );
       if (args.debug) {
-        print2(`GET    (${renderDurationSec(getExpiry)}): ${freshGetUrl}`);
+        print2(`GET    (${renderDurationSec(getExpirySeconds)}): ${getUrl}`);
       }
 
       const remotePath = `/home/${request.linuxUserName}/${basename(args.source)}`;
@@ -200,7 +203,7 @@ const fileTransferAction = async (
       const downloadCmdArgs = {
         ...sshCmdArgs,
         command: "curl",
-        arguments: ["-sSfL", freshGetUrl, "-o", remotePath],
+        arguments: ["-sSfL", getUrl, "-o", remotePath],
       };
 
       const exitCode = await sshOrScp({

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -95,7 +95,7 @@ const fileTransferAction = async (
 
       print2("Preparing upload credentials...");
       const s3 = createTransferClient(authn, target, args.debug);
-      // TODO probably can move generating delete URL later and rename this method to be clear it only makes delete url now
+      // TODO probably can move generating delete URL later
       const { signedUrl: deleteUrl, expirySeconds: deleteExpirySeconds } =
         await generateSignedUrl(
           authn,

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -95,7 +95,6 @@ const fileTransferAction = async (
 
       print2("Preparing upload credentials...");
       const s3 = createTransferClient(authn, target, args.debug);
-      // TODO probably can move generating delete URL later
       const { signedUrl: deleteUrl, expirySeconds: deleteExpirySeconds } =
         await generateSignedUrl(
           authn,

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -166,8 +166,8 @@ const fileTransferAction = async (
       const { source: _source, ...sshBaseArgs } = args;
       const sshCmdArgs = {
         ...sshBaseArgs,
-        arguments: [] as string[],
-        sshOptions: [] as string[],
+        arguments: [],
+        sshOptions: [],
       };
 
       const { request, requestId, privateKey, sshProvider, sshHostKeys } =

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -11,11 +11,14 @@ You should have received a copy of the GNU General Public License along with @p0
 import { retryWithSleep } from "../common/retry";
 import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
-import { traceSpan } from "../opentelemetry/otel-helpers";
+import { exitProcess, traceSpan } from "../opentelemetry/otel-helpers";
 import {
   generateTransferUrls,
   provisionTransferRequest,
+  signGetUrl,
 } from "../plugins/file-transfer";
+import { sshOrScp } from "../plugins/ssh";
+import { prepareRequest } from "./shared/ssh";
 import { Upload } from "@aws-sdk/lib-storage";
 import { createReadStream, statSync } from "fs";
 import { basename } from "node:path";
@@ -88,18 +91,16 @@ const fileTransferAction = async (
       const uploadKey = `${target.prefix}${basename(args.source)}`;
 
       print2("Preparing upload credentials...");
-      const { s3, getUrl, deleteUrl, expirySeconds } =
-        await generateTransferUrls(
-          authn,
-          { ...target, key: uploadKey },
-          args.debug
-        );
+      const { s3, deleteUrl, expirySeconds } = await generateTransferUrls(
+        authn,
+        { ...target, key: uploadKey },
+        args.debug
+      );
 
       const renderDurationSec = (s: number) =>
         s >= 3600 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 60)}m`;
       // TODO: remove logging when we remove the launchdarkly file-transfer flag
       if (args.debug) {
-        print2(`GET    (${renderDurationSec(expirySeconds.get)}): ${getUrl}`);
         print2(
           `DELETE (${renderDurationSec(expirySeconds.delete)}): ${deleteUrl}`
         );
@@ -152,6 +153,74 @@ const fileTransferAction = async (
       }
 
       print2("Uploaded.");
+
+      // Step 2: have the destination instance pull the file from S3.
+      // This is a separate approval ticket (SSH provider) — file-transfer
+      // access granted bucket write only, not instance shell access.
+      print2(`Requesting download access on ${args.destination}...`);
+
+      // Drop `source` (local file path) before passing to SSH plumbing —
+      // `createCommand` uses `"source" in args` to route between scp and ssh,
+      // and we want the ssh branch here.
+      const { source: _source, ...sshBaseArgs } = args;
+      const sshCmdArgs = {
+        ...sshBaseArgs,
+        arguments: [] as string[],
+        sshOptions: [] as string[],
+      };
+
+      const { request, requestId, privateKey, sshProvider, sshHostKeys } =
+        await prepareRequest(authn, sshCmdArgs, args.destination);
+
+      // Re-sign GET URL now so the 5-min TTL starts after approval clears,
+      // not before — otherwise long approval waits could expire the URL.
+      const { url: freshGetUrl, expirySeconds: getExpiry } = await signGetUrl(
+        s3,
+        { bucket: target.bucket, key: uploadKey }
+      );
+      if (args.debug) {
+        print2(`GET    (${renderDurationSec(getExpiry)}): ${freshGetUrl}`);
+      }
+
+      const remotePath = `/home/${request.linuxUserName}/${basename(args.source)}`;
+      print2(
+        `Downloading to ${request.linuxUserName}@${args.destination}:${remotePath}...`
+      );
+
+      // TODO(CUS-68): final download command (curl vs aws s3 cp vs wget) is
+      // being decided in CUS-68. Using curl for now — universally present on
+      // mainstream EC2 AMIs (Amazon Linux, Ubuntu, RHEL, etc.).
+      const downloadCmdArgs = {
+        ...sshCmdArgs,
+        command: "curl",
+        arguments: ["-sSfL", freshGetUrl, "-o", remotePath],
+      };
+
+      const exitCode = await sshOrScp({
+        authn,
+        request,
+        requestId,
+        cmdArgs: downloadCmdArgs,
+        privateKey,
+        sshProvider,
+        sshHostKeys,
+      });
+
+      if (exitCode === 127) {
+        throw `curl not found on ${args.destination}. The file is in S3 — install curl on the instance and re-run, or wait for CUS-68 to add a fallback downloader.`;
+      }
+      if (exitCode !== null && exitCode !== 0) {
+        throw `Remote download exited with code ${exitCode}`;
+      }
+
+      print2(`Downloaded to ${remotePath}.`);
+
+      // Force exit to prevent hanging due to orphaned child processes (e.g.,
+      // session-manager-plugin) holding open file descriptors. See:
+      // https://github.com/aws/amazon-ssm-agent/issues/173
+      if (process.env.NODE_ENV !== "unit") {
+        exitProcess(0);
+      }
     },
     {
       command: "file-transfer",

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -24,6 +24,7 @@ vi.mock("@aws-sdk/client-s3", () => ({
   GetObjectCommand: vi.fn(),
 }));
 
+const FIVE_MINUTES = 5 * 60;
 const ONE_HOUR = 60 * 60;
 const NOW = Date.parse("2030-01-01T00:00:00Z");
 const defaultCredentials = {
@@ -81,8 +82,8 @@ describe("generateTransferUrl()", () => {
 
     const result = await generateSignedUrl(authn, s3, target, "get");
 
-    expect(signedExpiries()).toBe(ONE_HOUR);
-    expect(result.expirySeconds).toBe(ONE_HOUR);
+    expect(signedExpiries()).toBe(FIVE_MINUTES);
+    expect(result.expirySeconds).toBe(FIVE_MINUTES);
   });
 
   it("caps the window to the remaining credential lifetime", async () => {
@@ -102,7 +103,7 @@ describe("generateTransferUrl()", () => {
 
     await generateSignedUrl(authn, s3, target, "get");
 
-    expect(signedExpiries()).toBe(ONE_HOUR);
+    expect(signedExpiries()).toBe(FIVE_MINUTES);
   });
 
   it("throws when credentials are already expired", async () => {
@@ -127,16 +128,18 @@ describe("generateTransferUrl()", () => {
     );
   });
 
-  it("correctly generates get signed URL when get command passed in", async () => {
+  it("correctly generates get signed URL and max get expiry time when get command passed in", async () => {
     const result = await generateSignedUrl(authn, s3, target, "get");
     expect(result.signedUrl).toBe("https://signed.example/url");
+    expect(result.expirySeconds).toBe(FIVE_MINUTES);
     expect(GetObjectCommand).toHaveBeenCalledOnce();
     expect(DeleteObjectCommand).not.toHaveBeenCalled();
   });
 
-  it("correctly generates delete signed URL when delete command passed in", async () => {
+  it("correctly generates delete signed URL and max delete expiry time when delete command passed in", async () => {
     const result = await generateSignedUrl(authn, s3, target, "delete");
     expect(result.signedUrl).toBe("https://signed.example/url");
+    expect(result.expirySeconds).toBe(ONE_HOUR);
     expect(DeleteObjectCommand).toHaveBeenCalledOnce();
     expect(GetObjectCommand).not.toHaveBeenCalled();
   });

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -10,7 +10,8 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { awsCloudAuth } from "../../aws/auth";
 import type { AwsResourcePermissionSpec } from "../../aws/types";
-import { generateTransferUrls } from "../index";
+import { generateSignedUrl } from "../index";
+import { GetObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,11 +19,21 @@ vi.mock("../../aws/auth", () => ({ awsCloudAuth: vi.fn() }));
 vi.mock("@aws-sdk/s3-request-presigner", () => ({
   getSignedUrl: vi.fn().mockResolvedValue("https://signed.example/url"),
 }));
+vi.mock("@aws-sdk/client-s3", () => ({
+  DeleteObjectCommand: vi.fn(),
+  GetObjectCommand: vi.fn(),
+}));
 
 const ONE_HOUR = 60 * 60;
 const NOW = Date.parse("2030-01-01T00:00:00Z");
+const defaultCredentials = {
+  AWS_ACCESS_KEY_ID: "test",
+  AWS_SECRET_ACCESS_KEY: "test",
+  AWS_SESSION_TOKEN: "test",
+  AWS_SECURITY_TOKEN: "test",
+};
 
-describe("generateTransferUrls()", () => {
+describe("generateTransferUrl()", () => {
   const target = {
     bucket: "my-bucket",
     key: "uploads/user/abc/file.txt",
@@ -44,16 +55,18 @@ describe("generateTransferUrls()", () => {
   const authn = {} as any;
   const s3 = {} as any;
 
-  // expiresIn passed to the GET and DELETE getSignedUrl calls, respectively.
-  const signedExpiries = () => ({
-    get: vi.mocked(getSignedUrl).mock.calls[0]![2]!.expiresIn,
-    delete: vi.mocked(getSignedUrl).mock.calls[1]![2]!.expiresIn,
-  });
+  // expiresIn passed to the getSignedUrl call.
+  const signedExpiries = () =>
+    vi.mocked(getSignedUrl).mock.calls[0]![2]!.expiresIn;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
+    vi.mocked(awsCloudAuth).mockResolvedValue({
+      ...defaultCredentials,
+      expiresAt: NOW + 2 * ONE_HOUR * 1000, // future time that won't be expired
+    });
   });
 
   afterEach(() => {
@@ -62,51 +75,69 @@ describe("generateTransferUrls()", () => {
 
   it("uses the full configured window when credentials outlive it", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({
+      ...defaultCredentials,
       expiresAt: NOW + 2 * ONE_HOUR * 1000,
-    } as any);
+    });
 
-    const result = await generateTransferUrls(authn, s3, target);
+    const result = await generateSignedUrl(authn, s3, target, "get");
 
-    expect(signedExpiries()).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
-    expect(result.expirySeconds).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
+    expect(signedExpiries()).toBe(ONE_HOUR);
+    expect(result.expirySeconds).toBe(ONE_HOUR);
   });
 
   it("caps the window to the remaining credential lifetime", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({
+      ...defaultCredentials,
       expiresAt: NOW + 300 * 1000, // 5 minutes left
-    } as any);
+    });
 
-    const result = await generateTransferUrls(authn, s3, target);
+    const result = await generateSignedUrl(authn, s3, target, "get");
 
-    expect(signedExpiries()).toEqual({ get: 300, delete: 300 });
-    expect(result.expirySeconds).toEqual({ get: 300, delete: 300 });
+    expect(signedExpiries()).toBe(300);
+    expect(result.expirySeconds).toBe(300);
   });
 
   it("falls back to the configured window when expiry is unknown", async () => {
-    vi.mocked(awsCloudAuth).mockResolvedValue({} as any);
+    vi.mocked(awsCloudAuth).mockResolvedValue({ ...defaultCredentials });
 
-    await generateTransferUrls(authn, s3, target);
+    await generateSignedUrl(authn, s3, target, "get");
 
-    expect(signedExpiries()).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
+    expect(signedExpiries()).toBe(ONE_HOUR);
   });
 
   it("throws when credentials are already expired", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({
+      ...defaultCredentials,
       expiresAt: NOW - 1000,
-    } as any);
+    });
 
-    await expect(generateTransferUrls(authn, s3, target)).rejects.toThrow(
+    await expect(generateSignedUrl(authn, s3, target, "get")).rejects.toThrow(
       /too soon to sign usable URLs/
     );
   });
 
   it("throws when credentials expire below the usable threshold", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({
+      ...defaultCredentials,
       expiresAt: NOW + 30 * 1000, // 30s left, below 60s threshold
-    } as any);
+    });
 
-    await expect(generateTransferUrls(authn, s3, target)).rejects.toThrow(
+    await expect(generateSignedUrl(authn, s3, target, "get")).rejects.toThrow(
       /too soon to sign usable URLs/
     );
+  });
+
+  it("correctly generates get signed URL when get command passed in", async () => {
+    const result = await generateSignedUrl(authn, s3, target, "get");
+    expect(result.signedUrl).toBe("https://signed.example/url");
+    expect(GetObjectCommand).toHaveBeenCalledOnce();
+    expect(DeleteObjectCommand).not.toHaveBeenCalled();
+  });
+
+  it("correctly generates delete signed URL when delete command passed in", async () => {
+    const result = await generateSignedUrl(authn, s3, target, "delete");
+    expect(result.signedUrl).toBe("https://signed.example/url");
+    expect(DeleteObjectCommand).toHaveBeenCalledOnce();
+    expect(GetObjectCommand).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -34,7 +34,7 @@ const defaultCredentials = {
   AWS_SECURITY_TOKEN: "test",
 };
 
-describe("generateTransferUrl()", () => {
+describe("generateSignedUrl()", () => {
   const target = {
     bucket: "my-bucket",
     key: "uploads/user/abc/file.txt",

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { FileTransferCommandArgs } from "../../commands/file-transfer";
 import { request } from "../../commands/shared/request";
+import { getDelegate } from "../../types/delegation";
 import { Authn } from "../../types/identity";
 import { PermissionRequest } from "../../types/request";
 import { awsCloudAuth } from "../aws/auth";
@@ -52,7 +53,7 @@ export const provisionTransferRequest = async (
     throw "Did not receive a response from server";
   }
 
-  const awsSpec = response.request.delegation.aws;
+  const awsSpec = getDelegate(response.request.delegation, "aws");
   if (!awsSpec) {
     throw "Backend granted file-transfer access, but there was an error getting AWS access details";
   }

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -79,9 +79,8 @@ export const generateTransferUrls = async (
   debug?: boolean
 ): Promise<{
   s3: S3Client;
-  getUrl: string;
   deleteUrl: string;
-  expirySeconds: { get: number; delete: number };
+  expirySeconds: { delete: number };
 }> => {
   const credentials = await awsCloudAuth(authn, target.awsSpec, debug);
 
@@ -96,23 +95,29 @@ export const generateTransferUrls = async (
     credentials: sdkCredentials,
   });
 
-  const objectArgs = { Bucket: target.bucket, Key: target.key };
-  const [getUrl, deleteUrl] = await Promise.all([
-    getSignedUrl(s3, new GetObjectCommand(objectArgs), {
-      expiresIn: GET_EXPIRES_SECONDS,
-    }),
-    getSignedUrl(s3, new DeleteObjectCommand(objectArgs), {
-      expiresIn: DELETE_EXPIRES_SECONDS,
-    }),
-  ]);
+  const deleteUrl = await getSignedUrl(
+    s3,
+    new DeleteObjectCommand({ Bucket: target.bucket, Key: target.key }),
+    { expiresIn: DELETE_EXPIRES_SECONDS }
+  );
 
   return {
     s3,
-    getUrl,
     deleteUrl,
-    expirySeconds: {
-      get: GET_EXPIRES_SECONDS,
-      delete: DELETE_EXPIRES_SECONDS,
-    },
+    expirySeconds: { delete: DELETE_EXPIRES_SECONDS },
   };
+};
+
+// GET URL is signed late (after SSH approval clears) so the 5-min TTL covers
+// the actual download window instead of expiring during approval wait.
+export const signGetUrl = async (
+  s3: S3Client,
+  target: { bucket: string; key: string }
+): Promise<{ url: string; expirySeconds: number }> => {
+  const url = await getSignedUrl(
+    s3,
+    new GetObjectCommand({ Bucket: target.bucket, Key: target.key }),
+    { expiresIn: GET_EXPIRES_SECONDS }
+  );
+  return { url, expirySeconds: GET_EXPIRES_SECONDS };
 };

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -25,7 +25,8 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { pick } from "lodash";
 import yargs from "yargs";
 
-const MAX_SECONDS_TO_EXPIRE_URL = 60 * 60;
+const MAX_SECONDS_TO_EXPIRE_GET_URL = 5 * 60;
+const MAX_SECONDS_TO_EXPIRE_DELETE_URL = 60 * 60;
 const MIN_URL_EXPIRY_THRESHOLD_SECONDS = 60;
 
 export const provisionTransferRequest = async (
@@ -127,7 +128,11 @@ export const generateSignedUrl = async (
         `Check your system clock or re-run the request.`
     );
   }
-  const secondsToExpireUrl = Math.min(MAX_SECONDS_TO_EXPIRE_URL, remaining);
+  const maxExpiry =
+    command === "get"
+      ? MAX_SECONDS_TO_EXPIRE_GET_URL
+      : MAX_SECONDS_TO_EXPIRE_DELETE_URL;
+  const secondsToExpireUrl = Math.min(maxExpiry, remaining);
 
   const s3Command =
     command === "get"

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -25,8 +25,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { pick } from "lodash";
 import yargs from "yargs";
 
-const SECONDS_TO_EXPIRE_GET_URL = 60 * 60;
-const SECONDS_TO_EXPIRE_DELETE_URL = 60 * 60;
+const MAX_SECONDS_TO_EXPIRE_URL = 60 * 60;
 const MIN_URL_EXPIRY_THRESHOLD_SECONDS = 60;
 
 export const provisionTransferRequest = async (
@@ -100,67 +99,23 @@ export const createTransferClient = (
   });
 
 /**
- * Signs the GET (download) and DELETE (cleanup) URLs. Call this AFTER the upload
+ * Signs the GET (download) or DELETE (cleanup) URL. Call this AFTER the upload
  * completes: the GET window is finite, and signing before a large upload would
  * burn that window while the file is still uploading.
  *
  * Each expiry is capped to the credentials' remaining lifetime so a URL can
  * never outlive the credentials that signed it.
  */
-export const generateTransferUrls = async (
+export const generateSignedUrl = async (
   authn: Authn,
   s3: S3Client,
   target: { bucket: string; key: string; awsSpec: AwsResourcePermissionSpec },
+  command: "delete" | "get",
   debug?: boolean
 ): Promise<{
-  deleteUrl: string;
-  expirySeconds: { delete: number };
+  signedUrl: string;
+  expirySeconds: number;
 }> => {
-  const secondsToExpireDeleteUrl = Math.min(
-    SECONDS_TO_EXPIRE_DELETE_URL,
-    await calculateRemainingTimeToExpiry(authn, target, debug)
-  );
-
-  const deleteUrl = await getSignedUrl(
-    s3,
-    new DeleteObjectCommand({ Bucket: target.bucket, Key: target.key }),
-    { expiresIn: secondsToExpireDeleteUrl }
-  );
-
-  return {
-    deleteUrl,
-    // Report the ACTUAL (capped) seconds so debug output is honest.
-    expirySeconds: {
-      delete: secondsToExpireDeleteUrl,
-    },
-  };
-};
-
-// GET URL is signed late (after SSH approval clears) so the 5-min TTL covers
-// the actual download window instead of expiring during approval wait.
-export const signGetUrl = async (
-  authn: Authn,
-  s3: S3Client,
-  target: { bucket: string; key: string; awsSpec: AwsResourcePermissionSpec },
-  debug?: boolean
-): Promise<{ url: string; expirySeconds: number }> => {
-  const secondsToExpireGetUrl = Math.min(
-    SECONDS_TO_EXPIRE_GET_URL,
-    await calculateRemainingTimeToExpiry(authn, target, debug)
-  );
-  const url = await getSignedUrl(
-    s3,
-    new GetObjectCommand({ Bucket: target.bucket, Key: target.key }),
-    { expiresIn: secondsToExpireGetUrl }
-  );
-  return { url, expirySeconds: secondsToExpireGetUrl };
-};
-
-const calculateRemainingTimeToExpiry = async (
-  authn: Authn,
-  target: { bucket: string; key: string; awsSpec: AwsResourcePermissionSpec },
-  debug?: boolean
-): Promise<number> => {
   const { expiresAt } = await awsCloudAuth(authn, target.awsSpec, debug);
   const remaining =
     expiresAt !== undefined
@@ -172,5 +127,19 @@ const calculateRemainingTimeToExpiry = async (
         `Check your system clock or re-run the request.`
     );
   }
-  return remaining;
+  const secondsToExpireUrl = Math.min(MAX_SECONDS_TO_EXPIRE_URL, remaining);
+
+  const s3Command =
+    command === "get"
+      ? new GetObjectCommand({ Bucket: target.bucket, Key: target.key })
+      : new DeleteObjectCommand({ Bucket: target.bucket, Key: target.key });
+  const signedUrl = await getSignedUrl(s3, s3Command, {
+    expiresIn: secondsToExpireUrl,
+  });
+
+  return {
+    signedUrl,
+    // Report the ACTUAL (capped) seconds so debug output is honest.
+    expirySeconds: secondsToExpireUrl,
+  };
 };

--- a/src/plugins/file-transfer/types.ts
+++ b/src/plugins/file-transfer/types.ts
@@ -29,9 +29,6 @@ export type FileTransferPermission = {
 export type FileTransferPermissionSpec = PermissionSpec<
   "file-transfer",
   FileTransferPermission,
-  Record<string, never>
-> & {
-  delegation: {
-    aws?: AwsResourcePermissionSpec;
-  };
-};
+  Record<string, never>,
+  { aws?: AwsResourcePermissionSpec }
+>;


### PR DESCRIPTION
**Problem**

The `file-transfer` command previously only handled half of the workflow: it uploaded a local file to a scoped S3 bucket and printed signed GET/DELETE URLs for the user to use manually. This change extends file-transfer to actually land the file on a target instance using a GET presigned url and `curl`.

**Change**

Extends `file-transfer` to complete the round trip in a single command:

1. Upload the local file to S3 (unchanged).
2. Request SSH access to the destination instance via the existing SSH approval flow.
3. Once approved, sign a fresh GET URL and have the instance pull the file via `curl` to the user's home directory.

The GET URL is now signed **after** the SSH approval clears rather than up front, so its 5-minute TTL covers the download window instead of being burned during the approval wait.

Also updates `delegation.aws` access to go through the typed `getDelegate` helper, matching how other plugins read delegation specs.

Check off any of the following areas of code that are modified:

- [x] authentication / authorization (uses SSH approval flow for the download leg)
- [x] workflow (file-transfer now composes upload + SSH download)
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Manual end-to-end test against a dev environment:
- Uploaded a file with `file-transfer <source> <destination>`, confirmed S3 upload succeeded.
- Confirmed SSH approval prompt appeared for the destination instance.
- After approval, confirmed file landed at `/home/<linuxUser>/<basename>` on the target.
- Confirmed the command exits cleanly (no hangs from orphaned `session-manager-plugin` processes).

Error paths covered:
- Missing `curl` on the remote (exit code 127) surfaces a clear error pointing at the followup ticket for a fallback downloader.
- Non-zero remote exit codes propagate with the code in the error message.

Risks:
- The download command is hardcoded to `curl` for now. Most mainstream EC2 AMIs ship with curl, but air-gapped or minimal images may not. Tracked as followup.
- The forced `exitProcess(0)` mirrors what the SSH commands already do for the same orphaned-child-process reason.

**Tracking (optional)**


**Implementation (optional)**

- Splits signed-URL generation: `generateSignedUrl` called to only sign the DELETE URL up front; `signGetUrl` is called later, after SSH approval, so the GET TTL isn't consumed by approval wait.
- The SSH leg reuses `prepareRequest` + `sshOrScp` from the existing SSH plumbing. `source` is stripped from args before reuse because `createCommand` routes on `"source" in args` to pick scp vs ssh, and we want the ssh branch here.
- `FileTransferPermissionSpec` moves `delegation.aws` from an intersection type into the `PermissionSpec` generic's delegation slot, matching the shape other permission specs use.
