### PR TITLE
add support for different shells like fish

### DIFF
--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -14,19 +14,17 @@ import { describe, expect, it } from "vitest";
 const asEnv = (env: Record<string, string>) => env as NodeJS.ProcessEnv;
 
 describe("detectShell", () => {
-  it("treats every common POSIX shell as posix", () => {
-    for (const shell of [
-      "/bin/bash",
-      "/usr/bin/bash",
-      "/usr/bin/zsh",
-      "/bin/zsh",
-      "/bin/sh",
-      "/bin/dash",
-      "/usr/bin/ksh",
-      "/usr/bin/bash", // git-bash on Windows reports this
-    ]) {
-      expect(detectShell(asEnv({ SHELL: shell }))).toBe("posix");
-    }
+  it.each([
+    "/bin/bash",
+    "/usr/bin/bash",
+    "/usr/bin/zsh",
+    "/bin/zsh",
+    "/bin/sh",
+    "/bin/dash",
+    "/usr/bin/ksh",
+    "/usr/bin/bash", // git-bash on Windows reports this
+  ])("treats %s as posix", (shell) => {
+    expect(detectShell(asEnv({ SHELL: shell }))).toBe("posix");
   });
 
   it("detects fish only on an exact basename match (no false positives)", () => {

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -44,7 +44,7 @@ describe("detectShell", () => {
   });
 });
 
-describe("posix formatter — must remain byte-identical to legacy output", () => {
+describe("posix formatter (env assignments/references remain byte-identical to legacy output)", () => {
   const f = newShellFormatter("posix");
 
   it("emits the legacy `export KEY=value` assignment", () => {
@@ -63,9 +63,9 @@ describe("posix formatter — must remain byte-identical to legacy output", () =
     expect(f.formatEnvReference("RDS_HOST")).toBe("${RDS_HOST}");
   });
 
-  it("emits POSIX command substitution", () => {
+  it("wraps command substitution in eval so multiline output runs line-by-line", () => {
     expect(f.formatEvalCommand("p0 aws role assume Role1")).toBe(
-      "$(p0 aws role assume Role1)"
+      'eval "$(p0 aws role assume Role1)"'
     );
   });
 });

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -1,0 +1,88 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { detectShell, newShellFormatter } from "../util";
+import { describe, expect, it } from "vitest";
+
+const asEnv = (env: Record<string, string>) => env as NodeJS.ProcessEnv;
+
+describe("detectShell", () => {
+  it("treats every common POSIX shell as posix", () => {
+    for (const shell of [
+      "/bin/bash",
+      "/usr/bin/bash",
+      "/usr/bin/zsh",
+      "/bin/zsh",
+      "/bin/sh",
+      "/bin/dash",
+      "/usr/bin/ksh",
+      "/usr/bin/bash", // git-bash on Windows reports this
+    ]) {
+      expect(detectShell(asEnv({ SHELL: shell }))).toBe("posix");
+    }
+  });
+
+  it("detects fish only on an exact basename match (no false positives)", () => {
+    expect(detectShell(asEnv({ SHELL: "/usr/bin/fish" }))).toBe("fish");
+    expect(detectShell(asEnv({ SHELL: "/opt/homebrew/bin/fish" }))).toBe(
+      "fish"
+    );
+    // A shell whose name merely contains "fish" must NOT be misclassified.
+    expect(detectShell(asEnv({ SHELL: "/bin/myfishshell" }))).toBe("posix");
+    expect(detectShell(asEnv({ SHELL: "/bin/swordfish" }))).toBe("posix");
+  });
+
+  it("defaults to posix when SHELL is unset", () => {
+    expect(detectShell(asEnv({}))).toBe("posix");
+  });
+});
+
+describe("posix formatter — must remain byte-identical to legacy output", () => {
+  const f = newShellFormatter("posix");
+
+  it("emits the legacy `export KEY=value` assignment", () => {
+    expect(f.formatEnvAssignment("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")).toBe(
+      "export AWS_ACCESS_KEY_ID=AKIAEXAMPLE"
+    );
+  });
+
+  it('emits the legacy quoted `export KEY="value"` for secrets', () => {
+    expect(
+      f.formatEnvAssignment("PGPASSWORD", "p@ss w0rd!", { quote: true })
+    ).toBe('export PGPASSWORD="p@ss w0rd!"');
+  });
+
+  it("emits the legacy `${KEY}` reference", () => {
+    expect(f.formatEnvReference("RDS_HOST")).toBe("${RDS_HOST}");
+  });
+
+  it("emits POSIX command substitution", () => {
+    expect(f.formatEvalCommand("p0 aws role assume Role1")).toBe(
+      "$(p0 aws role assume Role1)"
+    );
+  });
+});
+
+describe("fish formatter", () => {
+  const f = newShellFormatter("fish");
+
+  it("uses `set -gx` and `| source`", () => {
+    expect(f.formatEnvAssignment("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")).toBe(
+      "set -gx AWS_ACCESS_KEY_ID AKIAEXAMPLE"
+    );
+    expect(
+      f.formatEnvAssignment("PGPASSWORD", "p@ss w0rd!", { quote: true })
+    ).toBe('set -gx PGPASSWORD "p@ss w0rd!"');
+    expect(f.formatEnvReference("RDS_HOST")).toBe("$RDS_HOST");
+    expect(f.formatEvalCommand("p0 aws role assume Role1")).toBe(
+      "p0 aws role assume Role1 | source"
+    );
+  });
+});

--- a/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
+++ b/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
@@ -10,7 +10,7 @@ exports[`aws role > a single installed account > with Okta SAML > assume > shoul
     "
 Or, populate these environment variables by evaluating the output of this command:
 
-  $(p0 aws role assume Role1) ",
+  eval "$(p0 aws role assume Role1)" ",
   ],
 ]
 `;

--- a/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
+++ b/src/commands/aws/__tests__/__snapshots__/role.test.ts.snap
@@ -8,8 +8,8 @@ exports[`aws role > a single installed account > with Okta SAML > assume > shoul
   ],
   [
     "
-Or, populate these environment variables using BASH command substitution:
-  
+Or, populate these environment variables by evaluating the output of this command:
+
   $(p0 aws role assume Role1) ",
   ],
 ]
@@ -28,6 +28,38 @@ exports[`aws role > a single installed account > with Okta SAML > assume > shoul
   ],
   [
     "  export AWS_SECURITY_TOKEN=session-token",
+  ],
+]
+`;
+
+exports[`aws role > a single installed account > with Okta SAML > assume > should print fish-compatible syntax when the login shell is fish > stderr 1`] = `
+[
+  [
+    "Execute the following commands:
+",
+  ],
+  [
+    "
+Or, populate these environment variables by evaluating the output of this command:
+
+  p0 aws role assume Role1 | source ",
+  ],
+]
+`;
+
+exports[`aws role > a single installed account > with Okta SAML > assume > should print fish-compatible syntax when the login shell is fish > stdout 1`] = `
+[
+  [
+    "  set -gx AWS_ACCESS_KEY_ID test-access-key",
+  ],
+  [
+    "  set -gx AWS_SECRET_ACCESS_KEY secret-access-key",
+  ],
+  [
+    "  set -gx AWS_SESSION_TOKEN session-token",
+  ],
+  [
+    "  set -gx AWS_SECURITY_TOKEN session-token",
   ],
 ]
 `;

--- a/src/commands/aws/__tests__/rds.test.ts
+++ b/src/commands/aws/__tests__/rds.test.ts
@@ -9,6 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { fetchIntegrationConfig } from "../../../drivers/api";
+import { print2 } from "../../../drivers/stdio";
 import { awsCloudAuth } from "../../../plugins/aws/auth";
 import { AwsResourcePermissionSpec } from "../../../plugins/aws/types";
 import { DbPermissionSpec } from "../../../plugins/db/types";
@@ -50,6 +51,7 @@ const mockFetchIntegrationConfig = fetchIntegrationConfig as Mock;
 const mockWriteAwsTempCredentials = writeAwsTempCredentials as Mock;
 const mockWriteAwsConfigProfile = writeAwsConfigProfile as Mock;
 const mockExec = exec as Mock;
+const mockPrint2 = print2 as Mock;
 
 const AWS_DELEGATE: AwsResourcePermissionSpec = {
   type: "aws",
@@ -214,5 +216,50 @@ describe("rds generate-db-auth-token", () => {
 
     expect(error).toBe("P0 granted access, but db-1 is not a RDS instance.");
     expect(mockAwsCloudAuth).not.toHaveBeenCalled();
+  });
+
+  describe("connection instructions are shell-aware", () => {
+    const originalShell = process.env.SHELL;
+    afterEach(() => {
+      process.env.SHELL = originalShell;
+    });
+
+    const runWithShell = async (shell: string, arch: "mysql" | "postgres") => {
+      process.env.SHELL = shell;
+      mockAccessResponse({
+        "aws-rds": {
+          permission: { vpcId: "vpc-1" },
+          delegation: { aws: AWS_DELEGATE },
+        },
+      });
+      await buildRdsYargs().parse(
+        `rds generate-db-auth-token --arch ${arch} --role admin`
+      );
+      return mockPrint2.mock.calls.map((call) => call[0]).join("\n");
+    };
+
+    it("prints POSIX `export` / `${VAR}` instructions under bash (postgres)", async () => {
+      const output = await runWithShell("/bin/bash", "postgres");
+      expect(output).toContain('export PGPASSWORD="fake-rds-token"');
+      expect(output).toContain('export RDS_HOST="db.host"');
+      expect(output).toContain('export RDS_SSL_CA="/certs/global-bundle.pem"');
+      expect(output).toContain("host=${RDS_HOST}");
+      expect(output).not.toContain("set -gx");
+    });
+
+    it("prints fish `set -gx` / `$VAR` instructions when the login shell is fish (postgres)", async () => {
+      const output = await runWithShell("/usr/bin/fish", "postgres");
+      expect(output).toContain('set -gx PGPASSWORD "fake-rds-token"');
+      expect(output).toContain('set -gx RDS_HOST "db.host"');
+      expect(output).toContain('set -gx RDS_SSL_CA "/certs/global-bundle.pem"');
+      expect(output).toContain("host=$RDS_HOST");
+      expect(output).not.toContain("export PGPASSWORD");
+    });
+
+    it("uses MYSQL_PWD with fish syntax for mysql when the login shell is fish", async () => {
+      const output = await runWithShell("/usr/bin/fish", "mysql");
+      expect(output).toContain('set -gx MYSQL_PWD "fake-rds-token"');
+      expect(output).toContain("mysql -h $RDS_HOST");
+    });
   });
 });

--- a/src/commands/aws/__tests__/role.test.ts
+++ b/src/commands/aws/__tests__/role.test.ts
@@ -14,7 +14,7 @@ import { print1, print2 } from "../../../drivers/stdio";
 import { failure } from "../../../testing/yargs";
 import { samlResponse } from "./__input__/saml-response";
 import { stsResponse } from "./__input__/sts-response";
-import { beforeEach, describe, expect, it, vi, Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
 import yargs from "yargs";
 
 vi.mock("fs/promises");
@@ -96,7 +96,20 @@ describe("aws role", () => {
         });
       });
       describe("assume", () => {
+        const originalShell = process.env.SHELL;
+        afterEach(() => {
+          process.env.SHELL = originalShell;
+        });
+
         it("should assume a role", async () => {
+          process.env.SHELL = "/bin/bash";
+          await awsCommand(yargs()).parse("aws role assume Role1");
+          expect(mockPrint2.mock.calls).toMatchSnapshot("stderr");
+          expect(mockPrint1.mock.calls).toMatchSnapshot("stdout");
+        });
+
+        it("should print fish-compatible syntax when the login shell is fish", async () => {
+          process.env.SHELL = "/usr/bin/fish";
           await awsCommand(yargs()).parse("aws role assume Role1");
           expect(mockPrint2.mock.calls).toMatchSnapshot("stderr");
           expect(mockPrint1.mock.calls).toMatchSnapshot("stdout");

--- a/src/commands/aws/rds.ts
+++ b/src/commands/aws/rds.ts
@@ -16,7 +16,12 @@ import { DbPermissionSpec } from "../../plugins/db/types";
 import { getDelegate } from "../../types/delegation";
 import { Authn } from "../../types/identity";
 import { PermissionRequest } from "../../types/request";
-import { exec, osSafeCommand, throwAssertNever } from "../../util";
+import {
+  exec,
+  newShellFormatter,
+  osSafeCommand,
+  throwAssertNever,
+} from "../../util";
 import { decodeProvisionStatus } from "../shared";
 import { request } from "../shared/request";
 import { writeAwsConfigProfile, writeAwsTempCredentials } from "./files";
@@ -206,13 +211,18 @@ const rdsGenerateDbAuthToken = async (argv: RdsArgs, authn: Authn) => {
 
   const result = await exec(command, args, { check: true });
 
-  const pgInstructions = `export PGPASSWORD="${result.stdout.trim()}"
-  
-  psql "host=$\{RDS_HOST} port=${port} sslmode=verify-full sslrootcert=$\{RDS_SSL_CA} ${database ? `dbname=${database} ` : ""}user=${userName}"`;
+  const formatter = newShellFormatter();
+  const password = result.stdout.trim();
+  const rdsHostRef = formatter.formatEnvReference("RDS_HOST");
+  const rdsCaRef = formatter.formatEnvReference("RDS_SSL_CA");
 
-  const mysqlInstructions = `export MYSQL_PWD="${result.stdout.trim()}"
-  
-  mysql -h $\{RDS_HOST} --ssl-ca=$\{RDS_SSL_CA} --ssl-verify-server-cert -P ${port} -u ${userName} ${database}`;
+  const pgInstructions = `${formatter.formatEnvAssignment("PGPASSWORD", password, { quote: true })}
+
+  psql "host=${rdsHostRef} port=${port} sslmode=verify-full sslrootcert=${rdsCaRef} ${database ? `dbname=${database} ` : ""}user=${userName}"`;
+
+  const mysqlInstructions = `${formatter.formatEnvAssignment("MYSQL_PWD", password, { quote: true })}
+
+  mysql -h ${rdsHostRef} --ssl-ca=${rdsCaRef} --ssl-verify-server-cert -P ${port} -u ${userName} ${database}`;
 
   print2(result.stderr);
   print2(`Access your database by exporting the result of this command and executing psql in an environment with network access to the instance.
@@ -223,8 +233,8 @@ If you are executing from CloudShell this will be done for you already, and the 
 
 On CloudShell, you can execute:
 
-  export RDS_SSL_CA='/certs/global-bundle.pem'
-  export RDS_HOST='${dbConfig.hostname}'
+  ${formatter.formatEnvAssignment("RDS_SSL_CA", "/certs/global-bundle.pem", { quote: true })}
+  ${formatter.formatEnvAssignment("RDS_HOST", dbConfig.hostname, { quote: true })}
   ${argv.arch === "mysql" ? mysqlInstructions : argv.arch === "postgres" ? pgInstructions : throwAssertNever(argv.arch)}
 
 `);

--- a/src/commands/aws/util.ts
+++ b/src/commands/aws/util.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { print1, print2 } from "../../drivers/stdio";
 import { AwsCredentials } from "../../plugins/aws/types";
+import { newShellFormatter } from "../../util";
 import { sys } from "typescript";
 
 const CREDENTIAL_FIELDS: (keyof AwsCredentials)[] = [
@@ -25,20 +26,21 @@ export const printAwsCredentials = (
 ) => {
   const isTty = sys.writeOutputIsTTY?.();
   const indent = isTty ? "  " : "";
+  const formatter = newShellFormatter();
 
   if (isTty) print2("Execute the following commands:\n");
 
   for (const key of CREDENTIAL_FIELDS) {
     const value = awsCredentials[key];
     if (value) {
-      print1(`${indent}export ${key}=${value}`);
+      print1(`${indent}${formatter.formatEnvAssignment(key, value)}`);
     }
   }
 
   if (isTty) {
     print2(`
-Or, populate these environment variables using BASH command substitution:
-  
-  $(${command}) `);
+Or, populate these environment variables by evaluating the output of this command:
+
+  ${formatter.formatEvalCommand(command)} `);
   }
 };

--- a/src/plugins/aws/__tests__/ssh.test.ts
+++ b/src/plugins/aws/__tests__/ssh.test.ts
@@ -223,10 +223,10 @@ describe("awsSshProvider.reproCommands", () => {
     process.env.SHELL = originalShell;
   });
 
-  it("emits POSIX command substitution for a role request under bash", () => {
+  it("emits an eval-wrapped command substitution for a role request under bash", () => {
     process.env.SHELL = "/bin/bash";
     expect(awsSshProvider.reproCommands(ROLE_REQUEST)).toEqual([
-      "$(p0 aws role assume Role1 --account 123456789012 --no-request)",
+      'eval "$(p0 aws role assume Role1 --account 123456789012 --no-request)"',
     ]);
   });
 

--- a/src/plugins/aws/__tests__/ssh.test.ts
+++ b/src/plugins/aws/__tests__/ssh.test.ts
@@ -15,8 +15,16 @@ import {
   AwsSshGenerated,
   AwsSshPermission,
   AwsSshPermissionSpec,
+  AwsSshRequest,
 } from "../types";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Keep the printed app name deterministic; spread the original so the real
+// detectShell/newShellFormatter (which read process.env.SHELL) are used.
+vi.mock("../../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../util")>()),
+  getAppName: () => "p0",
+}));
 
 type SshRequest = CliPermissionSpec<AwsSshPermissionSpec, undefined>;
 
@@ -183,5 +191,54 @@ describe("awsSshProvider.requestToSsh", () => {
         "Backend did not provide an AWS account ID for SSH session."
       );
     });
+  });
+});
+
+describe("awsSshProvider.reproCommands", () => {
+  const ROLE_REQUEST: AwsSshRequest = {
+    type: "aws",
+    access: "role",
+    role: "Role1",
+    accountId: "123456789012",
+    region: "us-east-1",
+    id: "i-abc123",
+    linuxUserName: "ec2-user",
+    hostKeys: [],
+  };
+
+  const IDC_REQUEST: AwsSshRequest = {
+    type: "aws",
+    access: "idc",
+    permissionSet: "permset",
+    idc: { id: "idc-1", region: "us-east-1" },
+    accountId: "123456789012",
+    region: "us-east-1",
+    id: "i-abc123",
+    linuxUserName: "ec2-user",
+    hostKeys: [],
+  };
+
+  const originalShell = process.env.SHELL;
+  afterEach(() => {
+    process.env.SHELL = originalShell;
+  });
+
+  it("emits POSIX command substitution for a role request under bash", () => {
+    process.env.SHELL = "/bin/bash";
+    expect(awsSshProvider.reproCommands(ROLE_REQUEST)).toEqual([
+      "$(p0 aws role assume Role1 --account 123456789012 --no-request)",
+    ]);
+  });
+
+  it("emits fish-compatible piping for a role request when the login shell is fish", () => {
+    process.env.SHELL = "/usr/bin/fish";
+    expect(awsSshProvider.reproCommands(ROLE_REQUEST)).toEqual([
+      "p0 aws role assume Role1 --account 123456789012 --no-request | source",
+    ]);
+  });
+
+  it("returns undefined for IDC requests regardless of shell", () => {
+    process.env.SHELL = "/usr/bin/fish";
+    expect(awsSshProvider.reproCommands(IDC_REQUEST)).toBeUndefined();
   });
 });

--- a/src/plugins/aws/ssh.ts
+++ b/src/plugins/aws/ssh.ts
@@ -17,7 +17,7 @@ import { fetchSshHostKeys, submitPublicKey } from "../../drivers/api";
 import { print2 } from "../../drivers/stdio";
 import { getDelegate } from "../../types/delegation";
 import { SshProvider } from "../../types/ssh";
-import { getAppName, throwAssertNever } from "../../util";
+import { getAppName, newShellFormatter, throwAssertNever } from "../../util";
 import { assumeRoleWithOktaSaml } from "../okta/aws";
 import { getAwsConfig } from "./config";
 import { assumeRoleWithIdc } from "./idc";
@@ -126,9 +126,8 @@ export const awsSshProvider: SshProvider<
   reproCommands: (request) => {
     // TODO: Add manual commands for IDC login
     if (request.access !== "idc") {
-      return [
-        `eval $(${getAppName()} aws role assume ${request.role} --account ${request.accountId} --no-request)`,
-      ];
+      const assumeCommand = `${getAppName()} aws role assume ${request.role} --account ${request.accountId} --no-request`;
+      return [newShellFormatter().formatEvalCommand(assumeCommand)];
     }
     return undefined;
   },

--- a/src/plugins/ssh/__tests__/index.test.ts
+++ b/src/plugins/ssh/__tests__/index.test.ts
@@ -1,0 +1,134 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { sshProxy } from "../index";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../../drivers/api", () => ({
+  auditSshSessionActivity: vi.fn(async () => undefined),
+  fetchSshHostKeys: vi.fn(),
+}));
+
+vi.mock("../../../drivers/stdio", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../drivers/stdio")>()),
+  print2: vi.fn(),
+}));
+
+const mockSpawn = spawn as unknown as Mock;
+
+/** A minimal stand-in for a spawned ChildProcess that exits cleanly once
+ * spawnSshNode has attached its listeners. */
+const makeFakeChild = () => {
+  const child = new EventEmitter() as any;
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  child.unref = vi.fn();
+  setImmediate(() => child.emit("exit", 0));
+  return child;
+};
+
+const CREDENTIAL = {
+  AWS_ACCESS_KEY_ID: "AKIATEST",
+  AWS_SECRET_ACCESS_KEY: "secret-access-key",
+  AWS_SESSION_TOKEN: "session-token-123",
+  AWS_SECURITY_TOKEN: "session-token-123",
+};
+
+const fakeAwsProvider = {
+  cloudProviderLogin: vi.fn(async () => CREDENTIAL),
+  proxyCommand: () => ["aws", "ssm", "start-session", "--target", "i-abc123"],
+  propagationTimeoutMs: 1000,
+} as any;
+
+const runSshProxy = () =>
+  sshProxy({
+    authn: {} as any,
+    request: { type: "aws" } as any,
+    requestId: "req-1",
+    cmdArgs: {} as any,
+    privateKey: "pk",
+    sshProvider: fakeAwsProvider,
+    debug: false,
+    port: "22",
+  });
+
+const awsEnv = (env: NodeJS.ProcessEnv) => ({
+  AWS_ACCESS_KEY_ID: env.AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY: env.AWS_SECRET_ACCESS_KEY,
+  AWS_SESSION_TOKEN: env.AWS_SESSION_TOKEN,
+  AWS_SECURITY_TOKEN: env.AWS_SECURITY_TOKEN,
+});
+
+describe("sshProxy credential handoff stays shell-agnostic", () => {
+  const originalShell = process.env.SHELL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSpawn.mockImplementation(() => makeFakeChild());
+  });
+
+  afterEach(() => {
+    process.env.SHELL = originalShell;
+  });
+
+  it("injects AWS credentials into the spawned child env, without a shell", async () => {
+    process.env.SHELL = "/usr/bin/fish";
+    await runSshProxy();
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [command, , options] = mockSpawn.mock.calls[0]!;
+
+    // The spawned process is the binary itself, never the user's login shell,
+    // and Node is told not to interpose a shell.
+    expect(command).toBe("aws");
+    expect(options.shell).toBe(false);
+
+    // Credentials are delivered as environment variables on the child process.
+    expect(options.env.AWS_SESSION_TOKEN).toBe("session-token-123");
+    expect(options.env.AWS_ACCESS_KEY_ID).toBe("AKIATEST");
+    expect(options.env.AWS_SECRET_ACCESS_KEY).toBe("secret-access-key");
+  });
+
+  it("spawns identically regardless of $SHELL (login shell is never consulted)", async () => {
+    process.env.SHELL = "/usr/bin/fish";
+    await runSshProxy();
+    const [fishCmd, fishArgs, fishOpts] = mockSpawn.mock.calls[0]!;
+
+    vi.clearAllMocks();
+    mockSpawn.mockImplementation(() => makeFakeChild());
+
+    process.env.SHELL = "/bin/bash";
+    await runSshProxy();
+    const [bashCmd, bashArgs, bashOpts] = mockSpawn.mock.calls[0]!;
+
+    // Same command, args, and shell:false no matter the login shell.
+    expect(fishCmd).toBe("aws");
+    expect(bashCmd).toBe("aws");
+    expect(fishArgs).toEqual(bashArgs);
+    expect(fishOpts.shell).toBe(false);
+    expect(bashOpts.shell).toBe(false);
+
+    // Same injected credentials either way.
+    expect(awsEnv(fishOpts.env)).toEqual(awsEnv(bashOpts.env));
+    expect(fishOpts.env.AWS_SESSION_TOKEN).toBe("session-token-123");
+
+    // $SHELL is merely passed through (env is cloned), not used to decide
+    // anything — proving the credential handoff does not depend on it.
+    expect(fishOpts.env.SHELL).toBe("/usr/bin/fish");
+    expect(bashOpts.env.SHELL).toBe("/bin/bash");
+  });
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -230,8 +230,15 @@ export const detectShell = (
 };
 
 export type EnvAssignmentOptions = {
-  /** Wrap the value in double quotes; necessary for values that may contain
-   * shell-special characters (e.g. DB passwords). */
+  /**
+   * Wrap the value in double quotes so that whitespace does not cause
+   * word-splitting or globbing (e.g. DB passwords that contain spaces).
+   *
+   * Note: double quotes do NOT escape an embedded `"`, `$`, `` ` ``, or `\`
+   * in POSIX or fish — `$VAR`/`` `cmd` `` still expand. This is intended for
+   * displaying copy-paste instructions for typical generated credentials, not
+   * for safely quoting arbitrary untrusted values.
+   */
   quote?: boolean;
 };
 
@@ -261,7 +268,13 @@ const posixShellFormatter: ShellFormatter = {
   formatEnvAssignment: (key, value, options) =>
     `export ${key}=${options?.quote ? `"${value}"` : value}`,
   formatEnvReference: (key) => `\${${key}}`,
-  formatEvalCommand: (command) => `$(${command})`,
+  // Use `eval "$(...)"` rather than a bare `$(...)`: the command emits one
+  // `export ...` line per credential, and an unquoted command substitution
+  // collapses those newlines via word-splitting into a single
+  // `export A=v1 export B=v2 ...` line — which exports a stray variable named
+  // `export` and is brittle. Quoting inside `eval` preserves the newlines so
+  // each line runs as its own command, matching fish's `| source` behavior.
+  formatEvalCommand: (command) => `eval "$(${command})"`,
 };
 
 const fishShellFormatter: ShellFormatter = {

--- a/src/util.ts
+++ b/src/util.ts
@@ -220,6 +220,67 @@ export const getOperatingSystem = (): OperatingSystem => {
   }
 };
 
+export type ShellKind = "fish" | "posix";
+
+export const detectShell = (
+  env: NodeJS.ProcessEnv = process.env
+): ShellKind => {
+  const shellName = path.basename(env.SHELL ?? "").toLowerCase();
+  return shellName === "fish" ? "fish" : "posix";
+};
+
+export type EnvAssignmentOptions = {
+  /** Wrap the value in double quotes; necessary for values that may contain
+   * shell-special characters (e.g. DB passwords). */
+  quote?: boolean;
+};
+
+/**
+ * Formats shell snippets (environment-variable assignments and references,
+ * command evaluation) in the syntax of a particular shell family.
+ *
+ * Use {@link newShellFormatter} to obtain the formatter for the user's detected
+ * shell, e.g. `newShellFormatter().formatEnvAssignment("KEY", "value")`.
+ */
+export type ShellFormatter = {
+  readonly shell: ShellKind;
+
+  formatEnvAssignment: (
+    key: string,
+    value: string,
+    options?: EnvAssignmentOptions
+  ) => string;
+
+  formatEnvReference: (key: string) => string;
+
+  formatEvalCommand: (command: string) => string;
+};
+
+const posixShellFormatter: ShellFormatter = {
+  shell: "posix",
+  formatEnvAssignment: (key, value, options) =>
+    `export ${key}=${options?.quote ? `"${value}"` : value}`,
+  formatEnvReference: (key) => `\${${key}}`,
+  formatEvalCommand: (command) => `$(${command})`,
+};
+
+const fishShellFormatter: ShellFormatter = {
+  shell: "fish",
+  formatEnvAssignment: (key, value, options) =>
+    `set -gx ${key} ${options?.quote ? `"${value}"` : value}`,
+  formatEnvReference: (key) => `$${key}`,
+  formatEvalCommand: (command) => `${command} | source`,
+};
+
+const SHELL_FORMATTERS: Record<ShellKind, ShellFormatter> = {
+  fish: fishShellFormatter,
+  posix: posixShellFormatter,
+};
+
+export const newShellFormatter = (
+  shell: ShellKind = detectShell()
+): ShellFormatter => SHELL_FORMATTERS[shell];
+
 /**
  * Wraps a command with the operating-system specific method
  * executing it.


### PR DESCRIPTION
**Problem**

Users whose login shell is **fish** can't populate AWS credentials from the CLI's credential-export commands. `p0 aws role assume` (and `permission-set` / `rds`) print POSIX/bash syntax — `export KEY=value` and `eval $(...)` — which fish cannot parse, so the variables silently never get set and downstream AWS calls fall back to the default credential chain (often a 403). Investigation confirmed the `p0 ssh` transport itself is **not** shell-dependent (credentials are injected directly into the child process env), so this is scoped to the printed credential/instruction snippets users copy or `eval`.

**Change**

Adds a small shell-aware formatter (`detectShell` + `newShellFormatter` in `util.ts`) and routes the three credential/instruction printers through it:
- `printAwsCredentials` (`aws role assume`, `aws permission-set`)
- `awsSshProvider.reproCommands` (debug repro hint)
- `aws rds` psql/mysql connection instructions

fish users now get `set -gx KEY value` and `cmd | source`; everything else (bash/zsh/sh, unset `$SHELL`) keeps the existing POSIX output. Detection is fail-safe — only an exact `fish` match opts out of the legacy POSIX path.

**Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)

**Validation**

Automated unit tests added/extended:
- `util.test.ts` — `detectShell` (posix shells, exact-fish match, no false positives, unset) and the posix/fish formatters (posix output pinned byte-for-byte to the legacy strings).
- `role.test.ts` — bash + fish snapshots for `printAwsCredentials`.
- `aws/ssh.test.ts` — `reproCommands` for bash, fish, and IDC.
- `rds.test.ts` — shell-aware instructions for bash/postgres and fish postgres/mysql.

`tsc`, ESLint, and Prettier are clean. Risk to non-fish users is minimal: detection defaults to POSIX for everything but a literal fish login shell, the`export KEY=value` lines and `${VAR}` references are unchanged, and none of this code is executed by the CLI — these are strings printed for the user.

**Tracking**

[CUS-359](https://linear.app/p0-security/issue/CUS-359/p0-cli-expects-bash-shell)

**Implementation**

Formatter is modeled as an interface + plain object literals (one per shell) selected via a `Record<ShellKind, ShellFormatter>` map, rather than a class or inline switches.