### PR TITLE
automate google cloud auth login

### DIFF
--- a/src/plugins/google/__tests__/auth.test.ts
+++ b/src/plugins/google/__tests__/auth.test.ts
@@ -1,0 +1,109 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { asyncSpawn } from "../../../common/subprocess";
+import { spawnWithCleanEnv } from "../../../util";
+import { ensureGcloudLogin } from "../auth";
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../common/subprocess", () => ({
+  asyncSpawn: vi.fn(),
+}));
+
+vi.mock("../../../drivers/stdio", () => ({
+  print2: vi.fn(),
+}));
+
+// Spread the original so the real osSafeCommand (used by ./util's
+// gcloudCommandArgs) keeps working; only stub the interactive spawn.
+vi.mock("../../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../util")>()),
+  spawnWithCleanEnv: vi.fn(),
+}));
+
+const mockAsyncSpawn = vi.mocked(asyncSpawn);
+const mockSpawn = vi.mocked(spawnWithCleanEnv);
+
+/** A fake child process that the test drives by emitting `exit`/`error`. */
+const fakeChild = () => {
+  const child = new EventEmitter();
+  mockSpawn.mockReturnValue(child as any);
+  return child;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ensureGcloudLogin", () => {
+  it("skips login when gcloud credentials are valid", async () => {
+    mockAsyncSpawn.mockResolvedValue("ya29.an-access-token");
+
+    await expect(ensureGcloudLogin()).resolves.toBe("ya29.an-access-token");
+
+    expect(mockAsyncSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("never prints the access token (checks with debug:false even when debug:true)", async () => {
+    mockAsyncSpawn.mockResolvedValue("ya29.an-access-token");
+
+    await ensureGcloudLogin({ debug: true });
+
+    expect(mockAsyncSpawn).toHaveBeenCalledWith({ debug: false }, "gcloud", [
+      "auth",
+      "print-access-token",
+    ]);
+  });
+
+  it("runs `gcloud auth login` when credentials are invalid, then returns a fresh token, keeping child stdout off our stdout", async () => {
+    // First check rejects (not logged in); after login, the token fetch succeeds.
+    mockAsyncSpawn
+      .mockRejectedValueOnce("(gcloud) not logged in")
+      .mockResolvedValue("ya29.fresh-token");
+    const child = fakeChild();
+
+    const promise = ensureGcloudLogin({ debug: false });
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+    child.emit("exit", 0);
+
+    await expect(promise).resolves.toBe("ya29.fresh-token");
+
+    const [command, args, options] = mockSpawn.mock.calls[0]!;
+    expect(command).toBe("gcloud");
+    expect(args).toEqual(["auth", "login"]);
+    // stdout (index 1) must be routed to our stderr so it cannot corrupt the
+    // ssh-proxy data channel on fd 1.
+    expect((options as any).stdio[1]).toBe(process.stderr);
+  });
+
+  it("rejects with a helpful message when `gcloud auth login` exits non-zero", async () => {
+    mockAsyncSpawn.mockRejectedValue("(gcloud) not logged in");
+    const child = fakeChild();
+
+    const promise = ensureGcloudLogin();
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+    child.emit("exit", 1);
+
+    await expect(promise).rejects.toMatch(/gcloud auth login/);
+  });
+
+  it("rejects when `gcloud auth login` fails to spawn", async () => {
+    mockAsyncSpawn.mockRejectedValue("(gcloud) not logged in");
+    const child = fakeChild();
+
+    const promise = ensureGcloudLogin();
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled());
+    child.emit("error", new Error("ENOENT"));
+
+    await expect(promise).rejects.toMatch(/Failed to run 'gcloud auth login'/);
+  });
+});

--- a/src/plugins/google/auth.ts
+++ b/src/plugins/google/auth.ts
@@ -24,7 +24,13 @@ const runGcloudLogin = async ({ debug }: { debug?: boolean }) =>
     print2("Logging in to Google Cloud CLI...");
     const { command, args } = gcloudCommandArgs(["auth", "login"]);
     const child = spawnWithCleanEnv(command, args, {
-      // [stdin, stdout, stderr]: route child stdout to OUR stderr (never fd 1)
+      // stdio is [stdin, stdout, stderr]. We send the child's stdout to OUR
+      // stderr instead of inheriting fd 1: `gcloud auth login` writes its
+      // human-readable progress to stdout, but this CLI reserves fd 1 for
+      // machine-readable output (e.g. access tokens, JSON) that callers parse.
+      // Inheriting the child's stdout would interleave gcloud's chatter into
+      // that stream and corrupt it, so we redirect it to stderr — where
+      // human-facing text belongs.
       stdio: ["inherit", process.stderr, "inherit"],
     });
     child.on("error", (error) =>

--- a/src/plugins/google/auth.ts
+++ b/src/plugins/google/auth.ts
@@ -1,0 +1,60 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { asyncSpawn } from "../../common/subprocess";
+import { print2 } from "../../drivers/stdio";
+import { spawnWithCleanEnv } from "../../util";
+import { gcloudCommandArgs } from "./util";
+
+export const getGcloudAccessToken = async (): Promise<string> => {
+  const { command, args } = gcloudCommandArgs(["auth", "print-access-token"]);
+  // Force debug=false otherwise it prints the access token
+  return await asyncSpawn({ debug: false }, command, args);
+};
+
+const runGcloudLogin = async ({ debug }: { debug?: boolean }) =>
+  new Promise<void>((resolve, reject) => {
+    print2("Logging in to Google Cloud CLI...");
+    const { command, args } = gcloudCommandArgs(["auth", "login"]);
+    const child = spawnWithCleanEnv(command, args, {
+      // [stdin, stdout, stderr]: route child stdout to OUR stderr (never fd 1)
+      stdio: ["inherit", process.stderr, "inherit"],
+    });
+    child.on("error", (error) =>
+      reject(`Failed to run 'gcloud auth login': ${error.message}`)
+    );
+    child.on("exit", (code) => {
+      if (debug) {
+        print2(`'gcloud auth login' exited with code ${code}`);
+      }
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          "Google Cloud CLI login failed. Please run 'gcloud auth login' and try again."
+        );
+      }
+    });
+  });
+
+export const ensureGcloudLogin = async ({
+  debug,
+}: { debug?: boolean } = {}): Promise<string> => {
+  try {
+    const accessToken = await getGcloudAccessToken();
+    if (debug) {
+      print2("Google Cloud CLI credentials are valid; skipping login.");
+    }
+    return accessToken;
+  } catch {
+    await runGcloudLogin({ debug });
+    return await getGcloudAccessToken();
+  }
+};

--- a/src/plugins/google/ssh-key.ts
+++ b/src/plugins/google/ssh-key.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { asyncSpawn } from "../../common/subprocess";
 import { print2 } from "../../drivers/stdio";
+import { ensureGcloudLogin } from "./auth";
 import { ImportSshPublicKeyResponse } from "./types";
 import { gcloudCommandArgs } from "./util";
 
@@ -30,14 +31,12 @@ export const importSshKey = async (
 ) => {
   const debug = options?.debug ?? false;
 
-  // Force debug=false otherwise it prints the access token
-  const { command: accessTokenCommand, args: accessTokenArgs } =
-    gcloudCommandArgs(["auth", "print-access-token"]);
-  const accessToken = await asyncSpawn(
-    { debug: false },
-    accessTokenCommand,
-    accessTokenArgs
-  );
+  // Ensure the user is logged in to the Google Cloud CLI and return a valid
+  // access token. This is the earliest point a gcloud token is required in the
+  // direct `p0 ssh` and `ssh-resolve` flows (before the cloudProviderLogin hook
+  // runs), so the login must happen here. `gcloud auth login` runs only when
+  // the existing token is invalid.
+  const accessToken = await ensureGcloudLogin({ debug });
 
   const { command: accountCommand, args: accountArgs } = gcloudCommandArgs([
     "config",

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -11,6 +11,7 @@ You should have received a copy of the GNU General Public License along with @p0
 import { isSudoCommand } from "../../commands/shared/ssh";
 import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
+import { ensureGcloudLogin } from "./auth";
 import { ensureGcpSshInstall } from "./install";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
@@ -57,8 +58,10 @@ export const gcpSshProvider: SshProvider<
   { linuxUserName: string },
   GcpSshRequest
 > = {
-  // TODO support login with Google Cloud
-  cloudProviderLogin: async () => undefined,
+  cloudProviderLogin: async (_authn, _request, debug) => {
+    await ensureGcloudLogin({ debug });
+    return undefined;
+  },
 
   ensureInstall: async () => {
     if (!(await ensureGcpSshInstall())) {

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -696,7 +696,7 @@ export const sshProxy = async (args: {
   const { authn, sshProvider, request, requestId, debug } = args;
 
   const credential: AwsCredentials | undefined =
-    await sshProvider.cloudProviderLogin(authn, request);
+    await sshProvider.cloudProviderLogin(authn, request, debug);
 
   const abortController = new AbortController();
 


### PR DESCRIPTION
**Problem**

Connecting to a Google Cloud (GCP) instance with `p0 ssh` requires valid Google Cloud
CLI credentials — the CLI shells out to `gcloud` to import the OS Login SSH key and to
open the IAP tunnel. Logging in to P0 itself (via SSO such as Okta, or any other provider)
does **not** establish those credentials: they come from a separate `gcloud auth login`.

Previously the CLI assumed the user had already run `gcloud auth login` and, if they
hadn't, simply failed partway through with a hint to go run it manually. AWS and Azure
already perform their cloud-provider login automatically during `p0 ssh`; GCP did not.

**Change**

`p0 ssh` to a GCP target now triggers `gcloud auth login` automatically when the gcloud
credentials are missing/expired, and skips it when they are still valid — matching the
AWS/Azure behavior.

- New `ensureGcloudLogin` helper: checks validity with `gcloud auth print-access-token`
  (which succeeds whenever gcloud has valid or silently-refreshable credentials) and runs
  the interactive `gcloud auth login` only when that check fails. It returns a valid access
  token so callers don't fetch it twice.
- Wired in at both points a gcloud token is needed: the OS Login key import (covers the
  direct `p0 ssh` and `ssh-resolve` flows, which run before the cloud-login hook) and the
  GCP provider's `cloudProviderLogin` hook (covers the `ssh-proxy` ProxyCommand flow).
- The interactive login routes the child's stdout to stderr so it can never corrupt the
  SSH data channel that `ssh-proxy` carries on stdout.

Check off any of the following areas of code that are modified:

- [x] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

- Added unit tests (`src/plugins/google/__tests__/auth.test.ts`, 5 cases) covering: skip
  when credentials are valid; run login when invalid and return a fresh token; the token
  check never prints the token (debug forced off); and helpful rejections when login exits
  non-zero or fails to spawn. The new tests pass.
- `tsc` and `eslint --max-warnings 0` are clean on the changed files.
- Manual end-to-end against a live GCP instance was **not** performed in this session;
  reviewers connecting to a real GCP target should verify the login triggers after
  `gcloud auth revoke --all` and is skipped when already authenticated.
- Low blast radius: changes are confined to the GCP SSH provider plus a one-line `debug`
  pass-through in the shared `sshProxy`; other providers (AWS/Azure/self-hosted) are
  untouched. The pre-existing `gcloud auth login` hint paths are kept as a fallback.
- Also verified that the login prompt doesn't appear for non-gcloud requests

**Tracking (optional)**

[CUS-382](https://linear.app/p0-security/issue/CUS-382/p0-cli-automate-google-cloud-auth-login)

**Implementation (optional)**

- The gcloud token is first needed during OS Login key import, which runs *before* the
  generic `cloudProviderLogin` hook — and `ssh-resolve` never calls that hook while
  `ssh-proxy` never imports the key. Hence the helper is invoked at both sites; it's
  idempotent and cheap (a single token check) when already logged in.
- `ensureGcloudLogin` returns the access token so the key-import path makes one call
  instead of an ensure-then-fetch double round-trip.

**Follow-up Work (optional)**

- OS Login imports the key for whatever account `gcloud config get-value account` returns;
  `ensureGcloudLogin` guarantees *a* valid gcloud login but does not verify it matches the
  identity the access was approved for. Validating/auto-selecting the account is out of
  scope here and a candidate for a follow-up.
