### PR TITLE
Propagate AWS credential expiry and use it to harden file transfers

### DIFF
--- a/src/commands/aws/util.ts
+++ b/src/commands/aws/util.ts
@@ -12,12 +12,12 @@ import { print1, print2 } from "../../drivers/stdio";
 import { AwsCredentials } from "../../plugins/aws/types";
 import { sys } from "typescript";
 
-const CREDENTIAL_FIELDS: (keyof AwsCredentials)[] = [
+const CREDENTIAL_FIELDS = [
   "AWS_ACCESS_KEY_ID",
   "AWS_SECRET_ACCESS_KEY",
   "AWS_SESSION_TOKEN",
   "AWS_SECURITY_TOKEN",
-];
+] as const satisfies readonly (keyof AwsCredentials)[];
 
 export const printAwsCredentials = (
   awsCredentials: AwsCredentials,

--- a/src/commands/aws/util.ts
+++ b/src/commands/aws/util.ts
@@ -9,15 +9,15 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { print1, print2 } from "../../drivers/stdio";
-import { AwsCredentials } from "../../plugins/aws/types";
+import { AwsCredentialFields, AwsCredentials } from "../../plugins/aws/types";
 import { sys } from "typescript";
 
-const CREDENTIAL_FIELDS = [
+const CREDENTIAL_FIELDS: (keyof AwsCredentialFields)[] = [
   "AWS_ACCESS_KEY_ID",
   "AWS_SECRET_ACCESS_KEY",
   "AWS_SESSION_TOKEN",
   "AWS_SECURITY_TOKEN",
-] as const satisfies readonly (keyof AwsCredentials)[];
+];
 
 export const printAwsCredentials = (
   awsCredentials: AwsCredentials,

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -13,6 +13,7 @@ import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
 import { traceSpan } from "../opentelemetry/otel-helpers";
 import {
+  createTransferClient,
   generateTransferUrls,
   provisionTransferRequest,
 } from "../plugins/file-transfer";
@@ -88,22 +89,7 @@ const fileTransferAction = async (
       const uploadKey = `${target.prefix}${basename(args.source)}`;
 
       print2("Preparing upload credentials...");
-      const { s3, getUrl, deleteUrl, expirySeconds } =
-        await generateTransferUrls(
-          authn,
-          { ...target, key: uploadKey },
-          args.debug
-        );
-
-      const renderDurationSec = (s: number) =>
-        s >= 3600 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 60)}m`;
-      // TODO: remove logging when we remove the launchdarkly file-transfer flag
-      if (args.debug) {
-        print2(`GET    (${renderDurationSec(expirySeconds.get)}): ${getUrl}`);
-        print2(
-          `DELETE (${renderDurationSec(expirySeconds.delete)}): ${deleteUrl}`
-        );
-      }
+      const s3 = createTransferClient(authn, target, args.debug);
 
       print2(`Uploading ${args.source}...`);
 
@@ -152,6 +138,25 @@ const fileTransferAction = async (
       }
 
       print2("Uploaded.");
+
+      // Sign the download/cleanup URLs only now that the file is uploaded — the
+      // GET window is finite, so we don't want it ticking during the upload.
+      const { getUrl, deleteUrl, expirySeconds } = await generateTransferUrls(
+        authn,
+        s3,
+        { bucket: target.bucket, key: uploadKey, awsSpec: target.awsSpec },
+        args.debug
+      );
+
+      const renderDurationSec = (s: number) =>
+        s >= 3600 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 60)}m`;
+      // TODO: remove logging when we remove the launchdarkly file-transfer flag
+      if (args.debug) {
+        print2(`GET    (${renderDurationSec(expirySeconds.get)}): ${getUrl}`);
+        print2(
+          `DELETE (${renderDurationSec(expirySeconds.delete)}): ${deleteUrl}`
+        );
+      }
     },
     {
       command: "file-transfer",

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -29,6 +29,9 @@ export type FileTransferCommandArgs = {
   debug?: boolean;
 };
 
+const renderDurationSec = (s: number) =>
+  s >= 3600 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 60)}m`;
+
 export const fileTransferCommand = (yargs: yargs.Argv) =>
   yargs.command<FileTransferCommandArgs>(
     "file-transfer <source> <destination>",
@@ -148,8 +151,6 @@ const fileTransferAction = async (
         args.debug
       );
 
-      const renderDurationSec = (s: number) =>
-        s >= 3600 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 60)}m`;
       // TODO: remove logging when we remove the launchdarkly file-transfer flag
       if (args.debug) {
         print2(`GET    (${renderDurationSec(expirySeconds.get)}): ${getUrl}`);

--- a/src/plugins/aws/__mocks__/assumeRole.ts
+++ b/src/plugins/aws/__mocks__/assumeRole.ts
@@ -15,4 +15,5 @@ export const assumeRoleWithSaml = async (): Promise<AwsCredentials> => ({
   AWS_SECRET_ACCESS_KEY: "test-secret-access-key",
   AWS_SESSION_TOKEN: "test-session-token",
   AWS_SECURITY_TOKEN: "test-session-token",
+  expiresAt: 1893456000000, // 2030-01-01T00:00:00Z
 });

--- a/src/plugins/aws/__tests__/assumeRole.test.ts
+++ b/src/plugins/aws/__tests__/assumeRole.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../../common/xml", () => ({
           AccessKeyId: "AKIAEXAMPLE",
           SecretAccessKey: "secret",
           SessionToken: "session",
+          Expiration: "2030-01-01T00:00:00Z",
         },
       },
     },
@@ -70,6 +71,12 @@ describe("assumeRoleWithSaml()", () => {
       "arn:aws:iam::123456789012:saml-provider/okta"
     );
     expect(params.SAMLAssertion).toBe("base64-saml");
+  });
+
+  it("converts the STS Expiration ISO string to epoch ms", async () => {
+    const credentials = await assumeRoleWithSaml(baseArgs);
+
+    expect(credentials.expiresAt).toBe(Date.parse("2030-01-01T00:00:00Z"));
   });
 
   it("targets GovCloud STS and emits aws-us-gov ARNs", async () => {

--- a/src/plugins/aws/assumeRole.ts
+++ b/src/plugins/aws/assumeRole.ts
@@ -41,6 +41,7 @@ const stsAssume = async (
     AWS_SECRET_ACCESS_KEY: stsCredentials.SecretAccessKey,
     AWS_SESSION_TOKEN: stsCredentials.SessionToken,
     AWS_SECURITY_TOKEN: stsCredentials.SessionToken,
+    expiresAt: Date.parse(stsCredentials.Expiration), // epoch ms
   };
 };
 

--- a/src/plugins/aws/assumeRole.ts
+++ b/src/plugins/aws/assumeRole.ts
@@ -36,12 +36,18 @@ const stsAssume = async (
   const stsObject = parseXml(stsXml);
   const stsCredentials =
     stsObject.AssumeRoleWithSAMLResponse.AssumeRoleWithSAMLResult.Credentials;
+  // Date.parse returns NaN for a missing/malformed Expiration. Normalize that to
+  // undefined so downstream consumers treat it as "expiry unknown"
+  const parsedExpiration = Date.parse(stsCredentials.Expiration);
+  const expiresAt = Number.isNaN(parsedExpiration)
+    ? undefined
+    : parsedExpiration;
   return {
     AWS_ACCESS_KEY_ID: stsCredentials.AccessKeyId,
     AWS_SECRET_ACCESS_KEY: stsCredentials.SecretAccessKey,
     AWS_SESSION_TOKEN: stsCredentials.SessionToken,
     AWS_SECURITY_TOKEN: stsCredentials.SessionToken,
-    expiresAt: Date.parse(stsCredentials.Expiration), // epoch ms
+    expiresAt, // epoch ms, or undefined if AWS gave us an unparseable Expiration
   };
 };
 

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -12,12 +12,15 @@ import { PermissionSpec } from "../../types/request";
 import { CliPermissionSpec } from "../../types/ssh";
 import { CommonSshPermissionSpec } from "../ssh/types";
 
-export type AwsCredentials = {
+export type AwsCredentialFields = {
   AWS_ACCESS_KEY_ID: string;
   AWS_SECRET_ACCESS_KEY: string;
   AWS_SESSION_TOKEN: string;
   // AWS_SECURITY_TOKEN is the legacy version of AWS_SESSION_TOKEN. It does seem to take precedence over AWS_SESSION_TOKEN. The okta-aws-cli sets both: https://github.com/okta/okta-aws-cli/blob/f1e09eab509e295a7e7b3002d14f2a96b8c60914/internal/output/envvar.go#L49L63
   AWS_SECURITY_TOKEN: string;
+};
+
+export type AwsCredentials = AwsCredentialFields & {
   expiresAt?: number;
 };
 

--- a/src/plugins/aws/types.ts
+++ b/src/plugins/aws/types.ts
@@ -18,6 +18,7 @@ export type AwsCredentials = {
   AWS_SESSION_TOKEN: string;
   // AWS_SECURITY_TOKEN is the legacy version of AWS_SESSION_TOKEN. It does seem to take precedence over AWS_SESSION_TOKEN. The okta-aws-cli sets both: https://github.com/okta/okta-aws-cli/blob/f1e09eab509e295a7e7b3002d14f2a96b8c60914/internal/output/envvar.go#L49L63
   AWS_SECURITY_TOKEN: string;
+  expiresAt?: number;
 };
 
 export type AwsIamLogin = {

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -9,6 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { awsCloudAuth } from "../../aws/auth";
+import type { AwsResourcePermissionSpec } from "../../aws/types";
 import { generateTransferUrls } from "../index";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,8 +26,23 @@ describe("generateTransferUrls()", () => {
   const target = {
     bucket: "my-bucket",
     key: "uploads/user/abc/file.txt",
-    awsSpec: {} as never,
+    awsSpec: {
+      type: "aws",
+      permission: {
+        account: "test-account",
+        accountId: "123456789012",
+        arn: "arn:aws:iam::123456789012:role/test",
+        name: "test-role",
+        idcId: undefined,
+        idcRegion: undefined,
+      },
+      generated: { name: "test-role" },
+      delegation: {},
+    } satisfies AwsResourcePermissionSpec,
   };
+
+  const authn = {} as any;
+  const s3 = {} as any;
 
   // expiresIn passed to the GET and DELETE getSignedUrl calls, respectively.
   const signedExpiries = () => ({
@@ -47,9 +63,9 @@ describe("generateTransferUrls()", () => {
   it("uses the full configured window when credentials outlive it", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({
       expiresAt: NOW + 2 * ONE_HOUR * 1000,
-    } as never);
+    } as any);
 
-    const result = await generateTransferUrls({} as never, {} as never, target);
+    const result = await generateTransferUrls(authn, s3, target);
 
     expect(signedExpiries()).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
     expect(result.expirySeconds).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
@@ -58,29 +74,39 @@ describe("generateTransferUrls()", () => {
   it("caps the window to the remaining credential lifetime", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({
       expiresAt: NOW + 300 * 1000, // 5 minutes left
-    } as never);
+    } as any);
 
-    const result = await generateTransferUrls({} as never, {} as never, target);
+    const result = await generateTransferUrls(authn, s3, target);
 
     expect(signedExpiries()).toEqual({ get: 300, delete: 300 });
     expect(result.expirySeconds).toEqual({ get: 300, delete: 300 });
   });
 
   it("falls back to the configured window when expiry is unknown", async () => {
-    vi.mocked(awsCloudAuth).mockResolvedValue({} as never);
+    vi.mocked(awsCloudAuth).mockResolvedValue({} as any);
 
-    await generateTransferUrls({} as never, {} as never, target);
+    await generateTransferUrls(authn, s3, target);
 
     expect(signedExpiries()).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
   });
 
-  it("never signs a negative window when credentials are already expired", async () => {
+  it("throws when credentials are already expired", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({
       expiresAt: NOW - 1000,
-    } as never);
+    } as any);
 
-    await generateTransferUrls({} as never, {} as never, target);
+    await expect(generateTransferUrls(authn, s3, target)).rejects.toThrow(
+      /too soon to sign usable URLs/
+    );
+  });
 
-    expect(signedExpiries()).toEqual({ get: 0, delete: 0 });
+  it("throws when credentials expire below the usable threshold", async () => {
+    vi.mocked(awsCloudAuth).mockResolvedValue({
+      expiresAt: NOW + 30 * 1000, // 30s left, below 60s threshold
+    } as any);
+
+    await expect(generateTransferUrls(authn, s3, target)).rejects.toThrow(
+      /too soon to sign usable URLs/
+    );
   });
 });

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -1,0 +1,86 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { awsCloudAuth } from "../../aws/auth";
+import { generateTransferUrls } from "../index";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../aws/auth", () => ({ awsCloudAuth: vi.fn() }));
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: vi.fn().mockResolvedValue("https://signed.example/url"),
+}));
+
+const ONE_HOUR = 60 * 60;
+const NOW = Date.parse("2030-01-01T00:00:00Z");
+
+describe("generateTransferUrls()", () => {
+  const target = {
+    bucket: "my-bucket",
+    key: "uploads/user/abc/file.txt",
+    awsSpec: {} as never,
+  };
+
+  // expiresIn passed to the GET and DELETE getSignedUrl calls, respectively.
+  const signedExpiries = () => ({
+    get: vi.mocked(getSignedUrl).mock.calls[0]![2]!.expiresIn,
+    delete: vi.mocked(getSignedUrl).mock.calls[1]![2]!.expiresIn,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses the full configured window when credentials outlive it", async () => {
+    vi.mocked(awsCloudAuth).mockResolvedValue({
+      expiresAt: NOW + 2 * ONE_HOUR * 1000,
+    } as never);
+
+    const result = await generateTransferUrls({} as never, {} as never, target);
+
+    expect(signedExpiries()).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
+    expect(result.expirySeconds).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
+  });
+
+  it("caps the window to the remaining credential lifetime", async () => {
+    vi.mocked(awsCloudAuth).mockResolvedValue({
+      expiresAt: NOW + 300 * 1000, // 5 minutes left
+    } as never);
+
+    const result = await generateTransferUrls({} as never, {} as never, target);
+
+    expect(signedExpiries()).toEqual({ get: 300, delete: 300 });
+    expect(result.expirySeconds).toEqual({ get: 300, delete: 300 });
+  });
+
+  it("falls back to the configured window when expiry is unknown", async () => {
+    vi.mocked(awsCloudAuth).mockResolvedValue({} as never);
+
+    await generateTransferUrls({} as never, {} as never, target);
+
+    expect(signedExpiries()).toEqual({ get: ONE_HOUR, delete: ONE_HOUR });
+  });
+
+  it("never signs a negative window when credentials are already expired", async () => {
+    vi.mocked(awsCloudAuth).mockResolvedValue({
+      expiresAt: NOW - 1000,
+    } as never);
+
+    await generateTransferUrls({} as never, {} as never, target);
+
+    expect(signedExpiries()).toEqual({ get: 0, delete: 0 });
+  });
+});

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -24,8 +24,9 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { pick } from "lodash";
 import yargs from "yargs";
 
-const GET_EXPIRES_SECONDS = 60 * 60;
-const DELETE_EXPIRES_SECONDS = 60 * 60;
+const SECONDS_TO_EXPIRE_GET_URL = 60 * 60;
+const SECONDS_TO_EXPIRE_DELETE_URL = 60 * 60;
+const MIN_URL_EXPIRY_THRESHOLD_SECONDS = 60;
 
 export const provisionTransferRequest = async (
   authn: Authn,
@@ -87,6 +88,9 @@ export const createTransferClient = (
         accessKeyId: credentials.AWS_ACCESS_KEY_ID,
         secretAccessKey: credentials.AWS_SECRET_ACCESS_KEY,
         sessionToken: credentials.AWS_SESSION_TOKEN,
+        // Providing `expiration` is what tells the SDK to treat these creds as
+        // temporary. The SDK caches them and re-invokes this provider once they
+        // expire (or are within its skew window).
         ...(credentials.expiresAt !== undefined
           ? { expiration: new Date(credentials.expiresAt) }
           : {}),
@@ -113,23 +117,29 @@ export const generateTransferUrls = async (
   expirySeconds: { get: number; delete: number };
 }> => {
   const { expiresAt } = await awsCloudAuth(authn, target.awsSpec, debug);
-  // If we somehow don't know the expiry, fall back to the configured limits
-  // (Infinity makes Math.min pick the constant). Math.max(0, ...) avoids signing
-  // an already-expired URL if the credentials are right at the edge.
   const remaining =
     expiresAt !== undefined
-      ? Math.max(0, Math.floor((expiresAt - Date.now()) / 1000))
+      ? Math.floor((expiresAt - Date.now()) / 1000)
       : Infinity;
-  const getExpirySeconds = Math.min(GET_EXPIRES_SECONDS, remaining);
-  const deleteExpirySeconds = Math.min(DELETE_EXPIRES_SECONDS, remaining);
+  if (remaining < MIN_URL_EXPIRY_THRESHOLD_SECONDS) {
+    throw new Error(
+      `AWS credentials expire in ${remaining}s — too soon to sign usable URLs. ` +
+        `Check your system clock or re-run the request.`
+    );
+  }
+  const secondsToExpireGetUrl = Math.min(SECONDS_TO_EXPIRE_GET_URL, remaining);
+  const secondsToExpireDeleteUrl = Math.min(
+    SECONDS_TO_EXPIRE_DELETE_URL,
+    remaining
+  );
 
   const objectArgs = { Bucket: target.bucket, Key: target.key };
   const [getUrl, deleteUrl] = await Promise.all([
     getSignedUrl(s3, new GetObjectCommand(objectArgs), {
-      expiresIn: getExpirySeconds,
+      expiresIn: secondsToExpireGetUrl,
     }),
     getSignedUrl(s3, new DeleteObjectCommand(objectArgs), {
-      expiresIn: deleteExpirySeconds,
+      expiresIn: secondsToExpireDeleteUrl,
     }),
   ]);
 
@@ -137,6 +147,9 @@ export const generateTransferUrls = async (
     getUrl,
     deleteUrl,
     // Report the ACTUAL (capped) seconds so debug output is honest.
-    expirySeconds: { get: getExpirySeconds, delete: deleteExpirySeconds },
+    expirySeconds: {
+      get: secondsToExpireGetUrl,
+      delete: secondsToExpireDeleteUrl,
+    },
   };
 };

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -24,7 +24,7 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { pick } from "lodash";
 import yargs from "yargs";
 
-const GET_EXPIRES_SECONDS = 5 * 60;
+const GET_EXPIRES_SECONDS = 60 * 60;
 const DELETE_EXPIRES_SECONDS = 60 * 60;
 
 export const provisionTransferRequest = async (
@@ -68,51 +68,78 @@ export const provisionTransferRequest = async (
   };
 };
 
+/**
+ * Builds an S3 client whose credentials refresh automatically. A large upload
+ * can run longer than the temporary credentials live; passing a provider
+ * function (that returns `expiration`) lets the SDK re-fetch fresh credentials
+ * mid-upload instead of failing the in-flight parts with ExpiredToken.
+ */
+export const createTransferClient = (
+  authn: Authn,
+  target: { region: string; awsSpec: AwsResourcePermissionSpec },
+  debug?: boolean
+): S3Client =>
+  new S3Client({
+    region: target.region,
+    credentials: async () => {
+      const credentials = await awsCloudAuth(authn, target.awsSpec, debug);
+      return {
+        accessKeyId: credentials.AWS_ACCESS_KEY_ID,
+        secretAccessKey: credentials.AWS_SECRET_ACCESS_KEY,
+        sessionToken: credentials.AWS_SESSION_TOKEN,
+        // Providing `expiration` is what tells the SDK to call this provider
+        // again when the credentials are close to expiring. awsCloudAuth is
+        // cached and re-fetches once the old credentials expire.
+        ...(credentials.expiresAt !== undefined
+          ? { expiration: new Date(credentials.expiresAt) }
+          : {}),
+      };
+    },
+  });
+
+/**
+ * Signs the GET (download) and DELETE (cleanup) URLs. Call this AFTER the upload
+ * completes: the GET window is finite, and signing before a large upload would
+ * burn that window while the file is still uploading.
+ *
+ * Each expiry is capped to the credentials' remaining lifetime so a URL can
+ * never outlive the credentials that signed it.
+ */
 export const generateTransferUrls = async (
   authn: Authn,
-  target: {
-    bucket: string;
-    key: string;
-    region: string;
-    awsSpec: AwsResourcePermissionSpec;
-  },
+  s3: S3Client,
+  target: { bucket: string; key: string; awsSpec: AwsResourcePermissionSpec },
   debug?: boolean
 ): Promise<{
-  s3: S3Client;
   getUrl: string;
   deleteUrl: string;
   expirySeconds: { get: number; delete: number };
 }> => {
-  const credentials = await awsCloudAuth(authn, target.awsSpec, debug);
-
-  const sdkCredentials = {
-    accessKeyId: credentials.AWS_ACCESS_KEY_ID,
-    secretAccessKey: credentials.AWS_SECRET_ACCESS_KEY,
-    sessionToken: credentials.AWS_SESSION_TOKEN,
-  };
-
-  const s3 = new S3Client({
-    region: target.region,
-    credentials: sdkCredentials,
-  });
+  const { expiresAt } = await awsCloudAuth(authn, target.awsSpec, debug);
+  // If we somehow don't know the expiry, fall back to the configured limits
+  // (Infinity makes Math.min pick the constant). Math.max(0, ...) avoids signing
+  // an already-expired URL if the credentials are right at the edge.
+  const remaining =
+    expiresAt !== undefined
+      ? Math.max(0, Math.floor((expiresAt - Date.now()) / 1000))
+      : Infinity;
+  const getSeconds = Math.min(GET_EXPIRES_SECONDS, remaining);
+  const deleteSeconds = Math.min(DELETE_EXPIRES_SECONDS, remaining);
 
   const objectArgs = { Bucket: target.bucket, Key: target.key };
   const [getUrl, deleteUrl] = await Promise.all([
     getSignedUrl(s3, new GetObjectCommand(objectArgs), {
-      expiresIn: GET_EXPIRES_SECONDS,
+      expiresIn: getSeconds,
     }),
     getSignedUrl(s3, new DeleteObjectCommand(objectArgs), {
-      expiresIn: DELETE_EXPIRES_SECONDS,
+      expiresIn: deleteSeconds,
     }),
   ]);
 
   return {
-    s3,
     getUrl,
     deleteUrl,
-    expirySeconds: {
-      get: GET_EXPIRES_SECONDS,
-      delete: DELETE_EXPIRES_SECONDS,
-    },
+    // Report the ACTUAL (capped) seconds so debug output is honest.
+    expirySeconds: { get: getSeconds, delete: deleteSeconds },
   };
 };

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -87,9 +87,6 @@ export const createTransferClient = (
         accessKeyId: credentials.AWS_ACCESS_KEY_ID,
         secretAccessKey: credentials.AWS_SECRET_ACCESS_KEY,
         sessionToken: credentials.AWS_SESSION_TOKEN,
-        // Providing `expiration` is what tells the SDK to call this provider
-        // again when the credentials are close to expiring. awsCloudAuth is
-        // cached and re-fetches once the old credentials expire.
         ...(credentials.expiresAt !== undefined
           ? { expiration: new Date(credentials.expiresAt) }
           : {}),
@@ -123,16 +120,16 @@ export const generateTransferUrls = async (
     expiresAt !== undefined
       ? Math.max(0, Math.floor((expiresAt - Date.now()) / 1000))
       : Infinity;
-  const getSeconds = Math.min(GET_EXPIRES_SECONDS, remaining);
-  const deleteSeconds = Math.min(DELETE_EXPIRES_SECONDS, remaining);
+  const getExpirySeconds = Math.min(GET_EXPIRES_SECONDS, remaining);
+  const deleteExpirySeconds = Math.min(DELETE_EXPIRES_SECONDS, remaining);
 
   const objectArgs = { Bucket: target.bucket, Key: target.key };
   const [getUrl, deleteUrl] = await Promise.all([
     getSignedUrl(s3, new GetObjectCommand(objectArgs), {
-      expiresIn: getSeconds,
+      expiresIn: getExpirySeconds,
     }),
     getSignedUrl(s3, new DeleteObjectCommand(objectArgs), {
-      expiresIn: deleteSeconds,
+      expiresIn: deleteExpirySeconds,
     }),
   ]);
 
@@ -140,6 +137,6 @@ export const generateTransferUrls = async (
     getUrl,
     deleteUrl,
     // Report the ACTUAL (capped) seconds so debug output is honest.
-    expirySeconds: { get: getSeconds, delete: deleteSeconds },
+    expirySeconds: { get: getExpirySeconds, delete: deleteExpirySeconds },
   };
 };

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -203,10 +203,13 @@ async function spawnSshNode(
       );
     }
 
+    // `expiresAt` is metadata, not an env var, so exclude it from the child env.
+    const { expiresAt: _expiresAt, ...credentialEnv } =
+      options.credential ?? {};
     const child = spawn(options.command, options.args, {
       env: {
         ...createCleanChildEnv(),
-        ...options.credential,
+        ...credentialEnv,
       },
       stdio: options.stdio,
       shell: false,


### PR DESCRIPTION


**Problem**
Temporary AWS credentials carry an expiry that the CLI wasn't tracking. Surfacing it lets the file-transfer command (a) refresh credentials during uploads that run longer than a single credential's lifetime, and (b) ensure signed download/cleanup URLs never outlive the credentials that signed them


**Change**
1. Plumb credential expiry through 
Okta SAML path now reads STS Expiration (ISO string → epoch ms). The IDC path already returned epoch ms, so both paths now agree.
ssh spawn strips expiresAt before spreading credentials into the child process env (it's metadata, not an env var).

2. Auto-refreshing S3 client (createTransferClient)
The S3 client now takes a credentials provider function that returns expiration. The AWS SDK uses that to re-fetch fresh credentials mid-upload instead of failing — fixes long uploads.

3. Sign download/cleanup URLs after upload, capped to credential lifetime

Tests
Updated the assumeRole mock + tests to cover expiresAt (asserts the ISO Expiration is converted to epoch ms).
Added file-transfer plugin tests for the new client + URL-signing behavior.
