### PR TITLE
Surface a clear OS Login hint on GCP SSH auth failures

### DIFF
--- a/src/plugins/google/__tests__/connection-error.test.ts
+++ b/src/plugins/google/__tests__/connection-error.test.ts
@@ -1,0 +1,102 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import {
+  classifyGcpConnectionError,
+  GCP_SSH_PREREQUISITES_DOC,
+} from "../connection-error";
+import { describe, expect, it } from "vitest";
+
+const REQUEST = { id: "my-instance" };
+
+// Sample stderr captured from real connection attempts. Both the gcloud IAP
+// tunnel (the SSH ProxyCommand) and the SSH process write to the same stream,
+// so each sample mixes verbose SSH lines with gcloud output as observed.
+
+/** OS Login off: the tunnel established (SSH auth was reached) but the user's
+ * key was never provisioned onto the VM, so auth is rejected. */
+const PUBLICKEY_DENIED_STDERR = `
+debug1: Connecting to 127.0.0.1 [127.0.0.1] port 22.
+debug1: Authentications that can continue: publickey
+debug1: No more authentication methods to try.
+my-user@my-instance: Permission denied (publickey).
+`;
+
+/** A tunnel error followed, after the IAP role propagated, by an auth rejection.
+ * The terminal cause is auth (reaching it proves the tunnel works). */
+const MIXED_TUNNEL_THEN_PUBLICKEY_STDERR = `
+Error while connecting [4033: 'not authorized'].
+debug1: Authenticated to nothing.
+my-user@my-instance: Permission denied (publickey).
+`;
+
+/** IAP / firewall not configured: gcloud cannot reach the backend, so the tunnel
+ * never establishes and SSH auth is never attempted. We intentionally do not
+ * classify this — it falls through to the raw error. */
+const IAP_BACKEND_FAILURE_STDERR = `
+ERROR: (gcloud.compute.start-iap-tunnel) Error while connecting [4003: 'failed to connect to backend']. (Failed to connect to port 22)
+kex_exchange_identification: Connection closed by remote host
+`;
+
+describe("classifyGcpConnectionError", () => {
+  describe("OS Login / auth failures", () => {
+    it("classifies a publickey rejection as a likely OS Login problem", () => {
+      const message = classifyGcpConnectionError(
+        PUBLICKEY_DENIED_STDERR,
+        REQUEST
+      );
+      expect(message).toBeDefined();
+      expect(message).toContain("Connected to my-instance");
+      expect(message).toContain("Permission denied (publickey)");
+      expect(message).toContain("enable-oslogin=TRUE");
+      expect(message).toContain("most common cause is OS Login");
+      // Does not claim OS Login is definitively off — lists the alternatives.
+      expect(message).toContain("key-propagation delay");
+      expect(message).toContain("just-granted IAM role");
+      expect(message).toContain(GCP_SSH_PREREQUISITES_DOC);
+    });
+
+    it("classifies as OS Login when auth was reached, even if an earlier tunnel error is present", () => {
+      const message = classifyGcpConnectionError(
+        MIXED_TUNNEL_THEN_PUBLICKEY_STDERR,
+        REQUEST
+      );
+      // Reaching publickey auth proves the tunnel established, so this is the OS
+      // Login path.
+      expect(message).toContain("most common cause is OS Login");
+    });
+  });
+
+  describe("passthrough", () => {
+    it("does not classify an IAP / tunnel-establishment failure (left to the raw error)", () => {
+      expect(
+        classifyGcpConnectionError(IAP_BACKEND_FAILURE_STDERR, REQUEST)
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for an unrecognized error", () => {
+      const stderr = `
+ssh: connect to host my-instance port 22: Network is unreachable
+debug1: some unrelated verbose output
+`;
+      expect(classifyGcpConnectionError(stderr, REQUEST)).toBeUndefined();
+    });
+
+    it("returns undefined for empty stderr", () => {
+      expect(classifyGcpConnectionError("", REQUEST)).toBeUndefined();
+    });
+
+    it("does not match a benign host-key warning as a prerequisite failure", () => {
+      const stderr =
+        "Warning: Permanently added 'my-instance' to the list of known hosts.";
+      expect(classifyGcpConnectionError(stderr, REQUEST)).toBeUndefined();
+    });
+  });
+});

--- a/src/plugins/google/__tests__/install.test.ts
+++ b/src/plugins/google/__tests__/install.test.ts
@@ -1,0 +1,46 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { GcpSshInstall } from "../install";
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const packageCommand = GcpSshInstall.gcloud.commands.darwin.find((command) =>
+  command.startsWith("package=")
+);
+
+const runPackageCommand = (architecture: string): string => {
+  if (!packageCommand) {
+    throw new Error("GCloud install package command is missing");
+  }
+
+  return execFileSync(
+    "bash",
+    [
+      "-c",
+      `architecture=${architecture}; ${packageCommand}; printf "%s" "$package"`,
+    ],
+    { encoding: "utf8" }
+  );
+};
+
+describe("GcpSshInstall", () => {
+  it("selects the arm64 GCloud package on Apple Silicon", () => {
+    expect(runPackageCommand("arm64")).toBe(
+      "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-arm.tar.gz"
+    );
+  });
+
+  it("selects the x86_64 GCloud package on Intel Macs", () => {
+    expect(runPackageCommand("i386")).toBe(
+      "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-x86_64.tar.gz"
+    );
+  });
+});

--- a/src/plugins/google/connection-error.ts
+++ b/src/plugins/google/connection-error.ts
@@ -1,0 +1,60 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { GcpSshRequest } from "./types";
+
+/**
+ * P0 grants the IAM roles needed for GCP SSH, but OS Login must be enabled in
+ * the customer's project — P0 cannot enable it on their behalf. When OS Login is
+ * off the IAM grant still succeeds, but the connection fails at SSH
+ * authentication: without OS Login the user's key is never provisioned onto the
+ * VM (P0's grant does not include permission to write keys to instance
+ * metadata), so auth is rejected with `Permission denied (publickey)`.
+ *
+ * Historically the user saw only that raw, generic rejection and concluded P0
+ * was broken. We surface a targeted hint instead. `Permission denied
+ * (publickey)` is not exclusively an OS Login problem — it can also be a brief
+ * key-propagation delay or a just-granted IAM role — so the message names OS
+ * Login as the most likely cause while listing the alternatives, and never
+ * claims certainty.
+ *
+ * We deliberately do NOT try to classify the other GCP prerequisite failure (IAP
+ * / firewall not configured, which fails earlier, at the gcloud tunnel rather
+ * than at SSH auth). Its `gcloud start-iap-tunnel` error strings vary by gcloud
+ * version and are easy to misattribute; since misattributing is worse than the
+ * status quo, those failures fall through to the raw error unchanged.
+ */
+
+export const GCP_SSH_PREREQUISITES_DOC =
+  "https://docs.p0.dev/integrations/resource-integrations/ssh#gcp-project-requirements";
+
+/** SSH auth was reached and rejected — most likely because OS Login is off. */
+const AUTH_REJECTED_PATTERN = /Permission denied \(publickey\)/;
+
+// Leads with a newline so it prints with one blank line above the preceding SSH
+// output, for legibility.
+const osLoginMessage = (instance: string) =>
+  `\nConnected to ${instance} but authentication was rejected ` +
+  `(Permission denied (publickey)). The most common cause is OS Login not ` +
+  `being enabled. Enable it by setting enable-oslogin=TRUE on the project (or ` +
+  `instance) metadata, then retry. If OS Login is already enabled, this can ` +
+  `also be a brief key-propagation delay or a just-granted IAM role — wait ` +
+  `~30s and retry. See ${GCP_SSH_PREREQUISITES_DOC}`;
+
+/**
+ * Inspects the captured stderr of a failed GCP SSH connection and returns an
+ * actionable message when the failure is an SSH auth rejection (most likely OS
+ * Login not being enabled), or `undefined` to fall through to the raw error.
+ */
+export const classifyGcpConnectionError = (
+  stderr: string,
+  request: Pick<GcpSshRequest, "id">
+): string | undefined =>
+  AUTH_REJECTED_PATTERN.test(stderr) ? osLoginMessage(request.id) : undefined;

--- a/src/plugins/google/install.ts
+++ b/src/plugins/google/install.ts
@@ -15,14 +15,14 @@ export const SupportedPlatforms = ["darwin"] as const;
 const GcpSshItems = ["gcloud"] as const;
 type GcpSshItem = (typeof GcpSshItems)[number];
 
-const GcpSshInstall: Readonly<Record<GcpSshItem, InstallMetadata>> = {
+export const GcpSshInstall: Readonly<Record<GcpSshItem, InstallMetadata>> = {
   gcloud: {
     label: "GCloud CLI",
     commands: {
       darwin: [
         // See https://cloud.google.com/sdk/docs/install-sdk
         "architecture=$(arch)",
-        'package=$([ $architecture = "arm64" ] && echo "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-arm.tar.gz" || "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-x86_64.tar.gz" )',
+        'package=$([ "$architecture" = "arm64" ] && echo "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-arm.tar.gz" || echo "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-x86_64.tar.gz" )',
         "wget -O ~/google-cloud-cli.tar.gz $package",
         "tar -xzf ~/google-cloud-cli.tar.gz -C ~", // Extract to home directory
         "~/google-cloud-sdk/install.sh",

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -12,6 +12,7 @@ import { isSudoCommand } from "../../commands/shared/ssh";
 import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
 import { ensureGcloudLogin } from "./auth";
+import { classifyGcpConnectionError } from "./connection-error";
 import { ensureGcpSshInstall } from "./install";
 import { importSshKey } from "./ssh-key";
 import { GcpSshPermissionSpec, GcpSshRequest } from "./types";
@@ -62,6 +63,9 @@ export const gcpSshProvider: SshProvider<
     await ensureGcloudLogin({ debug });
     return undefined;
   },
+
+  connectionErrorMessage: (stderr, request) =>
+    classifyGcpConnectionError(stderr, request),
 
   ensureInstall: async () => {
     if (!(await ensureGcpSshInstall())) {

--- a/src/plugins/ssh/__tests__/index.test.ts
+++ b/src/plugins/ssh/__tests__/index.test.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { print2 } from "../../../drivers/stdio";
 import { sshProxy } from "../index";
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
@@ -38,6 +39,20 @@ const makeFakeChild = () => {
   child.kill = vi.fn();
   child.unref = vi.fn();
   setImmediate(() => child.emit("exit", 0));
+  return child;
+};
+
+/** A fake child that writes `stderr` to its stderr stream and then exits with
+ * `code`, mimicking a process that fails after emitting diagnostic output. */
+const makeFailingChild = (stderr: string, code: number) => {
+  const child = new EventEmitter() as any;
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  child.unref = vi.fn();
+  setImmediate(() => {
+    child.stderr.emit("data", Buffer.from(stderr));
+    child.emit("exit", code);
+  });
   return child;
 };
 
@@ -130,5 +145,82 @@ describe("sshProxy credential handoff stays shell-agnostic", () => {
     // anything — proving the credential handoff does not depend on it.
     expect(fishOpts.env.SHELL).toBe("/usr/bin/fish");
     expect(bashOpts.env.SHELL).toBe("/bin/bash");
+  });
+});
+
+describe("GCP connection failure diagnostics", () => {
+  // spawnSshNode resolves the provider (and thus its connectionErrorMessage and
+  // unprovisionedAccessPatterns) from the SSH_PROVIDERS registry keyed by
+  // request.type, so a `gcloud` request exercises the real GCP classifier. The
+  // passed sshProvider only supplies the hooks sshProxy itself calls; stub the
+  // gcloud login so the test never shells out.
+  const gcpProviderWith = (propagationTimeoutMs: number) =>
+    ({
+      cloudProviderLogin: vi.fn(async () => undefined),
+      proxyCommand: () => [
+        "gcloud",
+        "compute",
+        "start-iap-tunnel",
+        "my-instance",
+        "22",
+      ],
+      propagationTimeoutMs,
+    }) as any;
+
+  const runGcpProxy = (sshProvider: any) =>
+    sshProxy({
+      authn: {} as any,
+      request: {
+        type: "gcloud",
+        id: "my-instance",
+        projectId: "my-project",
+        zone: "us-central1-a",
+        linuxUserName: "user",
+      } as any,
+      requestId: "req-1",
+      cmdArgs: {} as any,
+      privateKey: "pk",
+      sshProvider,
+      debug: false,
+      port: "22",
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("surfaces the OS Login hint when SSH auth is rejected (publickey)", async () => {
+    mockSpawn.mockImplementation(() =>
+      makeFailingChild(
+        "my-user@my-instance: Permission denied (publickey).\n",
+        255
+      )
+    );
+
+    // A negative propagation timeout puts endTime in the past, so the first
+    // publickey rejection is terminal (no propagation wait) and the classifier
+    // replaces the generic "did not propagate" message.
+    const error = await runGcpProxy(gcpProviderWith(-1)).catch((e) => e);
+
+    expect(error).toContain("Connected to my-instance");
+    expect(error).toContain("most common cause is OS Login");
+    expect(error).toContain("enable-oslogin=TRUE");
+  });
+
+  it("passes an IAP / tunnel-establishment failure through unchanged", async () => {
+    mockSpawn.mockImplementation(() =>
+      makeFailingChild(
+        "ERROR: (gcloud.compute.start-iap-tunnel) Error while connecting [4003: 'failed to connect to backend'].\n",
+        1
+      )
+    );
+
+    const exitCode = await runGcpProxy(gcpProviderWith(1000));
+
+    // Tunnel failures are intentionally not classified: the original exit code is
+    // returned and no OS Login hint is emitted.
+    expect(exitCode).toBe(1);
+    const printed = (print2 as Mock).mock.calls.map((call) => String(call[0]));
+    expect(printed.some((line) => line.includes("OS Login"))).toBe(false);
   });
 });

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -41,6 +41,11 @@ import { Readable } from "node:stream";
 
 const RETRY_DELAY_MS = 5000;
 
+/** Upper bound on the stderr we retain per connection attempt for failure
+ * classification. The decisive error (e.g. an IAP backend-connect failure or a
+ * publickey rejection) appears near the end, so we keep the trailing bytes. */
+const MAX_CAPTURED_STDERR_BYTES = 64 * 1024;
+
 const HOST_KEY_MISMATCH_PATTERN =
   /WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED|Host key verification failed/;
 
@@ -81,9 +86,16 @@ const accessPropagationGuard = (
   let isLoginException = false;
   let isValidError = false;
   let isHostKeyMismatch = false;
+  // Retain the (bounded) raw stderr of this attempt so a terminal failure can be
+  // classified into an actionable message. We keep the trailing bytes because
+  // the decisive error appears at the end of the stream.
+  let capturedStderr = "";
 
   const stderrHandler = (chunk: Buffer) => {
     const chunkString: string = chunk.toString("utf-8");
+    capturedStderr = (capturedStderr + chunkString).slice(
+      -MAX_CAPTURED_STDERR_BYTES
+    );
     parseAndPrintSshOutputToStderr(chunkString, options);
 
     if (HOST_KEY_MISMATCH_PATTERN.test(chunkString)) {
@@ -124,6 +136,7 @@ const accessPropagationGuard = (
       (!validAccessPatterns || isValidError),
     isHostKeyMismatch: () => isHostKeyMismatch,
     isLoginException: () => isLoginException,
+    capturedStderr: () => capturedStderr,
     cleanup: () => {
       child.stderr.removeListener("data", stderrHandler);
     },
@@ -181,6 +194,7 @@ type SpawnSshNodeOptions = {
   abortController?: AbortController;
   stdio: [StdioNull, StdioNull, StdioPipe];
   provider: SupportedSshProvider;
+  request: SshRequest;
   debug?: boolean;
   isAccessPropagationPreTest?: boolean;
   audit?: (action: "end" | "start") => void;
@@ -236,6 +250,7 @@ async function spawnSshNode(
       isAccessPropagated,
       isHostKeyMismatch,
       isLoginException,
+      capturedStderr,
       cleanup: cleanupStderr,
     } = accessPropagationGuard(
       provider.unprovisionedAccessPatterns,
@@ -246,6 +261,12 @@ async function spawnSshNode(
       child,
       options
     );
+
+    // Classify a terminal connection failure (e.g. OS Login not being enabled)
+    // into an actionable message, or undefined to keep the raw error. The
+    // unmodified output remains available via --debug.
+    const connectionErrorMessage = () =>
+      provider.connectionErrorMessage?.(capturedStderr(), options.request);
 
     const onAbort = () =>
       reject(options.abortController?.signal.reason ?? "SSH session aborted");
@@ -272,7 +293,8 @@ async function spawnSshNode(
       if (!isAccessPropagated()) {
         if (options.endTime < Date.now()) {
           reject(
-            `Access did not propagate through ${provider.friendlyName} in time. ${getContactMessage()}`
+            connectionErrorMessage() ??
+              `Access did not propagate through ${provider.friendlyName} in time. ${getContactMessage()}`
           );
           return;
         }
@@ -540,6 +562,7 @@ const preTestAccessPropagationIfNeeded = async <
       stdio: ["inherit", "inherit", "pipe"],
       debug: cmdArgs.debug,
       provider: request.type,
+      request,
       endTime: endTime,
       isAccessPropagationPreTest: true,
     });
@@ -669,6 +692,7 @@ export const sshOrScp = async (args: {
         stdio: ["inherit", "inherit", "pipe"],
         debug,
         provider: request.type,
+        request,
         endTime: endTime,
         onHostKeyMismatch: request.type === "aws" ? refreshHostKeys : undefined,
       });
@@ -749,6 +773,7 @@ export const sshProxy = async (args: {
       stdio: ["inherit", "inherit", "pipe"],
       debug,
       provider: request.type,
+      request,
       endTime: endTime,
     });
   } finally {

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -292,8 +292,9 @@ async function spawnSshNode(
       // permissions, continually retry access until success
       if (!isAccessPropagated()) {
         if (options.endTime < Date.now()) {
+          const knownError = connectionErrorMessage();
           reject(
-            connectionErrorMessage() ??
+            knownError ??
               `Access did not propagate through ${provider.friendlyName} in time. ${getContactMessage()}`
           );
           return;

--- a/src/testing/authn.ts
+++ b/src/testing/authn.ts
@@ -1,0 +1,47 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { Authn } from "../types/identity";
+import { Config } from "../types/org";
+
+const testOrgConfig = {
+  fs: {
+    apiKey: "",
+    authDomain: "",
+    projectId: "",
+    storageBucket: "",
+    messagingSenderId: "",
+    appId: "",
+  },
+  appUrl: "https://example.com",
+  environment: "test",
+  contactMessage: "",
+  helpMessage: "",
+} satisfies Config;
+
+/** Credentials and org are empty; use when tests only need `getToken` or a well-typed `Authn`. */
+export const mockAuthn: Authn = {
+  getToken: () => Promise.resolve("mock-token"),
+  identity: {
+    credential: {
+      access_token: "",
+      id_token: "",
+      expires_in: 0,
+      expiry: "",
+      expires_at: 0,
+    },
+    org: {
+      slug: "test-org",
+      tenantId: "tenant-mock",
+      auth: { type: "password" },
+      config: testOrgConfig,
+    },
+  },
+};

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -160,6 +160,13 @@ export type SshProvider<
   /** Unwraps this provider's types */
   requestToSsh: (request: CliPermissionSpec<PR, O>) => SR;
 
+  /** Inspect the captured stderr of a failed connection attempt and, when the
+   * failure matches a known root cause (e.g. a missing cloud prerequisite),
+   * return an actionable message to surface in place of the raw error. Returns
+   * undefined to fall through to the raw error. Called only at terminal
+   * connection failure; the unmodified output remains available via --debug. */
+  connectionErrorMessage?: (stderr: string, request: SR) => string | undefined;
+
   /** Regex matches for error strings indicating that the provider has not yet fully provisioned node access */
   unprovisionedAccessPatterns: readonly AccessPattern[];
 


### PR DESCRIPTION
## Problem

A `p0 ssh <instance> --provider gcloud` grant can succeed while the connection still fails when **OS Login is not enabled** in the customer's project — and P0 cannot enable it on their behalf. Without OS Login the user's key is never provisioned onto the VM (P0's grant doesn't include permission to write keys to instance metadata), so SSH auth is rejected with `Permission denied (publickey)`.

Today the user sees only that raw, generic rejection and concludes P0 is broken, when the real cause is a missing GCP prerequisite. (Customer-reported, P1.)

## Fix

Detect this specific failure and replace the generic error with an actionable message:

> Connected to `<instance>` but authentication was rejected (Permission denied (publickey)). The most common cause is OS Login not being enabled. Enable it by setting `enable-oslogin=TRUE` on the project (or instance) metadata, then retry. If OS Login is already enabled, this can also be a brief key-propagation delay or a just-granted IAM role — wait ~30s and retry. See <SSH-for-GCP prerequisites doc>.

It names OS Login as the **most likely** cause and lists the alternatives — it never claims OS Login is definitively off, since `Permission denied (publickey)` is generic.

## How it works

The CLI runs the system `ssh` with `gcloud compute start-iap-tunnel` as the `ProxyCommand`; both layers write to one stderr stream that `spawnSshNode` already captures.

- New pure classifier [`src/plugins/google/connection-error.ts`](https://github.com/p0-security/p0cli/blob/michaeldimitras/oslogin-validation/src/plugins/google/connection-error.ts): if the captured stderr contains `Permission denied (publickey)`, return the OS Login hint; otherwise return `undefined` (pass the raw error through).
- Wired in via a new optional `SshProvider.connectionErrorMessage` hook that `spawnSshNode` consults at terminal connection failure.
- **No new permissions.** The raw gcloud/ssh output stays available under `--debug`, and the exit code is preserved.

### Deliberately out of scope
We do **not** try to classify the other prerequisite failure (IAP / firewall not configured, which fails earlier at the gcloud tunnel). Its error strings vary by gcloud version and are easy to misattribute — and misattributing is worse than the status quo — so those failures pass through unchanged. A complementary proactive metadata check is being handled backend-side.

The existing ~2-minute propagation-retry window is unchanged: a publickey rejection is retried (covering genuine propagation delays) and the hint is surfaced when it ultimately times out.

## Testing
- Classifier unit tests: publickey → OS Login hint; OS Login wins when auth was reached even with earlier tunnel noise; tunnel/IAP error, unknown error, empty, and benign host-key warning → passthrough.
- Integration tests driving the real reject path via `sshProxy`: a publickey rejection surfaces the OS Login message end-to-end; an IAP/tunnel failure passes through with its exit code intact.
- Full suite green (195 tests, stable across repeated runs); `tsc`, eslint, prettier clean.
- The OS Login message was verified against a real instance with OS Login disabled.

## Note
This commit also bundles a small pre-existing WIP fix to the gcloud install package-selection command (+ its test) and a shared test `authn` helper, which were already in the working tree.


<img width="1554" height="380" alt="Screenshot 2026-06-18 at 5 34 55 PM" src="https://github.com/user-attachments/assets/eb1351f6-7d78-42c4-b7c8-b1f34e11a177" />
