### PR TITLE
File Transfer: Delete object from s3 bucket after download complete

### DIFF
--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -12,16 +12,14 @@ import { retryWithSleep } from "../common/retry";
 import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
 import { exitProcess, traceSpan } from "../opentelemetry/otel-helpers";
-import { AwsResourcePermissionSpec } from "../plugins/aws/types";
 import {
   createTransferClient,
   generateSignedUrl,
   provisionTransferRequest,
 } from "../plugins/file-transfer";
 import { sshOrScp } from "../plugins/ssh";
-import { Authn } from "../types/identity";
 import { prepareRequest } from "./shared/ssh";
-import { S3Client } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { createReadStream, statSync } from "fs";
 import { basename } from "node:path";
@@ -42,11 +40,9 @@ const COMMAND_NOT_FOUND_EXIT_CODE = 127;
 const SUCCESS_EXIT_CODE = 0;
 
 /**
- * Best-effort cleanup of the uploaded S3 object via a presigned DELETE URL.
- * Call this only after a confirmed-successful download.
- *
- * The DELETE URL is signed here, at the point of use, rather than up front — a
- * long approval wait would otherwise burn its TTL before we ever issue it.
+ * Best-effort cleanup of the uploaded S3 object. The CLI already holds an
+ * authenticated S3 client, so it deletes directly and the client also
+ * auto-refreshes credentials.
  *
  * This must never fail an otherwise-successful transfer: the object still
  * expires via the bucket's lifecycle policy, so a failed delete is harmless.
@@ -54,32 +50,27 @@ const SUCCESS_EXIT_CODE = 0;
  * --debug.
  */
 const deleteUploadedObject = async (
-  authn: Authn,
   s3: S3Client,
-  target: { bucket: string; awsSpec: AwsResourcePermissionSpec },
+  bucket: string,
   key: string,
   debug?: boolean
 ) => {
   try {
-    const { signedUrl, expirySeconds } = await generateSignedUrl(
-      authn,
-      s3,
-      { bucket: target.bucket, key, awsSpec: target.awsSpec },
-      "delete",
-      debug
-    );
+    await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
     if (debug) {
-      print2(`DELETE (${renderDurationSec(expirySeconds)}): ${signedUrl}`);
+      print2(`Deleted s3://${bucket}/${key} from the bucket.`);
     }
-    const response = await fetch(signedUrl, { method: "DELETE" });
-    if (!response.ok) {
-      throw new Error(`S3 returned ${response.status} ${response.statusText}`);
-    }
-    print2(`Deleted s3://${target.bucket}/${key} from the bucket.`);
   } catch (err) {
+    print2(
+      `Warning: could not delete s3://${bucket}/${key}. The file transfer succeeded, 
+      so this is safe to ignore. You may delete this object manually, or it will be 
+      removed automatically by the file-transfer bucket's lifecycle expiration 
+      rule.`
+    );
+    // The raw error is debugging detail, not outcome info.
     if (debug) {
       const message = err instanceof Error ? err.message : String(err);
-      print2(`Warning: failed to delete S3 object: ${message}`);
+      print2(`Delete error: ${message}`);
     }
   }
 };
@@ -252,13 +243,7 @@ const fileTransferAction = async (
       if (exitCode === SUCCESS_EXIT_CODE) {
         // Success path: the file is on the instance, so clean it from the bucket.
         print2(`Downloaded to ${remotePath}.`);
-        await deleteUploadedObject(
-          authn,
-          s3,
-          { bucket: target.bucket, awsSpec: target.awsSpec },
-          uploadKey,
-          args.debug
-        );
+        await deleteUploadedObject(s3, target.bucket, uploadKey, args.debug);
       } else if (exitCode === null) {
         throw `Remote download was interrupted before completing ... re-run the file-transfer command`;
       } else {

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -12,13 +12,16 @@ import { retryWithSleep } from "../common/retry";
 import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
 import { exitProcess, traceSpan } from "../opentelemetry/otel-helpers";
+import { AwsResourcePermissionSpec } from "../plugins/aws/types";
 import {
   createTransferClient,
   generateSignedUrl,
   provisionTransferRequest,
 } from "../plugins/file-transfer";
 import { sshOrScp } from "../plugins/ssh";
+import { Authn } from "../types/identity";
 import { prepareRequest } from "./shared/ssh";
+import { S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { createReadStream, statSync } from "fs";
 import { basename } from "node:path";
@@ -33,6 +36,53 @@ export type FileTransferCommandArgs = {
 
 const renderDurationSec = (s: number) =>
   s >= 3600 ? `${Math.round(s / 3600)}h` : `${Math.round(s / 60)}m`;
+
+// Standard POSIX shell exit code for "command not found".
+const COMMAND_NOT_FOUND_EXIT_CODE = 127;
+const SUCCESS_EXIT_CODE = 0;
+
+/**
+ * Best-effort cleanup of the uploaded S3 object via a presigned DELETE URL.
+ * Call this only after a confirmed-successful download.
+ *
+ * The DELETE URL is signed here, at the point of use, rather than up front — a
+ * long approval wait would otherwise burn its TTL before we ever issue it.
+ *
+ * This must never fail an otherwise-successful transfer: the object still
+ * expires via the bucket's lifecycle policy, so a failed delete is harmless.
+ * The result therefore defaults to success — errors are only surfaced under
+ * --debug.
+ */
+const deleteUploadedObject = async (
+  authn: Authn,
+  s3: S3Client,
+  target: { bucket: string; awsSpec: AwsResourcePermissionSpec },
+  key: string,
+  debug?: boolean
+) => {
+  try {
+    const { signedUrl, expirySeconds } = await generateSignedUrl(
+      authn,
+      s3,
+      { bucket: target.bucket, key, awsSpec: target.awsSpec },
+      "delete",
+      debug
+    );
+    if (debug) {
+      print2(`DELETE (${renderDurationSec(expirySeconds)}): ${signedUrl}`);
+    }
+    const response = await fetch(signedUrl, { method: "DELETE" });
+    if (!response.ok) {
+      throw new Error(`S3 returned ${response.status} ${response.statusText}`);
+    }
+    print2(`Deleted s3://${target.bucket}/${key} from the bucket.`);
+  } catch (err) {
+    if (debug) {
+      const message = err instanceof Error ? err.message : String(err);
+      print2(`Warning: failed to delete S3 object: ${message}`);
+    }
+  }
+};
 
 export const fileTransferCommand = (yargs: yargs.Argv) =>
   yargs.command<FileTransferCommandArgs>(
@@ -94,21 +144,6 @@ const fileTransferAction = async (
 
       print2("Preparing upload credentials...");
       const s3 = createTransferClient(authn, target, args.debug);
-      const { signedUrl: deleteUrl, expirySeconds: deleteExpirySeconds } =
-        await generateSignedUrl(
-          authn,
-          s3,
-          { ...target, key: uploadKey },
-          "delete",
-          args.debug
-        );
-
-      // TODO: remove logging actual credential but log expiry when we remove the launchdarkly file-transfer flag
-      if (args.debug) {
-        print2(
-          `DELETE (${renderDurationSec(deleteExpirySeconds)}): ${deleteUrl}`
-        );
-      }
 
       print2(`Uploading ${args.source}...`);
 
@@ -209,15 +244,26 @@ const fileTransferAction = async (
         sshHostKeys,
       });
 
-      // TODO update comment when we add fallback downloader if needed
-      if (exitCode === 127) {
+      // curl is the only downloader today; revisit this branch if we add fallbacks
+      if (exitCode === COMMAND_NOT_FOUND_EXIT_CODE) {
         throw `curl not found on ${args.destination}. The file is in S3 — install curl on the destination instance and re-run file-transfer command`;
       }
-      if (exitCode !== null && exitCode !== 0) {
+
+      if (exitCode === SUCCESS_EXIT_CODE) {
+        // Success path: the file is on the instance, so clean it from the bucket.
+        print2(`Downloaded to ${remotePath}.`);
+        await deleteUploadedObject(
+          authn,
+          s3,
+          { bucket: target.bucket, awsSpec: target.awsSpec },
+          uploadKey,
+          args.debug
+        );
+      } else if (exitCode === null) {
+        throw `Remote download was interrupted before completing ... re-run the file-transfer command`;
+      } else {
         throw `Remote download exited with code ${exitCode}`;
       }
-
-      print2(`Downloaded to ${remotePath}.`);
 
       // Force exit to prevent hanging due to orphaned child processes (e.g.,
       // session-manager-plugin) holding open file descriptors. See:

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -62,10 +62,7 @@ const deleteUploadedObject = async (
     }
   } catch (err) {
     print2(
-      `Warning: could not delete s3://${bucket}/${key}. The file transfer succeeded, 
-      so this is safe to ignore. You may delete this object manually, or it will be 
-      removed automatically by the file-transfer bucket's lifecycle expiration 
-      rule.`
+      `Warning: could not delete s3://${bucket}/${key}. The file transfer succeeded, so this is safe to ignore. You may delete this object manually, or it will be removed automatically by the file-transfer bucket's lifecycle expiration rule.`
     );
     // The raw error is debugging detail, not outcome info.
     if (debug) {
@@ -206,7 +203,6 @@ const fileTransferAction = async (
           authn,
           s3,
           { bucket: target.bucket, key: uploadKey, awsSpec: target.awsSpec },
-          "get",
           args.debug
         );
       if (args.debug) {

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -10,12 +10,8 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { awsCloudAuth } from "../../aws/auth";
 import type { AwsResourcePermissionSpec } from "../../aws/types";
-import {
-  generateSignedUrl,
-  MAX_SECONDS_TO_EXPIRE_DELETE_URL,
-  MAX_SECONDS_TO_EXPIRE_GET_URL,
-} from "../index";
-import { GetObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
+import { generateSignedUrl, MAX_SECONDS_TO_EXPIRE_GET_URL } from "../index";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -84,7 +80,7 @@ describe("generateSignedUrl()", () => {
       expiresAt: NOW + 2 * ONE_HOUR * 1000,
     });
 
-    const result = await generateSignedUrl(authn, s3, target, "get");
+    const result = await generateSignedUrl(authn, s3, target);
 
     expect(signedExpiries()).toBe(FIVE_MINUTES);
     expect(result.expirySeconds).toBe(FIVE_MINUTES);
@@ -96,7 +92,7 @@ describe("generateSignedUrl()", () => {
       expiresAt: NOW + 300 * 1000, // 5 minutes left
     });
 
-    const result = await generateSignedUrl(authn, s3, target, "get");
+    const result = await generateSignedUrl(authn, s3, target);
 
     expect(signedExpiries()).toBe(300);
     expect(result.expirySeconds).toBe(300);
@@ -105,7 +101,7 @@ describe("generateSignedUrl()", () => {
   it("falls back to the configured window when expiry is unknown", async () => {
     vi.mocked(awsCloudAuth).mockResolvedValue({ ...defaultCredentials });
 
-    await generateSignedUrl(authn, s3, target, "get");
+    await generateSignedUrl(authn, s3, target);
 
     expect(signedExpiries()).toBe(FIVE_MINUTES);
   });
@@ -116,7 +112,7 @@ describe("generateSignedUrl()", () => {
       expiresAt: NOW - 1000,
     });
 
-    await expect(generateSignedUrl(authn, s3, target, "get")).rejects.toThrow(
+    await expect(generateSignedUrl(authn, s3, target)).rejects.toThrow(
       /too soon to sign usable URLs/
     );
   });
@@ -127,30 +123,19 @@ describe("generateSignedUrl()", () => {
       expiresAt: NOW + 30 * 1000, // 30s left, below 60s threshold
     });
 
-    await expect(generateSignedUrl(authn, s3, target, "get")).rejects.toThrow(
+    await expect(generateSignedUrl(authn, s3, target)).rejects.toThrow(
       /too soon to sign usable URLs/
     );
   });
 
-  it("correctly generates get signed URL and max get expiry time when get command passed in", async () => {
-    const result = await generateSignedUrl(authn, s3, target, "get");
+  it("correctly generates get signed URL and max get expiry time", async () => {
+    const result = await generateSignedUrl(authn, s3, target);
     expect(result.signedUrl).toBe("https://signed.example/url");
     expect(result.expirySeconds).toBe(FIVE_MINUTES);
     expect(getSignedUrl).toHaveBeenCalledWith(
       s3,
       expect.any(GetObjectCommand),
       { expiresIn: MAX_SECONDS_TO_EXPIRE_GET_URL }
-    );
-  });
-
-  it("correctly generates delete signed URL and max delete expiry time when delete command passed in", async () => {
-    const result = await generateSignedUrl(authn, s3, target, "delete");
-    expect(result.signedUrl).toBe("https://signed.example/url");
-    expect(result.expirySeconds).toBe(ONE_HOUR);
-    expect(getSignedUrl).toHaveBeenCalledWith(
-      s3,
-      expect.any(DeleteObjectCommand),
-      { expiresIn: MAX_SECONDS_TO_EXPIRE_DELETE_URL }
     );
   });
 });

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -16,17 +16,12 @@ import { PermissionRequest } from "../../types/request";
 import { awsCloudAuth } from "../aws/auth";
 import { AwsResourcePermissionSpec } from "../aws/types";
 import { FileTransferPermissionSpec } from "./types";
-import {
-  DeleteObjectCommand,
-  GetObjectCommand,
-  S3Client,
-} from "@aws-sdk/client-s3";
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { pick } from "lodash";
 import yargs from "yargs";
 
 export const MAX_SECONDS_TO_EXPIRE_GET_URL = 5 * 60;
-export const MAX_SECONDS_TO_EXPIRE_DELETE_URL = 60 * 60;
 const MIN_URL_EXPIRY_THRESHOLD_SECONDS = 60;
 
 export const provisionTransferRequest = async (
@@ -100,21 +95,17 @@ export const createTransferClient = (
   });
 
 /**
- * Signs the GET (download) or DELETE (cleanup) URL. Call this AFTER the upload
- * completes: the GET window is finite, and signing before a large upload would
- * burn that window while the file is still uploading.
+ * Signs the GET (download) URL. Call this AFTER the upload completes: the GET
+ * window is finite, and signing before a large upload would burn that window
+ * while the file is still uploading.
  *
- * Each expiry is capped to the credentials' remaining lifetime so a URL can
+ * The expiry is capped to the credentials' remaining lifetime so the URL can
  * never outlive the credentials that signed it.
  */
-
-type SignedUrlCommand = "delete" | "get";
-
 export const generateSignedUrl = async (
   authn: Authn,
   s3: S3Client,
   target: { bucket: string; key: string; awsSpec: AwsResourcePermissionSpec },
-  command: SignedUrlCommand,
   debug?: boolean
 ): Promise<{
   signedUrl: string;
@@ -132,33 +123,13 @@ export const generateSignedUrl = async (
     );
   }
 
-  const URL_CONFIGS: Record<
-    SignedUrlCommand,
-    { maxExpiry: number; s3Command: DeleteObjectCommand | GetObjectCommand }
-  > = {
-    get: {
-      maxExpiry: MAX_SECONDS_TO_EXPIRE_GET_URL,
-      s3Command: new GetObjectCommand({
-        Bucket: target.bucket,
-        Key: target.key,
-      }),
-    },
-    delete: {
-      maxExpiry: MAX_SECONDS_TO_EXPIRE_DELETE_URL,
-      s3Command: new DeleteObjectCommand({
-        Bucket: target.bucket,
-        Key: target.key,
-      }),
-    },
-  };
+  const secondsToExpireUrl = Math.min(MAX_SECONDS_TO_EXPIRE_GET_URL, remaining);
 
-  const urlConfig = URL_CONFIGS[command];
-
-  const secondsToExpireUrl = Math.min(urlConfig.maxExpiry, remaining);
-
-  const signedUrl = await getSignedUrl(s3, urlConfig.s3Command, {
-    expiresIn: secondsToExpireUrl,
-  });
+  const signedUrl = await getSignedUrl(
+    s3,
+    new GetObjectCommand({ Bucket: target.bucket, Key: target.key }),
+    { expiresIn: secondsToExpireUrl }
+  );
 
   return {
     signedUrl,


### PR DESCRIPTION


**Problem**

File Transfer integration did not delete the object after download has successfully completed. This change uses the delete presigned url to delete the object from the S3 bucket after the object has been successfully downloaded into the EC2 instance.


Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

<!-- Mark the relevant option(s) -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Verified that object was no longer in the S3 bucket after download completed.

