### PR TITLE
remove legacy delegate structure and update tests

### DIFF
--- a/src/commands/__tests__/kubeconfig.test.ts
+++ b/src/commands/__tests__/kubeconfig.test.ts
@@ -62,7 +62,7 @@ const AWS_DELEGATE: AwsResourcePermissionSpec = {
     name: "p0-role",
   },
   generated: { name: "p0-role" },
-  delegation: {},
+  delegation: [],
 };
 
 const buildRequest = (
@@ -117,18 +117,7 @@ describe("kubeconfigAction", () => {
     vi.clearAllMocks();
   });
 
-  it("passes the aws delegate to awsCloudAuth when delegation is in legacy record form", async () => {
-    mockRequestAccessToCluster.mockResolvedValue(
-      buildRequest({ aws: AWS_DELEGATE })
-    );
-
-    await runKubeconfig();
-
-    expect(mockAwsCloudAuth).toHaveBeenCalledOnce();
-    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
-  });
-
-  it("passes the aws delegate to awsCloudAuth when delegation is in new array form", async () => {
+  it("passes the aws delegate to awsCloudAuth when delegation is in array form", async () => {
     mockRequestAccessToCluster.mockResolvedValue(
       buildRequest([{ key: "aws", request: AWS_DELEGATE }])
     );
@@ -146,41 +135,5 @@ describe("kubeconfigAction", () => {
       "Backend granted k8s access, but this is not an EKS cluster."
     );
     expect(mockAwsCloudAuth).not.toHaveBeenCalled();
-  });
-
-  it("resolves equivalent shapes identically", async () => {
-    mockRequestAccessToCluster.mockResolvedValueOnce(
-      buildRequest({ aws: AWS_DELEGATE })
-    );
-    await runKubeconfig();
-    const recordCallArg = mockAwsCloudAuth.mock.calls[0]?.[1];
-
-    vi.clearAllMocks();
-    mockGetAndValidateK8sIntegration.mockResolvedValue({
-      clusterConfig: {
-        clusterId: "c-1",
-        awsAccountId: "111111111111",
-        awsClusterArn: "arn:aws:eks:us-east-1:111111111111:cluster/my-cluster",
-      },
-      awsLoginType: "federated",
-    });
-    mockEnsureEksInstall.mockResolvedValue(true);
-    mockAwsCloudAuth.mockResolvedValue({
-      AWS_ACCESS_KEY_ID: "k",
-      AWS_SECRET_ACCESS_KEY: "s",
-      AWS_SESSION_TOKEN: "t",
-      AWS_SECURITY_TOKEN: "t",
-    });
-    mockSpinUntil.mockImplementation(
-      async (_msg: string, action: any) => action
-    );
-    mockExec.mockResolvedValue({ stdout: "ok", stderr: "", code: 0 });
-    mockRequestAccessToCluster.mockResolvedValueOnce(
-      buildRequest([{ key: "aws", request: AWS_DELEGATE }])
-    );
-    await runKubeconfig();
-    const arrayCallArg = mockAwsCloudAuth.mock.calls[0]?.[1];
-
-    expect(arrayCallArg).toEqual(recordCallArg);
   });
 });

--- a/src/commands/aws/__tests__/rds.test.ts
+++ b/src/commands/aws/__tests__/rds.test.ts
@@ -64,7 +64,7 @@ const AWS_DELEGATE: AwsResourcePermissionSpec = {
     name: "p0-rds-role",
   },
   generated: { name: "p0-rds-role" },
-  delegation: {},
+  delegation: [],
 };
 
 const buildAccess = (
@@ -138,23 +138,7 @@ describe("rds generate-db-auth-token", () => {
     }));
   };
 
-  it("passes the inner aws delegate to awsCloudAuth (legacy nested record form)", async () => {
-    mockAccessResponse({
-      "aws-rds": {
-        permission: { vpcId: "vpc-1" },
-        delegation: { aws: AWS_DELEGATE },
-      },
-    });
-
-    await buildRdsYargs().parse(
-      "rds generate-db-auth-token --arch postgres --role admin"
-    );
-
-    expect(mockAwsCloudAuth).toHaveBeenCalledOnce();
-    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
-  });
-
-  it("passes the inner aws delegate to awsCloudAuth (new array form at both levels)", async () => {
+  it("passes the inner aws delegate to awsCloudAuth (array form at both levels)", async () => {
     mockAccessResponse([
       {
         key: "aws-rds",
@@ -170,39 +154,6 @@ describe("rds generate-db-auth-token", () => {
     );
 
     expect(mockAwsCloudAuth).toHaveBeenCalledOnce();
-    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
-  });
-
-  it("supports mixed nesting (array outer, record inner)", async () => {
-    mockAccessResponse([
-      {
-        key: "aws-rds",
-        request: {
-          permission: { vpcId: "vpc-1" },
-          delegation: { aws: AWS_DELEGATE },
-        },
-      },
-    ]);
-
-    await buildRdsYargs().parse(
-      "rds generate-db-auth-token --arch postgres --role admin"
-    );
-
-    expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
-  });
-
-  it("supports mixed nesting (record outer, array inner)", async () => {
-    mockAccessResponse({
-      "aws-rds": {
-        permission: { vpcId: "vpc-1" },
-        delegation: [{ key: "aws", request: AWS_DELEGATE }],
-      },
-    });
-
-    await buildRdsYargs().parse(
-      "rds generate-db-auth-token --arch postgres --role admin"
-    );
-
     expect(mockAwsCloudAuth.mock.calls[0]?.[1]).toEqual(AWS_DELEGATE);
   });
 
@@ -226,12 +177,15 @@ describe("rds generate-db-auth-token", () => {
 
     const runWithShell = async (shell: string, arch: "mysql" | "postgres") => {
       process.env.SHELL = shell;
-      mockAccessResponse({
-        "aws-rds": {
-          permission: { vpcId: "vpc-1" },
-          delegation: { aws: AWS_DELEGATE },
+      mockAccessResponse([
+        {
+          key: "aws-rds",
+          request: {
+            permission: { vpcId: "vpc-1" },
+            delegation: [{ key: "aws", request: AWS_DELEGATE }],
+          },
         },
-      });
+      ]);
       await buildRdsYargs().parse(
         `rds generate-db-auth-token --arch ${arch} --role admin`
       );

--- a/src/plugins/aws/__tests__/ssh.test.ts
+++ b/src/plugins/aws/__tests__/ssh.test.ts
@@ -39,7 +39,7 @@ const AWS_DELEGATE_IDC: AwsResourcePermissionSpec = {
     name: "permset",
   },
   generated: { name: "delegated-name" },
-  delegation: {},
+  delegation: [],
 };
 
 const AWS_DELEGATE_ROLE: AwsResourcePermissionSpec = {
@@ -84,7 +84,7 @@ describe("awsSshProvider.requestToSsh", () => {
   describe("legacy record-form delegation", () => {
     it("builds an IDC request when idc fields are populated", () => {
       const result = awsSshProvider.requestToSsh(
-        buildRequest({ aws: AWS_DELEGATE_IDC })
+        buildRequest([{ key: "aws", request: AWS_DELEGATE_IDC }])
       );
       expect(result).toEqual({
         type: "aws",
@@ -101,7 +101,7 @@ describe("awsSshProvider.requestToSsh", () => {
 
     it("builds a role request when idc fields are absent", () => {
       const result = awsSshProvider.requestToSsh(
-        buildRequest({ aws: AWS_DELEGATE_ROLE })
+        buildRequest([{ key: "aws", request: AWS_DELEGATE_ROLE }])
       );
       expect(result).toEqual({
         type: "aws",
@@ -152,7 +152,7 @@ describe("awsSshProvider.requestToSsh", () => {
 
     it("produces the same output as the record form for equivalent input", () => {
       const recordResult = awsSshProvider.requestToSsh(
-        buildRequest({ aws: AWS_DELEGATE_IDC })
+        buildRequest([{ key: "aws", request: AWS_DELEGATE_IDC }])
       );
       const arrayResult = awsSshProvider.requestToSsh(
         buildRequest([{ key: "aws", request: AWS_DELEGATE_IDC }])

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -53,7 +53,7 @@ describe("generateSignedUrl()", () => {
         idcRegion: undefined,
       },
       generated: { name: "test-role" },
-      delegation: {},
+      delegation: [],
     } satisfies AwsResourcePermissionSpec,
   };
 

--- a/src/types/__tests__/delegation.test.ts
+++ b/src/types/__tests__/delegation.test.ts
@@ -27,37 +27,15 @@ const AWS_DELEGATE: AwsDelegate = {
 };
 
 describe("getDelegate", () => {
-  describe("legacy record form", () => {
-    it("returns the delegate value when the key is present", () => {
-      const delegation: DelegationField<{ aws: AwsDelegate }> = {
-        aws: AWS_DELEGATE,
-      };
-      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
-    });
-
-    it("returns undefined when the key is absent on an optional field", () => {
-      const delegation: DelegationField<{ aws?: AwsDelegate }> = {};
-      expect(getDelegate(delegation, "aws")).toBeUndefined();
-    });
-
-    it("handles nested delegation by chaining calls", () => {
-      const delegation: DelegationField<{ "aws-rds": AwsRdsDelegate }> = {
-        "aws-rds": {
-          permission: { vpcId: "vpc-1" },
-          delegation: { aws: AWS_DELEGATE },
-        },
-      };
-      const rds = getDelegate(delegation, "aws-rds");
-      expect(getDelegate(rds?.delegation, "aws")).toEqual(AWS_DELEGATE);
-    });
-  });
-
-  describe("new array form", () => {
-    it("returns the request payload of the matching entry", () => {
+  describe("array form", () => {
+    it("returns the matching entry's request, stamped with its key as `type`", () => {
       const delegation: DelegationField<{ aws: AwsDelegate }> = [
         { key: "aws", request: AWS_DELEGATE },
       ];
-      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
+      expect(getDelegate(delegation, "aws")).toEqual({
+        ...AWS_DELEGATE,
+        type: "aws",
+      });
     });
 
     it("returns undefined when no entry matches the key", () => {
@@ -75,7 +53,10 @@ describe("getDelegate", () => {
         { key: "gcp", request: other },
         { key: "aws", request: AWS_DELEGATE },
       ];
-      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
+      expect(getDelegate(delegation, "aws")).toEqual({
+        ...AWS_DELEGATE,
+        type: "aws",
+      });
     });
 
     it("returns the first matching entry when keys are duplicated", () => {
@@ -91,7 +72,7 @@ describe("getDelegate", () => {
         { key: "aws", request: first },
         { key: "aws", request: second },
       ];
-      expect(getDelegate(delegation, "aws")).toEqual(first);
+      expect(getDelegate(delegation, "aws")).toEqual({ ...first, type: "aws" });
     });
 
     it("handles nested array-form delegation by chaining calls", () => {
@@ -105,21 +86,10 @@ describe("getDelegate", () => {
         },
       ];
       const rds = getDelegate(delegation, "aws-rds");
-      expect(getDelegate(rds?.delegation, "aws")).toEqual(AWS_DELEGATE);
-    });
-
-    it("handles a mixed nesting (array outside, record inside)", () => {
-      const delegation: DelegationField<{ "aws-rds": AwsRdsDelegate }> = [
-        {
-          key: "aws-rds",
-          request: {
-            permission: { vpcId: "vpc-1" },
-            delegation: { aws: AWS_DELEGATE },
-          },
-        },
-      ];
-      const rds = getDelegate(delegation, "aws-rds");
-      expect(getDelegate(rds?.delegation, "aws")).toEqual(AWS_DELEGATE);
+      expect(getDelegate(rds?.delegation, "aws")).toEqual({
+        ...AWS_DELEGATE,
+        type: "aws",
+      });
     });
 
     it("ignores malformed entries (missing key) without throwing", () => {
@@ -128,7 +98,10 @@ describe("getDelegate", () => {
         undefined,
         { key: "aws", request: AWS_DELEGATE },
       ] as any;
-      expect(getDelegate(delegation, "aws")).toEqual(AWS_DELEGATE);
+      expect(getDelegate(delegation, "aws")).toEqual({
+        ...AWS_DELEGATE,
+        type: "aws",
+      });
     });
   });
 

--- a/src/types/delegation.ts
+++ b/src/types/delegation.ts
@@ -9,46 +9,44 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 
-/** An entry in the new array-form delegation shape.
- *
- * The backend used to send delegation as a record (`{ aws: { ... } }`); it now
- * sends it as an array of `{ key, request }` entries. The `request` field holds
- * what used to be the record's value (permission, generated, nested delegation).
+/** An entry in the array-form delegation shape: an array of `{ key, request }`
+ * entries, where `request` holds the delegate value (permission, generated,
+ * nested delegation) and key is what type i.e 'aws.
  */
 export type DelegationEntry<K extends string, R> = {
   key: K;
   request: R;
 };
 
-/** Delegation field that tolerates both the legacy record form and the new
- * array form. Callers should not read this directly — use {@link getDelegate}.
+/** Array-form delegation. Callers should not read this directly — use
+ * {@link getDelegate}.
  */
-export type DelegationField<Spec extends Record<string, any>> =
-  | {
-      [K in keyof Spec & string]: DelegationEntry<K, Spec[K]>;
-    }[keyof Spec & string][]
-  | Spec;
+export type DelegationField<Spec extends Record<string, any>> = {
+  [K in keyof Spec & string]: DelegationEntry<K, Spec[K]>;
+}[keyof Spec & string][];
 
-/** Resolve a delegate by key, accepting either the legacy record-form
- * delegation or the new array-form delegation.
+/** Resolve a delegate by key from array-form delegation.
  *
  * Returns the underlying delegate value (with `permission`, `generated`,
  * and nested `delegation` fields), or `undefined` if no entry matches.
  *
- * The generic shape (`K`, `V` rather than the full `Spec` record) is
- * deliberate: matching the union `DelegationField<Spec>` bidirectionally
- * confuses TS's inference and can lock `Spec` onto the array branch.
- * Pinning `K` to the key argument and inferring `V` from the value avoids
- * that.
+ * Keyed on the whole `Spec` and indexed by `key`, so `getDelegate(d, "aws")`
+ * returns exactly `Spec["aws"]` — no union, no caller-side narrowing, even for
+ * multi-key delegations. The type-guard `find` asserts that the entry matching
+ * `key` carries `Spec[K]` (the runtime key check is the proof). The `Spec`
+ * default keeps nullish-input calls compiling when there is nothing to infer.
  */
-export const getDelegate = <K extends string, V>(
-  delegation: DelegationEntry<K, V>[] | { [P in K]?: V } | null | undefined,
+export const getDelegate = <
+  Spec extends Record<string, any> = Record<string, any>,
+  K extends keyof Spec & string = keyof Spec & string,
+>(
+  delegation: DelegationField<Spec> | null | undefined,
   key: K
-): V | undefined => {
-  if (delegation == null) return undefined;
-  if (Array.isArray(delegation)) {
-    const entry = delegation.find((e) => e?.key === key);
-    return entry?.request;
-  }
-  return delegation[key];
+): (Spec[K] & { type: K }) | undefined => {
+  const request = delegation?.find(
+    (e): e is DelegationEntry<K, Spec[K]> => e?.key === key
+  )?.request;
+  if (!request) return undefined;
+
+  return { ...request, type: key };
 };


### PR DESCRIPTION
**Problem**

The CLI reads "delegated" access details out of a permission request via a shared `getDelegate` helper — for example, pulling the AWS role grant out of an EKS/RDS request. Two things had accumulated in that helper:

1. It still tolerated a **legacy record-form** delegation shape (`{ aws: {...} }`) alongside the current **array form** (`[{ key, request }]`). A backend data-model migration has since converted all open and pending requests to the array form, so the record-form branch was dead code the CLI no longer receives.

2. Its typing was **loose** (`getDelegate<K, V>`), which returned a usable type only for delegations with a *single* delegate key. Every integration to date (SSH, kubeconfig, RDS, RDP) has exactly one delegate, so this was never exercised. The first integration to need **two** delegates from one request surfaced two latent problems:
   - `getDelegate(d, "aws")` returned the union of *all* delegate types rather than the one requested, so the precise type a caller needs didn't type-check.
   - The obvious way to narrow that union — a `type` discriminant declared on the spec — is **not present at runtime** on delegation entries (the entry's `key` is the discriminant, so the value carries no redundant `type`). Narrowing on it compiled but would have always failed at runtime.

**Change**

- Removed legacy record-form support from `DelegationField` and `getDelegate`; the helper now handles only the array form the backend sends.
- Reworked `getDelegate` to be keyed on the delegation spec and indexed by the requested key, so `getDelegate(d, "aws")` returns exactly that delegate's type — no union, no caller-side narrowing — including for multi-delegate requests.
- `getDelegate` now stamps the entry's `key` onto the returned value as `type`, reuniting the discriminant (carried by the key) with the value. As a result `type` is now correct both in the type system and at runtime.
- Updated unit tests to the array-only contract and the new `type`-stamping behavior.

Check off any of the following areas of code that are modified:

*(None of the above — this is CLI-side parsing of request payloads.)*

**Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue) — the loose typing/missing-discriminant combination would break any multi-delegate caller
- [x] Refactoring (code changes that neither fix bugs nor add features) — removes dead legacy-shape handling and tightens the helper's typing

**Validation**

- `tsc --noEmit` passes with zero errors across the repo, including all four `getDelegate` callers (file-transfer, kubeconfig, RDS, SSH) — confirming the precise per-key typing infers correctly everywhere.
- Unit tests updated and passing for `delegation`, `kubeconfig`, `rds`, `aws/ssh`, and `file-transfer` (32 tests). Tests now assert both the array-only contract and that `getDelegate` returns the delegate with its `type` populated from the key.
- Risk is contained to delegation parsing, which is exercised by every integration's test suite; the precise typing means future multi-delegate callers get correct types without re-deriving discriminants.

**Implementation (optional)**

- The precise signature keys `getDelegate` on the whole spec and indexes by `key`, using a type-guarded `find` so the matching entry's `request` is returned as the exact per-key type without a cast.
- Removing the record-form union was a prerequisite: it was the only reason the loose multi-delegate typing compiled, so it was masking the unsound array typing.
- No known technical debt introduced. The `type`-stamping at read time is a deliberate bridge: the backend keys delegates by `key` rather than emitting a redundant `type`, and stamping reunites the two so callers can rely on a single, consistent discriminant.

-->
