### PR TITLE
make unit tests run from ide with correct node env so ssh tests pass

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,6 +19,7 @@ export default defineConfig({
     exclude: ["**/node_modules/**", "**/build/**"],
     globals: true,
     // Mirrors the `test:unit` npm script so tests run with NODE_ENV=unit no matter how they're launched (CLI, IDE/Vitest extension). Code under test (e.g. ssh.ts) skips process-exiting side effects when NODE_ENV === "unit".
+    // TODO we should fix the unit tests to not set NODE_ENV and when we do we can remove this
     env: { NODE_ENV: "unit" },
   },
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -18,5 +18,7 @@ export default defineConfig({
     include: ["**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/build/**"],
     globals: true,
+    // Mirrors the `test:unit` npm script so tests run with NODE_ENV=unit no matter how they're launched (CLI, IDE/Vitest extension). Code under test (e.g. ssh.ts) skips process-exiting side effects when NODE_ENV === "unit".
+    env: { NODE_ENV: "unit" },
   },
 });


### PR DESCRIPTION
**Problem**

SSh unit tests weren't working when ran from vitest integration within IDE. b/c missing NODE_ENV set to unit, like the yarn script does. and SSH needs that to do preprocessing so unit tests work. This configs vitest to always set NODE_ENV = unit

**Type of Change**
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Unit tests pass in both IDE and via yarn test