### PR TITLE
File transfer use ssh delegation not 2nd ssh request

### DIFF
--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -195,8 +195,6 @@ const fileTransferAction = async (
 
       print2("Uploaded.");
 
-      // TODO we need to remove this second request. it should be included in file transfer delegation. Will be removed in future ticket
-      print2(`Requesting download access on ${args.destination}...`);
       print2(`Preparing to ssh into ${args.destination}...`);
 
       await cleanupStaleSshConfigs(args.debug);
@@ -228,7 +226,9 @@ const fileTransferAction = async (
           args.debug
         );
       if (args.debug) {
-        print2(`GET    (${renderDurationSec(getExpirySeconds)}): ${getUrl}`);
+        print2(
+          `GET URL created. Expiry:${renderDurationSec(getExpirySeconds)}`
+        );
       }
 
       const remotePath = `/home/${request.linuxUserName}/${basename(args.source)}`;
@@ -260,7 +260,7 @@ const fileTransferAction = async (
 
       if (exitCode === SUCCESS_EXIT_CODE) {
         // Success path: the file is on the instance, so clean it from the bucket.
-        print2(`Downloaded to ${remotePath}.`);
+        print2(`Downloaded to ${remotePath}. File transfer succeeded.`);
         await deleteUploadedObject(s3, target.bucket, uploadKey, args.debug);
       } else if (exitCode === null) {
         throw `Remote download was interrupted before completing ... re-run the file-transfer command`;

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -8,6 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { createKeyPair } from "../common/keys";
 import { retryWithSleep } from "../common/retry";
 import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
@@ -18,7 +19,8 @@ import {
   provisionTransferRequest,
 } from "../plugins/file-transfer";
 import { sshOrScp } from "../plugins/ssh";
-import { prepareRequest } from "./shared/ssh";
+import { setupSshConnection, validateSshInstall } from "./shared/ssh";
+import { cleanupStaleSshConfigs } from "./shared/ssh-cleanup";
 import { DeleteObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { createReadStream, statSync } from "fs";
@@ -99,6 +101,10 @@ export const fileTransferCommand = (yargs: yargs.Argv) =>
     fileTransferAction
   );
 
+/** Transfers files between a local and AWS remote host using s3. Allows for faster transfer speeds than scp.
+ *
+ * Implicitly gains access to the SSH resource.
+ */
 const fileTransferAction = async (
   args: yargs.ArgumentsCamelCase<FileTransferCommandArgs>
 ) => {
@@ -107,6 +113,14 @@ const fileTransferAction = async (
     async (span) => {
       span.setAttribute("source", args.source);
       span.setAttribute("destination", args.destination);
+
+      const authn = await authenticate(args);
+
+      // file transfer requires ssh to be installed
+      await validateSshInstall(authn, args);
+      const { publicKey, privateKey } = await createKeyPair();
+
+      // TODO need to add file transfer verify it's installed
 
       // Fail before requesting backend approval if the source can't be uploaded —
       // a missing path or directory would otherwise only surface mid-upload, after
@@ -121,10 +135,10 @@ const fileTransferAction = async (
         throw `Source path is not a regular file: ${args.source}`;
       }
 
-      const authn = await authenticate(args);
-
       print2("Requesting file-transfer access...");
-      const target = await provisionTransferRequest(authn, args);
+
+      const { target, delegatedSshRequest, requestId } =
+        await provisionTransferRequest(authn, args, publicKey);
       print2(`Access approved for s3://${target.bucket}/${target.prefix}`);
 
       // append original basename so the S3 object preserves the original filename.
@@ -183,6 +197,17 @@ const fileTransferAction = async (
 
       // TODO we need to remove this second request. it should be included in file transfer delegation. Will be removed in future ticket
       print2(`Requesting download access on ${args.destination}...`);
+      print2(`Preparing to ssh into ${args.destination}...`);
+
+      await cleanupStaleSshConfigs(args.debug);
+
+      const { request, sshProvider, sshHostKeys } = await setupSshConnection(
+        authn,
+        args,
+        requestId,
+        publicKey,
+        delegatedSshRequest
+      );
 
       // Drop `source` (local file path) before passing to SSH plumbing —
       // `createCommand` uses `"source" in args` to branch between scp and ssh path, and we want the ssh branch here.
@@ -192,9 +217,6 @@ const fileTransferAction = async (
         arguments: [],
         sshOptions: [],
       };
-
-      const { request, requestId, privateKey, sshProvider, sshHostKeys } =
-        await prepareRequest(authn, sshCmdArgs, args.destination);
 
       // Sign GET URL now so the 5-min TTL starts after approval clears,
       // not before — otherwise long approval waits could expire the URL.

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -96,7 +96,7 @@ export const fileTransferCommand = (yargs: yargs.Argv) =>
         })
         .option("debug", {
           type: "boolean",
-          describe: "Print debug information, including signed URLs.",
+          describe: "Print debug information.",
         }),
     fileTransferAction
   );
@@ -120,7 +120,7 @@ const fileTransferAction = async (
       await validateSshInstall(authn, args);
       const { publicKey, privateKey } = await createKeyPair();
 
-      // TODO need to add file transfer verify it's installed
+      // TODO need to add verify file transfer installed?
 
       // Fail before requesting backend approval if the source can't be uploaded —
       // a missing path or directory would otherwise only surface mid-upload, after

--- a/src/commands/shared/__tests__/ssh-setup-connection.test.ts
+++ b/src/commands/shared/__tests__/ssh-setup-connection.test.ts
@@ -1,0 +1,117 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { Authn } from "../../../types/identity";
+import { PermissionRequest } from "../../../types/request";
+import { PluginSshRequest, SshProvider } from "../../../types/ssh";
+import { BaseSshCommandArgs, SSH_PROVIDERS, setupSshConnection } from "../ssh";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import yargs from "yargs";
+
+const mockEnsureInstall = vi.fn();
+const mockSubmitPublicKey = vi.fn();
+const mockToCliRequest = vi.fn();
+const mockRequestToSsh = vi.fn();
+const mockResolveHostKeys = vi.fn();
+
+const mockProvider = {
+  ensureInstall: mockEnsureInstall,
+  submitPublicKey: mockSubmitPublicKey,
+  toCliRequest: mockToCliRequest,
+  requestToSsh: mockRequestToSsh,
+  resolveHostKeys: mockResolveHostKeys,
+} as unknown as SshProvider<any, any, any, any>;
+
+const mockAuthn = {
+  identity: { credential: { expires_at: 0 }, org: {} },
+  getToken: vi.fn().mockResolvedValue("mock-token"),
+} as unknown as Authn;
+
+const requestId = "request-123";
+const publicKey = "ssh-ed25519 AAAA...";
+
+const baseArgs = {
+  $0: "p0",
+  _: ["ssh"],
+  debug: true,
+} satisfies yargs.ArgumentsCamelCase<BaseSshCommandArgs>;
+
+const provisionedRequest = {
+  permission: { provider: "aws" },
+} as unknown as PermissionRequest<PluginSshRequest>;
+
+describe("setupSshConnection", () => {
+  // setupSshConnection resolves the provider from the shared SSH_PROVIDERS record at call time, so overwrite the "aws" entry with the mock and restore it afterwards so it doesn't affect other tests.
+  let originalProvider: SshProvider<any, any, any, any>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalProvider = SSH_PROVIDERS.aws;
+    SSH_PROVIDERS.aws = mockProvider;
+  });
+
+  afterEach(() => {
+    SSH_PROVIDERS.aws = originalProvider;
+  });
+
+  it("calls each required ssh prep method", async () => {
+    await setupSshConnection(
+      mockAuthn,
+      baseArgs,
+      requestId,
+      publicKey,
+      provisionedRequest
+    );
+
+    expect(mockEnsureInstall).toHaveBeenCalled();
+    expect(mockSubmitPublicKey).toHaveBeenCalled();
+    expect(mockToCliRequest).toHaveBeenCalled();
+    expect(mockRequestToSsh).toHaveBeenCalled();
+    expect(mockResolveHostKeys).toHaveBeenCalled();
+  });
+
+  it("functions for providers without submitPublicKey/resolveHostKeys", async () => {
+    // Same partial-mock cast as mockProvider, omitting the two optional methods to exercise the ?. branch.
+    SSH_PROVIDERS.aws = {
+      ensureInstall: mockEnsureInstall,
+      toCliRequest: mockToCliRequest,
+      requestToSsh: mockRequestToSsh,
+    } as unknown as SshProvider<any, any, any, any>;
+
+    const result = await setupSshConnection(
+      mockAuthn,
+      baseArgs,
+      requestId,
+      publicKey,
+      provisionedRequest
+    );
+
+    expect(mockSubmitPublicKey).not.toHaveBeenCalled();
+    expect(mockResolveHostKeys).not.toHaveBeenCalled();
+    expect(result.sshHostKeys).toBeUndefined();
+  });
+
+  it("returns host keys resolved by the provider", async () => {
+    const hostKeys = {
+      keys: ["ssh-ed25519 AAAAHOSTKEY..."],
+    };
+    mockResolveHostKeys.mockResolvedValue(hostKeys);
+
+    const result = await setupSshConnection(
+      mockAuthn,
+      baseArgs,
+      requestId,
+      publicKey,
+      provisionedRequest
+    );
+
+    expect(result.sshHostKeys).toBe(hostKeys);
+  });
+});

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -99,7 +99,7 @@ export const SSH_PROVIDERS: Record<
   "self-hosted": selfHostedSshProvider,
 };
 
-const validateSshInstall = async (
+export const validateSshInstall = async (
   authn: Authn,
   args: yargs.ArgumentsCamelCase<BaseSshCommandArgs>
 ) => {
@@ -172,21 +172,7 @@ export const provisionRequest = async (
     );
   };
 
-  // Always prints the error, but adds a hint if we think a username was included in the instance name by mistake.
-  const requestErrorHandler = (err: any) => {
-    if (typeof err === "string") {
-      print2(err);
-      if (
-        err.startsWith("Could not find any instances matching") &&
-        destination.includes("@")
-      ) {
-        print2(
-          "Hint: The instance name appears to include a username. The username should be omitted."
-        );
-      }
-    }
-    sys.exit(1);
-  };
+  const requestErrorHandler = newSshRequestErrorHandler(destination);
 
   let response;
   if (options?.approvedOnly) {
@@ -238,7 +224,7 @@ const pluginToCliRequest = async (
   options: { debug?: boolean; publicKey: string }
 ): Promise<PermissionRequest<CliSshRequest>> =>
   await SSH_PROVIDERS[request.permission.provider].toCliRequest(
-    request as any,
+    request,
     options
   );
 
@@ -258,36 +244,68 @@ export const prepareRequest = async (
 
     const { requestId, publicKey, provisionedRequest } = result;
 
-    const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
-
     span.setAttribute("provider", provisionedRequest.permission.provider);
     span.setAttribute("requestId", requestId);
-
-    await sshProvider.ensureInstall({ debug: args.debug });
-
-    await sshProvider.submitPublicKey?.(
+    const { request, sshProvider, sshHostKeys } = await setupSshConnection(
       authn,
-      provisionedRequest,
+      args,
       requestId,
       publicKey,
-      args.debug
+      provisionedRequest
     );
-
-    await sshProvider.ensureInstall();
-
-    const cliRequest = await pluginToCliRequest(provisionedRequest, {
-      ...args,
-      publicKey,
-    });
-
-    const request = sshProvider.requestToSsh(cliRequest);
-
-    const sshHostKeys = await sshProvider.resolveHostKeys?.(request, {
-      ...args,
-      authn,
-      requestId,
-    });
 
     return { ...result, request, sshProvider, provisionedRequest, sshHostKeys };
   });
+};
+
+// Always prints the error, but adds a hint if we think a username was included in the instance name by mistake.
+export const newSshRequestErrorHandler =
+  (destination: string) => (err: any) => {
+    if (typeof err === "string") {
+      print2(err);
+      if (
+        err.startsWith("Could not find any instances matching") &&
+        destination.includes("@")
+      ) {
+        print2(
+          "Hint: The instance name appears to include a username. The username should be omitted."
+        );
+      }
+    }
+    sys.exit(1);
+  };
+
+export const setupSshConnection = async (
+  authn: Authn,
+  args: yargs.ArgumentsCamelCase<BaseSshCommandArgs>,
+  requestId: string,
+  publicKey: string,
+  provisionedRequest: PermissionRequest<PluginSshRequest>
+) => {
+  const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
+
+  await sshProvider.ensureInstall({ debug: args.debug });
+
+  await sshProvider.submitPublicKey?.(
+    authn,
+    provisionedRequest,
+    requestId,
+    publicKey,
+    args.debug
+  );
+
+  const cliRequest = await pluginToCliRequest(provisionedRequest, {
+    ...args,
+    publicKey,
+  });
+
+  const request = sshProvider.requestToSsh(cliRequest);
+
+  const sshHostKeys = await sshProvider.resolveHostKeys?.(request, {
+    ...args,
+    authn,
+    requestId,
+  });
+
+  return { request, sshProvider, sshHostKeys };
 };

--- a/src/plugins/file-transfer/__tests__/index.test.ts
+++ b/src/plugins/file-transfer/__tests__/index.test.ts
@@ -8,21 +8,31 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { FileTransferCommandArgs } from "../../../commands/file-transfer";
+import { decodeProvisionStatus } from "../../../commands/shared";
+import { request } from "../../../commands/shared/request";
+import { Authn } from "../../../types/identity";
 import { awsCloudAuth } from "../../aws/auth";
 import type { AwsResourcePermissionSpec } from "../../aws/types";
-import { generateSignedUrl, MAX_SECONDS_TO_EXPIRE_GET_URL } from "../index";
+import {
+  generateSignedUrl,
+  MAX_SECONDS_TO_EXPIRE_GET_URL,
+  provisionTransferRequest,
+} from "../index";
 import { GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import yargs from "yargs";
 
 vi.mock("../../aws/auth", () => ({ awsCloudAuth: vi.fn() }));
 vi.mock("@aws-sdk/s3-request-presigner", () => ({
   getSignedUrl: vi.fn().mockResolvedValue("https://signed.example/url"),
 }));
-// vi.mock("@aws-sdk/client-s3", () => ({
-//   DeleteObjectCommand: vi.fn(),
-//   GetObjectCommand: vi.fn(),
-// }));
+vi.mock("../../../commands/shared/request", () => ({ request: vi.fn() }));
+vi.mock("../../../commands/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../commands/shared")>()),
+  decodeProvisionStatus: vi.fn(),
+}));
 
 const FIVE_MINUTES = 5 * 60;
 const ONE_HOUR = 60 * 60;
@@ -137,5 +147,65 @@ describe("generateSignedUrl()", () => {
       expect.any(GetObjectCommand),
       { expiresIn: MAX_SECONDS_TO_EXPIRE_GET_URL }
     );
+  });
+});
+
+describe("provisionTransferRequest()", () => {
+  // `request` is curried: request("request") returns the inner fn that calls the API, so we mock both layers.
+  const mockRequest = vi.mocked(request);
+  const mockInnerRequest = vi.fn();
+  const mockDecodeProvisionStatus = vi.mocked(decodeProvisionStatus);
+  const mockAuthn = {} as unknown as Authn;
+  const publicKey = "ssh-ed25519 AAAA...";
+  const args = {
+    $0: "p0",
+    _: ["file-transfer"],
+    source: "file.txt",
+    destination: "i-0123456789",
+  } satisfies yargs.ArgumentsCamelCase<FileTransferCommandArgs>;
+
+  // Backend strips `type` from delegate entries (the array key is the discriminant); getDelegate reattaches it.
+  const awsDelegate = {
+    key: "aws",
+    request: { permission: {}, generated: {} },
+  };
+  const sshDelegate = {
+    key: "ssh",
+    request: { permission: {}, generated: {} },
+  };
+  const backendRequestResponse = {
+    id: "req-abc",
+    request: {
+      status: "DONE",
+      principal: "user@example.com",
+      delegation: [] as { key: string; request: object }[],
+    },
+  };
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest.mockReturnValue(mockInnerRequest);
+    mockDecodeProvisionStatus.mockResolvedValue(true);
+    backendRequestResponse.request.delegation = [];
+  });
+
+  it("throws when the aws delegate is missing", async () => {
+    // only has ssh delegate, should have both ssh and aws
+    backendRequestResponse.request.delegation = [sshDelegate];
+    mockInnerRequest.mockResolvedValue(backendRequestResponse);
+
+    await expect(
+      provisionTransferRequest(mockAuthn, args, publicKey)
+    ).rejects.toMatch(/AWS access details/);
+  });
+
+  it("throws when the ssh delegate is missing", async () => {
+    // only has aws delegate, should have both ssh and aws
+    backendRequestResponse.request.delegation = [awsDelegate];
+
+    mockInnerRequest.mockResolvedValue(backendRequestResponse);
+
+    await expect(
+      provisionTransferRequest(mockAuthn, args, publicKey)
+    ).rejects.toMatch(/SSH access details/);
   });
 });

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -9,7 +9,9 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { FileTransferCommandArgs } from "../../commands/file-transfer";
+import { decodeProvisionStatus } from "../../commands/shared";
 import { request } from "../../commands/shared/request";
+import { newSshRequestErrorHandler } from "../../commands/shared/ssh";
 import { getDelegate } from "../../types/delegation";
 import { Authn } from "../../types/identity";
 import { PermissionRequest } from "../../types/request";
@@ -19,6 +21,7 @@ import { FileTransferPermissionSpec } from "./types";
 import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { pick } from "lodash";
+import { sys } from "typescript";
 import yargs from "yargs";
 
 export const MAX_SECONDS_TO_EXPIRE_GET_URL = 5 * 60;
@@ -26,8 +29,12 @@ const MIN_URL_EXPIRY_THRESHOLD_SECONDS = 60;
 
 export const provisionTransferRequest = async (
   authn: Authn,
-  args: yargs.ArgumentsCamelCase<FileTransferCommandArgs>
+  args: yargs.ArgumentsCamelCase<FileTransferCommandArgs>,
+  publicKey: string
 ) => {
+  // Always prints the error, but adds a hint if we think a username was included in the destination instance name by mistake.
+  const requestErrorHandler = newSshRequestErrorHandler(args.destination);
+
   const response = await request("request")<
     PermissionRequest<FileTransferPermissionSpec>
   >(
@@ -37,31 +44,58 @@ export const provisionTransferRequest = async (
         "file-transfer",
         "session",
         args.destination,
+        "--public-key",
+        publicKey,
         ...(args.reason ? ["--reason", args.reason] : []),
       ],
       wait: true,
     },
     authn,
     { message: "approval-required" }
-  );
+  ).catch(requestErrorHandler);
 
   if (!response) {
     throw "Did not receive a response from server";
   }
 
+  const result = await decodeProvisionStatus<FileTransferPermissionSpec>(
+    response.request
+  );
+  if (!result) sys.exit(1);
+
+  const { id: requestId } = response;
+  const { status, principal } = response.request;
+
   const awsSpec = getDelegate(response.request.delegation, "aws");
-  if (!awsSpec) {
+  if (!awsSpec || awsSpec.type !== "aws") {
     throw "Backend granted file-transfer access, but there was an error getting AWS access details";
   }
+
+  const sshSpec = getDelegate(response.request.delegation, "ssh");
+  if (!sshSpec || sshSpec.type !== "ssh") {
+    throw "Backend granted file-transfer access, but there was an error getting SSH access details";
+  }
+
+  const delegatedSshRequest = {
+    ...sshSpec,
+    status,
+    principal,
+  };
 
   const { bucketName, bucketRegion, objectPrefix } =
     response.request.permission.resource;
 
   return {
-    bucket: bucketName,
-    prefix: objectPrefix,
-    region: bucketRegion,
-    awsSpec,
+    target: {
+      bucket: bucketName,
+      prefix: objectPrefix,
+      region: bucketRegion,
+      awsSpec,
+      sshSpec,
+    },
+    // needed for further delegate ssh request processing within file-transfer command
+    delegatedSshRequest,
+    requestId,
   };
 };
 

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -67,12 +67,13 @@ export const provisionTransferRequest = async (
   const { status, principal } = response.request;
 
   const awsSpec = getDelegate(response.request.delegation, "aws");
-  if (!awsSpec || awsSpec.type !== "aws") {
+  if (!awsSpec) {
     throw "Backend granted file-transfer access, but there was an error getting AWS access details";
   }
 
   const sshSpec = getDelegate(response.request.delegation, "ssh");
-  if (!sshSpec || sshSpec.type !== "ssh") {
+
+  if (!sshSpec) {
     throw "Backend granted file-transfer access, but there was an error getting SSH access details";
   }
 

--- a/src/plugins/file-transfer/index.ts
+++ b/src/plugins/file-transfer/index.ts
@@ -92,7 +92,6 @@ export const provisionTransferRequest = async (
       prefix: objectPrefix,
       region: bucketRegion,
       awsSpec,
-      sshSpec,
     },
     // needed for further delegate ssh request processing within file-transfer command
     delegatedSshRequest,

--- a/src/plugins/file-transfer/types.ts
+++ b/src/plugins/file-transfer/types.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { PermissionSpec } from "../../types/request";
-import { AwsResourcePermissionSpec } from "../aws/types";
+import { AwsResourcePermissionSpec, AwsSshPermissionSpec } from "../aws/types";
 
 export type FileTransferPermission = {
   resource: {
@@ -30,5 +30,5 @@ export type FileTransferPermissionSpec = PermissionSpec<
   "file-transfer",
   FileTransferPermission,
   Record<string, never>,
-  { aws?: AwsResourcePermissionSpec }
+  { aws?: AwsResourcePermissionSpec; ssh?: AwsSshPermissionSpec }
 >;

--- a/src/plugins/file-transfer/types.ts
+++ b/src/plugins/file-transfer/types.ts
@@ -23,6 +23,7 @@ export type FileTransferPermission = {
     objectPrefix: string;
   };
   destination: string;
+  publicKey: string;
   type: "resource";
 };
 

--- a/src/plugins/file-transfer/types.ts
+++ b/src/plugins/file-transfer/types.ts
@@ -23,7 +23,6 @@ export type FileTransferPermission = {
     objectPrefix: string;
   };
   destination: string;
-  publicKey: string;
   type: "resource";
 };
 


### PR DESCRIPTION
**Problem**

File transfer was making a second ssh request. with this PR and the paired backend PR it uses ssh through request delegation.

**Change**


Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**
- file transfer validates ssh is installed
- file transfer creates key pair before making file transfer req to backend. then sends public key to backend file transfer req so  backend can pass it to ssh delegate
- file transfer cleans up stale ssh configs, copying ssh flow
- refactor ssh provisionRequest flow into the part that makes the request and a new function called sshSetupConnection. That way file transfer can use that to set up the ssh connection without actually making a second request
- add unit tests
- have file transfer use ssh error handler so it gives hint if destination has @ symbol that it shoudn't have username in destination
- have file transfer correctly use decodeProvisionStatus like every other integration. so it stops if request was denied or something.

<!-- Mark the relevant option(s) -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

unit tests and thorough manual testing of file transefr
manual tests of ssh and ssh resolve/proxy flow to ensure no regressions in ssh.

**Implementation (optional)**

-This is paired with backend PR too b/c file transfer changes needed there and file transfer contract betweencli and backend changes slightly with this. https://github.com/p0-security/app/pull/6035

