### PR TITLE
More robust logging for file transfer if access request goes stale

### DIFF
--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -295,7 +295,7 @@ async function spawnSshNode(
           const knownError = connectionErrorMessage();
           reject(
             knownError ??
-              `Access did not propagate through ${provider.friendlyName} in time. ${getContactMessage()}`
+              `Access did not propagate through ${provider.friendlyName} in time. If you had existing access, try revoking it and re-running the command to request fresh access. ${getContactMessage()}`
           );
           return;
         }


### PR DESCRIPTION
if your access request is stale, it's possible the file transfer upload may silently fail, adding a log to give the user recovery instructions.