### PR TITLE
add intial scaffolding for our ssh e2e tests in cli

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
     ".eslintrc.js",
     "prettier.config.js",
     "vitest.config.mts",
+    "vitest.e2e.config.mts",
     "public/**",
     "build/**",
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ web_modules/
 .env.test.local
 .env.production.local
 .env.local
+.env.e2e
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "build:debian": "tsc --project tsconfig.build.json && cp -r public build/dist/ && node esbuild.js",
     "test": "yarn test:unit",
     "test:unit": "NODE_ENV=unit vitest run",
+    "e2e": "vitest run --config vitest.e2e.config.mts",
     "clean": "rm -rf build",
     "format": "yarn prettier --write .",
     "lint": "yarn lint:formatting && yarn lint:code && yarn lint:types",

--- a/src/e2e/README.md
+++ b/src/e2e/README.md
@@ -63,3 +63,5 @@ Each provider's flow is skipped with a warning when its node is not configured â
 - Your `~/.ssh/config` delegating to this repository's CLI (see "The ssh flow" above).
 - Cloud CLIs installed for the providers under test (`aws` + session-manager plugin, `az`, `gcloud`), plus a system `ssh`/`scp`.
 - Expect long runtimes: access propagation can take several minutes per provider; individual tests time out after 20 minutes.
+
+Tests against real cloud infra hit occasional transient failures (propagation timing, intermittent connection errors), so each test retries up to 3 times before failing the run (see `retry` in `vitest.e2e.config.mts`).

--- a/src/e2e/README.md
+++ b/src/e2e/README.md
@@ -1,0 +1,65 @@
+# P0 CLI end-to-end tests
+
+Automated end-to-end tests that exercise the real CLI against a live P0 organization (default: `p0-e2e`) and real cloud nodes. They are entirely separate from the unit tests (`yarn test:unit`).
+
+```
+yarn e2e
+```
+
+Target a single cloud provider's flow by passing its spec file (see "What it does" below for the file names):
+
+```
+yarn e2e src/e2e/ssh-aws.e2e.ts
+yarn e2e src/e2e/ssh-azure.e2e.ts
+yarn e2e src/e2e/ssh-gcloud.e2e.ts
+```
+
+Global setup and login still run first; only that provider's node needs to be configured (see Configuration below).
+
+## What it does
+
+Global setup (before any test) smoke-tests the existing build with `p0 --version` and runs `p0 login p0-e2e` — a failure of either step aborts the whole run. Run `yarn build` yourself first; the suite does not build for you.
+
+There's one ssh flow spec per cloud provider — `ssh-aws.e2e.ts`, `ssh-azure.e2e.ts`, `ssh-gcloud.e2e.ts` — each driving its configured node through the whole access lifecycle, in order. They share their step logic (`ssh-flow.ts`) but are separate files so you can run one provider independently, e.g. `yarn e2e src/e2e/ssh-aws.e2e.ts`. Each step runs a remote command instead of an interactive shell, so its session ends on its own once the connection succeeds:
+
+1. `p0 ls ssh session destination --json` — confirms the configured node is visible to the e2e user (matched by key, value, instance ID, name, or alternative name) before spending time requesting access to it
+2. `p0 ssh <node-id> --provider <p>` — requests access to the node (waits for approval and propagation), connects, runs a command
+3. `p0 ssh <node-id> --provider <p> --sudo` — reconnects with a sudo grant, runs a command as root
+4. `p0 scp` — upload/download round trip
+5. plain `ssh <node-id>` — the system ssh resolves the node through your own ssh config: a `Match exec` line runs `p0 ssh-resolve`, and an `Include` picks up the generated config whose ProxyCommand drives `p0 ssh-proxy`
+
+Step 5 requires your `~/.ssh/config` to delegate to this repository's CLI — set it up before running the suite by adding these lines:
+
+```
+Match exec "<repo>/p0 ssh-resolve %h"
+Include <P0_PATH>/ssh/configs/*.config
+```
+
+(`<P0_PATH>` is `~/.p0` or `~/.p0-<env>` depending on your CLI environment; extra `ssh-resolve` flags such as `--debug` are fine, but the `Match` line must come before the `Include`.)
+
+At the end of the run the suite prints a reminder: **please revoke all access granted to the e2e user before running the suite again**, so the next run requests access from scratch.
+
+## Configuration
+
+Set node IDs via environment variables, or put them in a git-ignored `.env` file at the repository root:
+
+```
+P0_E2E_AWS_NODE=my-aws-instance
+P0_E2E_AZURE_NODE=my-azure-vm
+P0_E2E_GCLOUD_NODE=my-gcp-instance
+
+# Optional overrides
+P0_E2E_ORG=p0-e2e
+P0_E2E_REASON=P0 CLI automated e2e test
+```
+
+Each provider's flow is skipped with a warning when its node is not configured — set as many or as few as you have access to. Set `P0_E2E_SKIP_SETUP=1` to reuse the existing login session when iterating on individual specs.
+
+## Prerequisites
+
+- A build: run `yarn build` before `yarn e2e` (and again after pulling in CLI changes — the suite does not rebuild for you).
+- A user for the e2e org whose access requests are auto-approved (a first run may open a browser to complete login).
+- All access for the e2e user revoked, so each flow exercises fresh requests.
+- Your `~/.ssh/config` delegating to this repository's CLI (see "The ssh flow" above).
+- Cloud CLIs installed for the providers under test (`aws` + session-manager plugin, `az`, `gcloud`), plus a system `ssh`/`scp`.
+- Expect long runtimes: access propagation can take several minutes per provider; individual tests time out after 20 minutes.

--- a/src/e2e/README.md
+++ b/src/e2e/README.md
@@ -65,3 +65,7 @@ Each provider's flow is skipped with a warning when its node is not configured â
 - Expect long runtimes: access propagation can take several minutes per provider; individual tests time out after 20 minutes.
 
 Tests against real cloud infra hit occasional transient failures (propagation timing, intermittent connection errors), so each test retries up to 3 times before failing the run (see `retry` in `vitest.e2e.config.mts`).
+
+## Troubleshooting
+
+If the plain-`ssh` step consistently fails with `Could not resolve hostname` while a manual `ssh <node-id>` works, check the p0 process's environment size. The `Match exec` command runs through your login shell, so an oversized shell profile (e.g. a `~/.zshenv` that grows `PATH` on every invocation) can push the resolved environment to a size where `p0 ssh-resolve` crashes and the `Include` never applies. `zsh -c 'printf %s "$PATH" | wc -c'` should be well under a few KB.

--- a/src/e2e/global-setup.ts
+++ b/src/e2e/global-setup.ts
@@ -1,0 +1,61 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { E2E_ORG, P0_LAUNCHER, REPO_ROOT, runCommand, runP0 } from "./harness";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/** Runs after the whole suite. The flow spec leaves its access grants in
+ * place, and a re-run only exercises fresh requests once they are gone. */
+const teardown = () => {
+  process.stderr.write(
+    `\n[e2e] Reminder: please revoke all access granted to the e2e user in the "${E2E_ORG}" org before running the suite again, so the next run requests access from scratch.\n`
+  );
+};
+
+/** Prepares the suite: smoke-tests the existing build via `p0 --version` (run
+ * `yarn build` yourself first if `build/dist` is stale or missing), then logs
+ * in to the e2e org. A failure of either step aborts the whole run.
+ *
+ * Set P0_E2E_SKIP_SETUP=1 to reuse the existing login session when iterating
+ * on individual specs. */
+export default async function globalSetup() {
+  if (process.env.P0_E2E_SKIP_SETUP) {
+    process.stderr.write(
+      "[e2e] P0_E2E_SKIP_SETUP is set; reusing existing login\n"
+    );
+    return teardown;
+  }
+
+  const version = await runP0(["--version"], { timeoutMs: 60_000 });
+  const { version: packageVersion } = JSON.parse(
+    fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8")
+  ) as { version: string };
+  if (version.code !== 0 || !version.stdout.includes(packageVersion)) {
+    throw new Error(
+      `[e2e] p0 --version did not report ${packageVersion}\n${version.output}`
+    );
+  }
+
+  // Interactive so a first-time browser/device login flow can complete; a
+  // no-op when a valid session already exists.
+  const login = await runCommand(
+    "node",
+    ["--no-deprecation", P0_LAUNCHER, "login", E2E_ORG],
+    { interactive: true, timeoutMs: 5 * 60 * 1000 }
+  );
+  if (login.code !== 0) {
+    throw new Error(
+      `[e2e] p0 login ${E2E_ORG} failed with exit code ${login.code}`
+    );
+  }
+
+  return teardown;
+}

--- a/src/e2e/harness.ts
+++ b/src/e2e/harness.ts
@@ -88,10 +88,31 @@ export type RunOptions = {
  * shell, so this is purely for the log. */
 const shellQuote = (arg: string) => (/\s/.test(arg) ? `"${arg}"` : arg);
 
+const STRIPPED_ENV_PREFIXES = ["npm_", "VITEST", "TINYPOOL_"];
+const STRIPPED_ENV_KEYS = new Set([
+  // Would silently turn every ssh test into a sudo request; the suite always
+  // controls sudo explicitly.
+  "P0_SSH_SUDO",
+  "NODE_ENV",
+  "TEST",
+  "MODE",
+  "DEV",
+  "PROD",
+  "SSR",
+  "BASE_URL",
+  "FORCE_TTY",
+  "COLOR",
+  "NODE_CHANNEL_FD",
+]);
+
 const childEnv = (extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
-  // P0_SSH_SUDO would silently turn every ssh test into a sudo request, so the
-  // suite always controls sudo explicitly.
-  const { P0_SSH_SUDO: _ignored, ...env } = process.env;
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([key]) =>
+        !STRIPPED_ENV_KEYS.has(key) &&
+        !STRIPPED_ENV_PREFIXES.some((prefix) => key.startsWith(prefix))
+    )
+  );
   return { ...env, ...extra };
 };
 

--- a/src/e2e/harness.ts
+++ b/src/e2e/harness.ts
@@ -1,0 +1,163 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import * as dotenv from "dotenv";
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+
+// `yarn e2e` always runs from the repository root (vitest sets cwd to the
+// config's root), so the CLI under test is the repo's own `p0` launcher,
+// which runs the output of `yarn build`.
+export const REPO_ROOT = process.cwd();
+export const P0_LAUNCHER = path.join(REPO_ROOT, "p0");
+
+// Node IDs and org overrides can live in a git-ignored .env file.
+dotenv.config({ path: path.join(REPO_ROOT, ".env") });
+
+/** The P0 organization the suite logs in to before running any test. */
+export const E2E_ORG = process.env.P0_E2E_ORG ?? "p0-e2e";
+
+/** Access requests generally require a reason in the e2e org. */
+export const E2E_REASON =
+  process.env.P0_E2E_REASON ?? "P0 CLI automated e2e test";
+
+export type SshTarget = {
+  /** Value passed to `--provider` on the CLI. */
+  provider: "aws" | "azure" | "gcloud";
+  /** Value of the `provider` field in `p0 ls --json` output for this cloud;
+   * gcloud is reported there as "gcp". */
+  lsProvider: string;
+  node: string | undefined;
+};
+
+/** An SSH-able node for one cloud provider in the e2e org. The flow built on
+ * top of this target is skipped (with a warning) when its node is not
+ * configured, so each provider's spec file can run independently. */
+const sshTarget = (
+  provider: SshTarget["provider"],
+  lsProvider: string,
+  node: string | undefined
+): SshTarget => {
+  if (!node) {
+    process.stderr.write(
+      `[e2e] P0_E2E_${provider.toUpperCase()}_NODE is not set; skipping the ${provider} ssh flow\n`
+    );
+  }
+  return { provider, lsProvider, node };
+};
+
+export const AWS_TARGET = sshTarget("aws", "aws", process.env.P0_E2E_AWS_NODE);
+export const AZURE_TARGET = sshTarget(
+  "azure",
+  "azure",
+  process.env.P0_E2E_AZURE_NODE
+);
+export const GCLOUD_TARGET = sshTarget(
+  "gcloud",
+  "gcp",
+  process.env.P0_E2E_GCLOUD_NODE
+);
+
+export type CliResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  /** stdout and stderr interleaved in arrival order, for assertion messages */
+  output: string;
+};
+
+export type RunOptions = {
+  /** Kill the process (SIGTERM, then SIGKILL) after this long */
+  timeoutMs?: number;
+  /** Extra environment variables for the child */
+  env?: NodeJS.ProcessEnv;
+  /** Attach the child directly to the terminal instead of capturing output;
+   * used for steps that may need user interaction (e.g. a login flow) */
+  interactive?: boolean;
+};
+
+/** Quotes args containing whitespace so the logged command line is safe to
+ * copy-paste into a real shell; the child process itself is spawned without a
+ * shell, so this is purely for the log. */
+const shellQuote = (arg: string) => (/\s/.test(arg) ? `"${arg}"` : arg);
+
+const childEnv = (extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
+  // P0_SSH_SUDO would silently turn every ssh test into a sudo request, so the
+  // suite always controls sudo explicitly.
+  const { P0_SSH_SUDO: _ignored, ...env } = process.env;
+  return { ...env, ...extra };
+};
+
+export const runCommand = (
+  command: string,
+  args: string[],
+  options: RunOptions = {}
+): Promise<CliResult> => {
+  const { timeoutMs = 15 * 60 * 1000, env, interactive } = options;
+
+  process.stderr.write(
+    `\n[e2e] $ ${command} ${args.map(shellQuote).join(" ")}\n`
+  );
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: REPO_ROOT,
+      env: childEnv(env),
+      stdio: interactive ? "inherit" : ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let output = "";
+    let timedOut = false;
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stdout += text;
+      output += text;
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stderr += text;
+      output += text;
+    });
+
+    const killTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 10_000).unref();
+    }, timeoutMs);
+
+    child.on("error", (error) => {
+      clearTimeout(killTimer);
+      reject(new Error(`Failed to run ${command}: ${error.message}`));
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(killTimer);
+      resolve({
+        code,
+        stdout,
+        stderr,
+        output: timedOut
+          ? `${output}\n[e2e] command timed out after ${timeoutMs} ms`
+          : output,
+      });
+    });
+  });
+};
+
+/** Runs the built CLI: `p0 <args>` */
+export const runP0 = (args: string[], options: RunOptions = {}) =>
+  runCommand("node", ["--no-deprecation", P0_LAUNCHER, ...args], options);
+
+/** A unique, greppable token to prove a remote command actually ran. */
+export const uniqueMarker = (label: string) =>
+  `p0-e2e-${label}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;

--- a/src/e2e/ssh-aws.e2e.ts
+++ b/src/e2e/ssh-aws.e2e.ts
@@ -1,0 +1,14 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { AWS_TARGET } from "./harness";
+import { describeSshFlow } from "./ssh-flow";
+
+describeSshFlow(AWS_TARGET);

--- a/src/e2e/ssh-azure.e2e.ts
+++ b/src/e2e/ssh-azure.e2e.ts
@@ -1,0 +1,14 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { AZURE_TARGET } from "./harness";
+import { describeSshFlow } from "./ssh-flow";
+
+describeSshFlow(AZURE_TARGET);

--- a/src/e2e/ssh-flow.ts
+++ b/src/e2e/ssh-flow.ts
@@ -1,0 +1,166 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import {
+  E2E_REASON,
+  runCommand,
+  runP0,
+  SshTarget,
+  uniqueMarker,
+} from "./harness";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+/** Registers the sequential access-lifecycle flow for a single cloud
+ * provider's node: a `p0 ls` lookup, `p0 ssh`, `p0 ssh --sudo`, `p0 scp`, then
+ * a plain `ssh <node-id>` through the user's own ssh config. The first
+ * `p0 ssh` requests access to the node; every later step reuses that grant.
+ * Each step runs a remote command instead of an interactive shell, so its
+ * session ends on its own as soon as the connection succeeds.
+ *
+ * Call this once per provider spec file so each provider's flow can be run
+ * independently (e.g. `yarn e2e src/e2e/ssh-aws.e2e.ts`). */
+export const describeSshFlow = ({ provider, lsProvider, node }: SshTarget) => {
+  describe.skipIf(!node)(`p0 ssh flow (${provider})`, () => {
+    const marker = uniqueMarker(`flow-${provider}`);
+    const localDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), `p0-e2e-flow-${provider}-`)
+    );
+    const uploadPath = path.join(localDir, "upload.txt");
+    const downloadPath = path.join(localDir, "download.txt");
+    const remotePath = `/tmp/${marker}.txt`;
+
+    afterAll(async () => {
+      fs.rmSync(localDir, { recursive: true, force: true });
+      // Best-effort remote cleanup; not part of the assertion.
+      await runP0(
+        [
+          "ssh",
+          node!,
+          "--provider",
+          provider,
+          "--reason",
+          E2E_REASON,
+          "rm",
+          "-f",
+          remotePath,
+        ],
+        { timeoutMs: 5 * 60_000 }
+      );
+    });
+
+    it("finds the configured node via p0 ls before requesting access", async () => {
+      const result = await runP0(
+        ["ls", "ssh", "session", "destination", "--json", "--size", "500"],
+        { timeoutMs: 2 * 60_000 }
+      );
+      expect(result.code, result.output).toBe(0);
+
+      const { items } = JSON.parse(result.stdout) as {
+        items: {
+          provider: string;
+          key: string;
+          value: string;
+          instanceId?: string;
+          name?: string;
+          alternativeNames?: string[];
+        }[];
+      };
+      const found = items.some(
+        (item) =>
+          item.provider === lsProvider &&
+          (item.key === node ||
+            item.value === node ||
+            item.instanceId === node ||
+            item.name === node ||
+            // eslint is having a hard time realizing that node is not null here.
+            (!!node && item.alternativeNames?.includes(node)))
+      );
+      expect(
+        found,
+        `${node} was not found among ${lsProvider} destinations in \`p0 ls ssh session destination\`; is it visible to the e2e user?\n${result.output}`
+      ).toBe(true);
+    });
+
+    it("requests access with p0 ssh and runs a command", async () => {
+      const result = await runP0([
+        "ssh",
+        node!,
+        "--provider",
+        provider,
+        "--reason",
+        E2E_REASON,
+        "echo",
+        marker,
+      ]);
+
+      expect(result.code, result.output).toBe(0);
+      expect(result.output).toContain(marker);
+    });
+
+    it("reconnects with p0 ssh --sudo and runs a command as root", async () => {
+      const result = await runP0([
+        "ssh",
+        node!,
+        "--provider",
+        provider,
+        "--sudo",
+        "--reason",
+        E2E_REASON,
+        "sudo",
+        "whoami",
+      ]);
+
+      expect(result.code, result.output).toBe(0);
+      expect(result.output).toContain("root");
+    });
+
+    it("uploads and downloads a file round trip with p0 scp", async () => {
+      fs.writeFileSync(uploadPath, `${marker}\n`);
+
+      const upload = await runP0([
+        "scp",
+        uploadPath,
+        `${node!}:${remotePath}`,
+        "--provider",
+        provider,
+        "--reason",
+        E2E_REASON,
+      ]);
+      expect(upload.code, upload.output).toBe(0);
+
+      const download = await runP0([
+        "scp",
+        `${node!}:${remotePath}`,
+        downloadPath,
+        "--provider",
+        provider,
+        "--reason",
+        E2E_REASON,
+      ]);
+      expect(download.code, download.output).toBe(0);
+
+      expect(fs.readFileSync(downloadPath, "utf8")).toBe(`${marker}\n`);
+    });
+
+    it("connects with a plain `ssh <node-id>` through the user's ssh config", async () => {
+      // The Match exec line runs `p0 ssh-resolve`, which writes the node's
+      // config under P0_PATH; the Include then applies its `p0 ssh-proxy`
+      // ProxyCommand — the native-ssh setup end to end.
+      const sshMarker = uniqueMarker(`flow-${provider}-native-ssh`);
+      const ssh = await runCommand("ssh", [node!, `echo ${sshMarker}`]);
+
+      expect(ssh.code, ssh.output).toBe(0);
+      expect(ssh.output).toContain(sshMarker);
+    });
+  });
+};

--- a/src/e2e/ssh-gcloud.e2e.ts
+++ b/src/e2e/ssh-gcloud.e2e.ts
@@ -1,0 +1,14 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { GCLOUD_TARGET } from "./harness";
+import { describeSshFlow } from "./ssh-flow";
+
+describeSshFlow(GCLOUD_TARGET);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,9 @@
     "build",
     "node_modules",
     "vitest.config.mts",
+    "vitest.e2e.config.mts",
     "**/__mocks__/**",
-    "**/__tests__/**"
+    "**/__tests__/**",
+    "src/e2e/**"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -105,5 +105,5 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
 
-  "exclude": ["build", "node_modules", "vitest.config.mts"],
+  "exclude": ["build", "node_modules", "vitest.config.mts", "vitest.e2e.config.mts"],
 }

--- a/vitest.e2e.config.mts
+++ b/vitest.e2e.config.mts
@@ -1,0 +1,36 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    include: ["src/e2e/**/*.e2e.ts"],
+    exclude: ["**/node_modules/**", "**/build/**"],
+    globals: true,
+    globalSetup: ["src/e2e/global-setup.ts"],
+    reporters: ["verbose"],
+
+    // These tests drive real cloud access against the e2e org and share one
+    // login session, so everything runs strictly one test at a time. Each
+    // spec assumes the global-setup login.
+    fileParallelism: false,
+    maxConcurrency: 1,
+    pool: "forks",
+    poolOptions: { forks: { singleFork: true } },
+
+    // SSH access propagation alone can take up to ~10 minutes per provider.
+    testTimeout: 20 * 60 * 1000,
+    hookTimeout: 5 * 60 * 1000,
+  },
+});

--- a/vitest.e2e.config.mts
+++ b/vitest.e2e.config.mts
@@ -32,5 +32,10 @@ export default defineConfig({
     // SSH access propagation alone can take up to ~10 minutes per provider.
     testTimeout: 20 * 60 * 1000,
     hookTimeout: 5 * 60 * 1000,
+
+    // These tests drive real cloud infra and hit occasional transient
+    // failures (propagation timing, intermittent connection errors), so
+    // retry before failing the run.
+    retry: 3,
   },
 });


### PR DESCRIPTION
**Problem**

We lack a repeatable test harness for developers to run for verification of new features/changes to the CLI in a repeatable and consistent way.

**Change**

Implement a short repeatable test suite for ssh e2e tests that verifies ssh capabilities for aws, gcloud, and azure for the following features: ssh, scp, ssh-proxy, ssh-resolve, and sudo/non-sudo access.

**Type of Change**

- [x] e2e tests

**Validation**

Ran the test manually with the following env variables:

```
P0_E2E_AWS_NODE=i-05495395f44da0ac5
P0_E2E_AZURE_NODE=miguel-node-1
P0_E2E_GCLOUD_NODE=test-micro2
P0_E2E_ORG=p0-e2e
P0_E2E_REASON=P0 CLI automated e2e test
```

**Tracking (optional)**

https://linear.app/p0-security/issue/CUS-575/add-initial-scaffolding-for-local-ssh-e2e-tests

**Attachments (optional)**

<img width="615" height="235" alt="image" src="https://github.com/user-attachments/assets/d563aead-1709-4862-96f9-00f56a33d062" />

<img width="584" height="234" alt="image" src="https://github.com/user-attachments/assets/375ac574-c29d-4994-ba55-9fadd7e4bb74" />

<img width="608" height="228" alt="image" src="https://github.com/user-attachments/assets/8c148044-d2e5-47bc-9054-bfbe6e0e4f73" />


**Follow-up Work**

More e2e tests are necessary for the full test-suite, test also takes a long time to complete.
