### PR TITLE
add support for connection timeout overrides in ssh providers

### DIFF
--- a/src/commands/shared/__tests__/ssh-resolve.test.ts
+++ b/src/commands/shared/__tests__/ssh-resolve.test.ts
@@ -123,6 +123,30 @@ describe("sshResolveAction", () => {
     }
   });
 
+  it.each([-5, 0, 2.5, NaN])(
+    "omits ConnectTimeout when the provider sets an invalid sshConnectTimeoutSeconds (%s)",
+    async (invalidTimeout) => {
+      const originalTimeout = SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
+      SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = invalidTimeout;
+      try {
+        await sshResolveAction({ ...baseArgs });
+
+        const configWriteCall = (fs.writeFileSync as Mock).mock.calls.find(
+          ([path]) => typeof path === "string" && path.endsWith(".config")
+        );
+        expect(configWriteCall).toBeDefined();
+        const configContent = configWriteCall![1] as string;
+        expect(configContent).not.toContain("ConnectTimeout");
+      } finally {
+        if (originalTimeout === undefined) {
+          delete SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
+        } else {
+          SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = originalTimeout;
+        }
+      }
+    }
+  );
+
   it("omits ConnectTimeout when the provider does not set sshConnectTimeoutSeconds", async () => {
     await sshResolveAction({ ...baseArgs });
 

--- a/src/commands/shared/__tests__/ssh-resolve.test.ts
+++ b/src/commands/shared/__tests__/ssh-resolve.test.ts
@@ -12,7 +12,7 @@ import { authenticate } from "../../../drivers/auth";
 import { Authn } from "../../../types/identity";
 import { sshResolveAction } from "../../ssh-resolve";
 import { SshResolveCommandArgs } from "../ssh";
-import { prepareRequest } from "../ssh";
+import { prepareRequest, SSH_PROVIDERS } from "../ssh";
 import fs from "fs";
 import { beforeEach, describe, expect, it, vi, Mock } from "vitest";
 import yargs from "yargs";
@@ -100,5 +100,32 @@ describe("sshResolveAction", () => {
     expect(configWriteCall).toBeDefined();
     const configContent = configWriteCall![1] as string;
     expect(configContent).not.toContain("--org");
+  });
+
+  it("includes ConnectTimeout when the provider sets sshConnectTimeoutSeconds", async () => {
+    SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = 10;
+    try {
+      await sshResolveAction({ ...baseArgs });
+
+      const configWriteCall = (fs.writeFileSync as Mock).mock.calls.find(
+        ([path]) => typeof path === "string" && path.endsWith(".config")
+      );
+      expect(configWriteCall).toBeDefined();
+      const configContent = configWriteCall![1] as string;
+      expect(configContent).toContain("ConnectTimeout 10");
+    } finally {
+      delete SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
+    }
+  });
+
+  it("omits ConnectTimeout when the provider does not set sshConnectTimeoutSeconds", async () => {
+    await sshResolveAction({ ...baseArgs });
+
+    const configWriteCall = (fs.writeFileSync as Mock).mock.calls.find(
+      ([path]) => typeof path === "string" && path.endsWith(".config")
+    );
+    expect(configWriteCall).toBeDefined();
+    const configContent = configWriteCall![1] as string;
+    expect(configContent).not.toContain("ConnectTimeout");
   });
 });

--- a/src/commands/shared/__tests__/ssh-resolve.test.ts
+++ b/src/commands/shared/__tests__/ssh-resolve.test.ts
@@ -103,6 +103,7 @@ describe("sshResolveAction", () => {
   });
 
   it("includes ConnectTimeout when the provider sets sshConnectTimeoutSeconds", async () => {
+    const originalTimeout = SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
     SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = 10;
     try {
       await sshResolveAction({ ...baseArgs });
@@ -114,7 +115,11 @@ describe("sshResolveAction", () => {
       const configContent = configWriteCall![1] as string;
       expect(configContent).toContain("ConnectTimeout 10");
     } finally {
-      delete SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
+      if (originalTimeout === undefined) {
+        delete SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
+      } else {
+        SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = originalTimeout;
+      }
     }
   });
 

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -71,6 +71,15 @@ export const sshResolveCommand = (yargs: yargs.Argv) =>
     sshResolveAction
   );
 
+export const connectTimeoutDirective = (
+  timeoutSeconds: number | undefined
+): string =>
+  timeoutSeconds !== undefined &&
+  Number.isInteger(timeoutSeconds) &&
+  timeoutSeconds > 0
+    ? `ConnectTimeout ${timeoutSeconds}`
+    : "";
+
 /** Determine if an SSH backend is accessible to the user and prepares local files for access
  *
  * Creates an access request with approvedOnly and creates any
@@ -155,9 +164,9 @@ export const sshResolveAction = async (
 
   // Bound the ssh handshake for providers that request it (e.g. Azure jump hosts), so an offline/unreachable
   // target VM surfaces a prompt error instead of hanging indefinitely.
-  const connectTimeoutInfo = sshProvider?.sshConnectTimeoutSeconds
-    ? `ConnectTimeout ${sshProvider.sshConnectTimeoutSeconds}`
-    : "";
+  const connectTimeoutInfo = connectTimeoutDirective(
+    sshProvider?.sshConnectTimeoutSeconds
+  );
 
   const alias = sshHostKeys?.alias ?? request?.id;
 

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -153,6 +153,12 @@ export const sshResolveAction = async (
     ? `UserKnownHostsFile ${sshHostKeys.path}`
     : "";
 
+  // Bound the ssh handshake for providers that request it (e.g. Azure jump hosts), so an offline/unreachable
+  // target VM surfaces a prompt error instead of hanging indefinitely.
+  const connectTimeoutInfo = sshProvider?.sshConnectTimeoutSeconds
+    ? `ConnectTimeout ${sshProvider.sshConnectTimeoutSeconds}`
+    : "";
+
   const alias = sshHostKeys?.alias ?? request?.id;
 
   const hostKeyAlias = alias ? `HostKeyAlias ${alias}` : "";
@@ -177,6 +183,7 @@ export const sshResolveAction = async (
   User ${request.linuxUserName}
   IdentityFile ${identityFile}
   ${certificateInfo}
+  ${connectTimeoutInfo}
   PasswordAuthentication no
   ProxyCommand ${appPath} ssh-proxy %h --port %p --provider ${provisionedRequest.permission.provider} --identity-file ${identityFile} --request-json ${tmpFile.name}${orgFlag}${debugFlag}
   ${hostKeysInfo}

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -150,6 +150,11 @@ export type SshProvider<
   /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option */
   proxyCommand: (request: SR, port?: string) => string[];
 
+  /** When set, generated SSH configs bound the handshake with this timeout so an unreachable target surfaces a
+   * prompt, retryable error instead of hanging indefinitely. Used by providers whose ProxyCommand cannot itself
+   * bound the full path to the target (e.g. Azure jump hosts). */
+  sshConnectTimeoutSeconds?: number;
+
   /** Each element in the returned array is a command that can be run to reproduce the
    * steps of logging in the user to the ssh session. */
   reproCommands: (


### PR DESCRIPTION
**Problem**

The SSH configs generated by `p0 ssh-resolve` never set a `ConnectTimeout`, so if a target host is offline or unreachable, the SSH handshake can hang indefinitely. Providers whose ProxyCommand cannot bound the full path to the target (e.g. upcoming Azure jump host support) need a way to fail fast with a retryable error instead.

**Change**

Adds an optional `sshConnectTimeoutSeconds` field to the shared `SshProvider` type. When a provider sets it, `ssh-resolve` emits a `ConnectTimeout <seconds>` line in the generated SSH config; when unset (the default for all current providers — aws, azure, gcloud, self-hosted), the config is unchanged. No provider implements it yet; Azure jump hosts will opt in via a follow-up.

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Added unit tests covering both paths: `ConnectTimeout` is included when a provider sets the field, and omitted otherwise (`ssh-resolve.test.ts`, 4/4 passing). `tsc` is clean. Since no provider sets the field yet, generated configs are byte-identical to before, so regression risk is minimal.

**Tracking (optional)**

[CUS-572](https://linear.app/p0-security/issue/CUS-572/azure-ssh-add-a-connecttimeout-to-ssh-resolve)

**Follow-up Work (optional)**

Azure jump host provider will set `sshConnectTimeoutSeconds` when it lands (prototyped in #429).
