### PR TITLE
switch to an ssh factory method for provider selection

### DIFF
--- a/src/commands/shared/__tests__/ssh-resolve.test.ts
+++ b/src/commands/shared/__tests__/ssh-resolve.test.ts
@@ -59,6 +59,9 @@ const basePrepareResult = {
     permission: { provider: "aws", resource: {} },
   },
   sshHostKeys: undefined,
+  sshProvider: {
+    generateKeys: vi.fn(async () => ({ privateKeyPath: "/tmp/key" })),
+  },
 };
 
 const baseArgs = {

--- a/src/commands/shared/__tests__/ssh-resolve.test.ts
+++ b/src/commands/shared/__tests__/ssh-resolve.test.ts
@@ -9,10 +9,11 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { authenticate } from "../../../drivers/auth";
+import { awsSshProvider } from "../../../plugins/aws/ssh";
 import { Authn } from "../../../types/identity";
 import { sshResolveAction } from "../../ssh-resolve";
 import { SshResolveCommandArgs } from "../ssh";
-import { prepareRequest, SSH_PROVIDERS } from "../ssh";
+import { prepareRequest } from "../ssh";
 import fs from "fs";
 import { beforeEach, describe, expect, it, vi, Mock } from "vitest";
 import yargs from "yargs";
@@ -106,8 +107,8 @@ describe("sshResolveAction", () => {
   });
 
   it("includes ConnectTimeout when the provider sets sshConnectTimeoutSeconds", async () => {
-    const originalTimeout = SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
-    SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = 10;
+    const originalTimeout = awsSshProvider.sshConnectTimeoutSeconds;
+    awsSshProvider.sshConnectTimeoutSeconds = 10;
     try {
       await sshResolveAction({ ...baseArgs });
 
@@ -119,9 +120,9 @@ describe("sshResolveAction", () => {
       expect(configContent).toContain("ConnectTimeout 10");
     } finally {
       if (originalTimeout === undefined) {
-        delete SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
+        delete awsSshProvider.sshConnectTimeoutSeconds;
       } else {
-        SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = originalTimeout;
+        awsSshProvider.sshConnectTimeoutSeconds = originalTimeout;
       }
     }
   });
@@ -129,8 +130,8 @@ describe("sshResolveAction", () => {
   it.each([-5, 0, 2.5, NaN])(
     "omits ConnectTimeout when the provider sets an invalid sshConnectTimeoutSeconds (%s)",
     async (invalidTimeout) => {
-      const originalTimeout = SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
-      SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = invalidTimeout;
+      const originalTimeout = awsSshProvider.sshConnectTimeoutSeconds;
+      awsSshProvider.sshConnectTimeoutSeconds = invalidTimeout;
       try {
         await sshResolveAction({ ...baseArgs });
 
@@ -142,9 +143,9 @@ describe("sshResolveAction", () => {
         expect(configContent).not.toContain("ConnectTimeout");
       } finally {
         if (originalTimeout === undefined) {
-          delete SSH_PROVIDERS.aws.sshConnectTimeoutSeconds;
+          delete awsSshProvider.sshConnectTimeoutSeconds;
         } else {
-          SSH_PROVIDERS.aws.sshConnectTimeoutSeconds = originalTimeout;
+          awsSshProvider.sshConnectTimeoutSeconds = originalTimeout;
         }
       }
     }

--- a/src/commands/shared/__tests__/ssh-setup-connection.test.ts
+++ b/src/commands/shared/__tests__/ssh-setup-connection.test.ts
@@ -10,24 +10,27 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { Authn } from "../../../types/identity";
 import { PermissionRequest } from "../../../types/request";
-import { PluginSshRequest, SshProvider } from "../../../types/ssh";
-import { BaseSshCommandArgs, SSH_PROVIDERS, setupSshConnection } from "../ssh";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginSshRequest } from "../../../types/ssh";
+import { BaseSshCommandArgs, setupSshConnection } from "../ssh";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import yargs from "yargs";
 
-const mockEnsureInstall = vi.fn();
-const mockSubmitPublicKey = vi.fn();
-const mockToCliRequest = vi.fn();
-const mockRequestToSsh = vi.fn();
-const mockResolveHostKeys = vi.fn();
+// setupSshConnection resolves its provider through newSshProvider at call
+// time, which for an "aws" request returns the aws plugin's provider — so mock
+// that module. Vitest resolves the export at property-access time, so tests
+// can swap awsSshModule.awsSshProvider per test case.
+const { mockProvider, awsSshModule } = vi.hoisted(() => {
+  const mockProvider = {
+    ensureInstall: vi.fn(),
+    submitPublicKey: vi.fn(),
+    toCliRequest: vi.fn(),
+    requestToSsh: vi.fn(),
+    resolveHostKeys: vi.fn(),
+  };
+  return { mockProvider, awsSshModule: { awsSshProvider: mockProvider } };
+});
 
-const mockProvider = {
-  ensureInstall: mockEnsureInstall,
-  submitPublicKey: mockSubmitPublicKey,
-  toCliRequest: mockToCliRequest,
-  requestToSsh: mockRequestToSsh,
-  resolveHostKeys: mockResolveHostKeys,
-} as unknown as SshProvider<any, any, any, any>;
+vi.mock("../../../plugins/aws/ssh", () => awsSshModule);
 
 const mockAuthn = {
   identity: { credential: { expires_at: 0 }, org: {} },
@@ -48,17 +51,9 @@ const provisionedRequest = {
 } as unknown as PermissionRequest<PluginSshRequest>;
 
 describe("setupSshConnection", () => {
-  // setupSshConnection resolves the provider from the shared SSH_PROVIDERS record at call time, so overwrite the "aws" entry with the mock and restore it afterwards so it doesn't affect other tests.
-  let originalProvider: SshProvider<any, any, any, any>;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    originalProvider = SSH_PROVIDERS.aws;
-    SSH_PROVIDERS.aws = mockProvider;
-  });
-
-  afterEach(() => {
-    SSH_PROVIDERS.aws = originalProvider;
+    awsSshModule.awsSshProvider = mockProvider;
   });
 
   it("calls each required ssh prep method", async () => {
@@ -70,20 +65,20 @@ describe("setupSshConnection", () => {
       provisionedRequest
     );
 
-    expect(mockEnsureInstall).toHaveBeenCalled();
-    expect(mockSubmitPublicKey).toHaveBeenCalled();
-    expect(mockToCliRequest).toHaveBeenCalled();
-    expect(mockRequestToSsh).toHaveBeenCalled();
-    expect(mockResolveHostKeys).toHaveBeenCalled();
+    expect(mockProvider.ensureInstall).toHaveBeenCalled();
+    expect(mockProvider.submitPublicKey).toHaveBeenCalled();
+    expect(mockProvider.toCliRequest).toHaveBeenCalled();
+    expect(mockProvider.requestToSsh).toHaveBeenCalled();
+    expect(mockProvider.resolveHostKeys).toHaveBeenCalled();
   });
 
   it("functions for providers without submitPublicKey/resolveHostKeys", async () => {
-    // Same partial-mock cast as mockProvider, omitting the two optional methods to exercise the ?. branch.
-    SSH_PROVIDERS.aws = {
-      ensureInstall: mockEnsureInstall,
-      toCliRequest: mockToCliRequest,
-      requestToSsh: mockRequestToSsh,
-    } as unknown as SshProvider<any, any, any, any>;
+    // Partial provider omitting the two optional methods to exercise the ?. branch.
+    awsSshModule.awsSshProvider = {
+      ensureInstall: mockProvider.ensureInstall,
+      toCliRequest: mockProvider.toCliRequest,
+      requestToSsh: mockProvider.requestToSsh,
+    } as typeof mockProvider;
 
     const result = await setupSshConnection(
       mockAuthn,
@@ -93,8 +88,8 @@ describe("setupSshConnection", () => {
       provisionedRequest
     );
 
-    expect(mockSubmitPublicKey).not.toHaveBeenCalled();
-    expect(mockResolveHostKeys).not.toHaveBeenCalled();
+    expect(mockProvider.submitPublicKey).not.toHaveBeenCalled();
+    expect(mockProvider.resolveHostKeys).not.toHaveBeenCalled();
     expect(result.sshHostKeys).toBeUndefined();
   });
 
@@ -102,7 +97,7 @@ describe("setupSshConnection", () => {
     const hostKeys = {
       keys: ["ssh-ed25519 AAAAHOSTKEY..."],
     };
-    mockResolveHostKeys.mockResolvedValue(hostKeys);
+    mockProvider.resolveHostKeys.mockResolvedValue(hostKeys);
 
     const result = await setupSshConnection(
       mockAuthn,

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -25,9 +25,11 @@ import {
   CliSshRequest,
   PluginSshRequest,
   SshProvider,
+  SshRequest,
   SupportedSshProvider,
   SupportedSshProviders,
 } from "../../types/ssh";
+import { assertNever } from "../../util";
 import { request } from "./request";
 import { pick } from "lodash";
 import { sys } from "typescript";
@@ -89,14 +91,24 @@ export type SshAdditionalSetup = {
   teardown: () => Promise<void>;
 };
 
-export const SSH_PROVIDERS: Record<
-  SupportedSshProvider,
-  SshProvider<any, any, any, any>
-> = {
-  aws: awsSshProvider,
-  azure: azureSshProvider,
-  gcloud: gcpSshProvider,
-  "self-hosted": selfHostedSshProvider,
+export const newSshProvider = (
+  request: PermissionRequest<PluginSshRequest> | SshRequest
+): SshProvider<any, any, any, any> => {
+  const provider =
+    "permission" in request ? request.permission.provider : request.type;
+
+  switch (provider) {
+    case "aws":
+      return awsSshProvider;
+    case "gcloud":
+      return gcpSshProvider;
+    case "self-hosted":
+      return selfHostedSshProvider;
+    case "azure":
+      return azureSshProvider;
+    default:
+      throw assertNever(provider);
+  }
 };
 
 export const validateSshInstall = async (
@@ -223,10 +235,7 @@ const pluginToCliRequest = async (
   request: PermissionRequest<PluginSshRequest>,
   options: { debug?: boolean; publicKey: string }
 ): Promise<PermissionRequest<CliSshRequest>> =>
-  await SSH_PROVIDERS[request.permission.provider].toCliRequest(
-    request,
-    options
-  );
+  await newSshProvider(request).toCliRequest(request, options);
 
 export const prepareRequest = async (
   authn: Authn,
@@ -282,7 +291,7 @@ export const setupSshConnection = async (
   publicKey: string,
   provisionedRequest: PermissionRequest<PluginSshRequest>
 ) => {
-  const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
+  const sshProvider = newSshProvider(provisionedRequest);
 
   await sshProvider.ensureInstall({ debug: args.debug });
 

--- a/src/commands/ssh-proxy.ts
+++ b/src/commands/ssh-proxy.ts
@@ -13,7 +13,7 @@ import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
 import { sshProxy } from "../plugins/ssh";
 import { P0_PATH } from "../util";
-import { SshProxyCommandArgs, SSH_PROVIDERS } from "./shared/ssh";
+import { newSshProvider, SshProxyCommandArgs } from "./shared/ssh";
 import { cleanupStaleSshConfigs } from "./shared/ssh-cleanup";
 import * as fs from "fs/promises";
 import path from "path";
@@ -94,10 +94,10 @@ const sshProxyAction = async (
     throw "Azure SSH does not currently support specifying a port. SSH on the target VM must be listening on the default port 22.";
   }
 
-  const sshProvider = SSH_PROVIDERS[args.provider];
-
   const requestJson = await fs.readFile(args.requestJson, "utf8");
   const request = JSON.parse(requestJson);
+
+  const sshProvider = newSshProvider(request);
 
   const privateKey = await fs.readFile(args.identityFile, "utf8");
 

--- a/src/commands/ssh-resolve.ts
+++ b/src/commands/ssh-resolve.ts
@@ -20,9 +20,9 @@ import {
   P0_PATH,
 } from "../util";
 import {
+  newSshProvider,
   prepareRequest,
   SshResolveCommandArgs,
-  SSH_PROVIDERS,
 } from "./shared/ssh";
 import { cleanupStaleSshConfigs } from "./shared/ssh-cleanup";
 import fs from "fs";
@@ -129,13 +129,12 @@ export const sshResolveAction = async (
       approvedOnly: true,
       quiet: args.quiet,
     }).catch(requestErrorHandler);
-
-  const sshProvider = SSH_PROVIDERS[provisionedRequest.permission.provider];
+  const sshProvider = newSshProvider(provisionedRequest);
 
   if (args.debug) {
     print2("Generating Keys");
   }
-  const keys = await sshProvider?.generateKeys?.(
+  const keys = await sshProvider.generateKeys?.(
     authn,
     provisionedRequest.permission.resource,
     {

--- a/src/plugins/ssh/__tests__/index.test.ts
+++ b/src/plugins/ssh/__tests__/index.test.ts
@@ -149,11 +149,6 @@ describe("sshProxy credential handoff stays shell-agnostic", () => {
 });
 
 describe("GCP connection failure diagnostics", () => {
-  // spawnSshNode resolves the provider (and thus its connectionErrorMessage and
-  // unprovisionedAccessPatterns) from the SSH_PROVIDERS registry keyed by
-  // request.type, so a `gcloud` request exercises the real GCP classifier. The
-  // passed sshProvider only supplies the hooks sshProxy itself calls; stub the
-  // gcloud login so the test never shells out.
   const gcpProviderWith = (propagationTimeoutMs: number) =>
     ({
       cloudProviderLogin: vi.fn(async () => undefined),

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -10,8 +10,8 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import {
   CommandArgs,
+  newSshProvider,
   ScpCommandArgs,
-  SSH_PROVIDERS,
   SshAdditionalSetup,
   SshProxyCommandArgs,
 } from "../../commands/shared/ssh";
@@ -26,7 +26,6 @@ import {
   SshHostKeyInfo,
   SshProvider,
   SshRequest,
-  SupportedSshProvider,
 } from "../../types/ssh";
 import { delay, createCleanChildEnv, getOperatingSystem } from "../../util";
 import { AwsCredentials } from "../aws/types";
@@ -193,7 +192,6 @@ type SpawnSshNodeOptions = {
   endTime: number;
   abortController?: AbortController;
   stdio: [StdioNull, StdioNull, StdioPipe];
-  provider: SupportedSshProvider;
   request: SshRequest;
   debug?: boolean;
   isAccessPropagationPreTest?: boolean;
@@ -205,7 +203,7 @@ async function spawnSshNode(
   options: SpawnSshNodeOptions
 ): Promise<number | null> {
   return new Promise((resolve, reject) => {
-    const provider = SSH_PROVIDERS[options.provider];
+    const provider = newSshProvider(options.request);
 
     if (options.debug) {
       const gerund = options.isAccessPropagationPreTest
@@ -562,7 +560,6 @@ const preTestAccessPropagationIfNeeded = async <
       args,
       stdio: ["inherit", "inherit", "pipe"],
       debug: cmdArgs.debug,
-      provider: request.type,
       request,
       endTime: endTime,
       isAccessPropagationPreTest: true,
@@ -692,7 +689,6 @@ export const sshOrScp = async (args: {
         args: commandArgs,
         stdio: ["inherit", "inherit", "pipe"],
         debug,
-        provider: request.type,
         request,
         endTime: endTime,
         onHostKeyMismatch: request.type === "aws" ? refreshHostKeys : undefined,
@@ -773,7 +769,6 @@ export const sshProxy = async (args: {
       args: proxyArgs,
       stdio: ["inherit", "inherit", "pipe"],
       debug,
-      provider: request.type,
       request,
       endTime: endTime,
     });


### PR DESCRIPTION
**Problem**

SSH provider implementations are resolved from a static `SSH_PROVIDERS` record keyed by provider name, which hard-codes one implementation per cloud provider. Upcoming Azure SSH work adds a second connection method (SSH jump hosts alongside Azure Bastion tunnels), where the correct implementation depends on the contents of the access request — not just the provider name — and may need to carry per-request state (e.g. locally generated credentials). The record lookup can't express either.

**Change**

Replaces the `SSH_PROVIDERS` record with a `newSshProvider(request)` factory that selects the provider implementation from the request itself. It accepts both shapes the CLI holds a request in: the backend permission shape and the CLI request shape (the request JSON handed to `ssh-proxy`, which now parses the JSON before selecting a provider). All lookup sites (`pluginToCliRequest`, `setupSshConnection`, `ssh-resolve`, `ssh-proxy`, `spawnSshNode`) go through the factory, and `spawnSshNode` drops its now-redundant `provider` option in favor of the request it already receives.

No behavior change: every provider still resolves to the same single implementation it did before.

Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

- `yarn lint` (prettier, eslint, `tsc`) passes.
- Unit tests: all test files touching the changed code pass (`src/commands/shared/__tests__`, `src/plugins/ssh/__tests__` — 16 tests). The `setupSshConnection` test was reworked to mock the aws provider module, since it previously stubbed providers by swapping entries in the `SSH_PROVIDERS` record, which no longer exists.
- `src/commands/__tests__/ssh.test.ts` has 8 failures locally that reproduce identically on a clean `main` checkout (they require AWS utilities installed on the machine); unrelated to this change.

Risk is low: the factory is a pure mapping from provider name to the same implementations as before, and the switch is exhaustively checked by the compiler.

**Tracking (optional)**

[CUS-573
](https://linear.app/p0-security/issue/CUS-573/azure-ssh-customize-the-ssh-factory-method-to-key-off-requests)
**Implementation (optional)**

- Selection is keyed on the request so a follow-up can return a different (and per-request, stateful) implementation for Azure jump-host requests without changing any call sites.


**Follow-up Work (optional)**

- Azure SSH jump host support will add a second Azure provider implementation selected via this factory.
