### PR TITLE
add new jump-host types to the CLI

### DIFF
--- a/src/plugins/azure/ssh-bastion.ts
+++ b/src/plugins/azure/ssh-bastion.ts
@@ -225,16 +225,24 @@ export const azureSshProvider: SshProvider<
     };
   },
 
-  requestToSsh: (request) => ({
-    type: "azure",
-    id: "localhost",
-    ...request.cliLocalData,
-    instanceId: request.permission.resource.instanceId,
-    subscriptionId: request.permission.resource.subscriptionId,
-    instanceResourceGroup: request.permission.resource.resourceGroupId,
-    bastionId: request.permission.bastionHostId,
-    directoryId: request.generated.directoryId,
-  }),
+  requestToSsh: (request) => {
+    const { bastionHost, jumpHost } = request.permission;
+    if (!bastionHost) {
+      throw jumpHost
+        ? "This SSH session uses an Azure jump host, which is not yet supported by this CLI version. Please request a Bastion-based session or retry after upgrading."
+        : "Backend did not provide an Azure Bastion host for SSH session.";
+    }
+    return {
+      type: "azure",
+      id: "localhost",
+      ...request.cliLocalData,
+      instanceId: request.permission.resource.instanceId,
+      subscriptionId: request.permission.resource.subscriptionId,
+      instanceResourceGroup: request.permission.resource.resourceGroupId,
+      bastionId: bastionHost.id,
+      directoryId: request.generated.directoryId,
+    };
+  },
 
   unprovisionedAccessPatterns,
   provisionedAccessPatterns,

--- a/src/plugins/azure/tunnel.ts
+++ b/src/plugins/azure/tunnel.ts
@@ -42,8 +42,12 @@ export type BastionTunnelMeta = {
 export const azBastionTunnelCommand = (
   request: AzureSshRequest,
   port: string
-) =>
-  osSafeCommand("az", [
+) => {
+  if (!request.bastionId) {
+    throw "Cannot establish an Azure Bastion tunnel: no bastion host is associated with this request.";
+  }
+
+  return osSafeCommand("az", [
     "network",
     "bastion",
     "tunnel",
@@ -60,6 +64,7 @@ export const azBastionTunnelCommand = (
     // doesn't pass the --debug flag to the p0 ssh process.
     "--debug",
   ]);
+};
 
 const selectRandomPort = (): string => {
   // The IANA ephemeral port range is 49152 to 65535, inclusive. Pick a random value in that range.

--- a/src/plugins/azure/types.ts
+++ b/src/plugins/azure/types.ts
@@ -28,12 +28,25 @@ export type AzureSsh = CliPermissionSpec<
   AzureLocalData
 >;
 
+export type AzureBastionHost = {
+  id: string;
+};
+
+export type AzureJumpHost = {
+  id: string;
+  roleId: string;
+  ip: string;
+};
+
 export type AzureSshPermission = CommonSshPermissionSpec & {
   provider: "azure";
   destination: string;
   parent: string | undefined;
   group: string | undefined;
-  bastionHostId: string;
+  // Exactly one of `bastionHost` / `jumpHost` is set, depending on how the
+  // subscription's bastion-host installation is configured
+  bastionHost?: AzureBastionHost;
+  jumpHost?: AzureJumpHost;
   principal: string;
   resource: {
     instanceId: string;
@@ -42,7 +55,12 @@ export type AzureSshPermission = CommonSshPermissionSpec & {
     resourceGroupId: string;
     subscriptionId: string;
     region: string;
-    networkInterfaceIds: string[];
+    networkInterface: {
+      id: string;
+      subnetId: string;
+      // The target's private IP, used to hop to it through a jump host
+      privateIp?: string;
+    };
   };
 };
 


### PR DESCRIPTION
**Problem**

The P0 backend's Azure SSH access schema is transitioning from a flat, legacy
`bastionHostId` parameter to structured host objects: sessions now carry exactly
one of `bastionHost` or `jumpHost`, depending on how the subscription's
bastion-host installation is configured. The CLI still read the legacy field and
had no types for jump-host data.

**Change**

- Removes the CLI's dependency on the legacy `bastionHostId` permission field;
  the bastion provider now reads `bastionHost.id` and throws a clear error if a
  session has no bastion host (i.e. jump-host sessions, until the CLI supports
  connecting through them).
- Adds `AzureBastionHost` and `AzureJumpHost` types (`id`, `roleId`, `ip`) to the
  Azure SSH permission spec, and replaces `resource.networkInterfaceIds` with the
  new `resource.networkInterface` shape (`id`, `subnetId`, `privateIp`) to match
  the updated backend schema.

Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

`tsc --noEmit` passes. `vitest run` shows failures only in pre-existing
`ssh.test.ts` / `ls.test.ts` command tests, verified identical on `origin/main`.
Types-only change plus one field rename in `requestToSsh`; Azure sessions staged
before the backend wrote `bastionHost` would fail with the new error message and
need to be re-requested.

**Tracking (optional)**

[CUS-642
](https://linear.app/p0-security/issue/CUS-642/add-new-jump-host-types-to-the-cli)
**Follow-up Work (optional)**

Jump-host sessions are not yet connectable from the CLI; a jump-host SSH
provider consuming `jumpHost` / `networkInterface.privateIp` will follow.
