### PR TITLE
create a shared file for common azure ssh functions

### DIFF
--- a/src/commands/shared/__tests__/ssh-resolve.test.ts
+++ b/src/commands/shared/__tests__/ssh-resolve.test.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { authenticate } from "../../../drivers/auth";
 import { awsSshProvider } from "../../../plugins/aws/ssh";
+import { TARGET_CONNECT_TIMEOUT_SECONDS } from "../../../plugins/azure/ssh-jump-host";
 import { Authn } from "../../../types/identity";
 import { sshResolveAction } from "../../ssh-resolve";
 import { SshResolveCommandArgs } from "../ssh";
@@ -21,6 +22,19 @@ import yargs from "yargs";
 vi.mock("../../../drivers/auth", () => ({
   authenticate: vi.fn(),
 }));
+// The azure jump-host provider's generateKeys shells out to the Azure CLI;
+// stub the login boundary and pin the temp key directory.
+vi.mock("../../../plugins/azure/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../plugins/azure/auth")>()),
+  azSetSubscription: vi.fn(async () => "testuser"),
+}));
+vi.mock("../../../plugins/ssh/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../plugins/ssh/shared")>()),
+  createTempDirectoryForKeys: vi.fn(async () => ({
+    path: "/tmp/azure",
+    cleanup: async () => {},
+  })),
+}));
 vi.mock("../../../drivers/stdio", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../drivers/stdio")>()),
   print2: vi.fn(),
@@ -29,6 +43,8 @@ vi.mock("../../../util", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../util")>()),
   getAppPath: vi.fn().mockReturnValue("/usr/local/bin/p0"),
   conditionalAbortBeforeThrow: vi.fn().mockReturnValue(vi.fn()),
+  // Stubs the `az ssh cert` subprocess run by the azure jump-host generateKeys
+  exec: vi.fn(async () => ({ stdout: "", stderr: "" })),
 }));
 vi.mock("../ssh", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../ssh")>()),
@@ -150,6 +166,38 @@ describe("sshResolveAction", () => {
       }
     }
   );
+
+  it("emits ConnectTimeout and the minted keys for an azure jump-host request, via the real provider", async () => {
+    mockPrepareRequest.mockResolvedValue({
+      ...basePrepareResult,
+      provisionedRequest: {
+        permission: {
+          provider: "azure",
+          jumpHost: {
+            id: "jump-1",
+            roleId: "jrole-1",
+            publicIp: "4.154.21.27",
+          },
+          resource: { subscriptionId: "sub-1" },
+        },
+      },
+    });
+
+    await sshResolveAction({ ...baseArgs });
+
+    const configWriteCall = (fs.writeFileSync as Mock).mock.calls.find(
+      ([path]) => typeof path === "string" && path.endsWith(".config")
+    );
+    expect(configWriteCall).toBeDefined();
+    const configContent = configWriteCall![1] as string;
+    expect(configContent).toContain(
+      `ConnectTimeout ${TARGET_CONNECT_TIMEOUT_SECONDS}`
+    );
+    expect(configContent).toContain("IdentityFile /tmp/azure/id_rsa");
+    expect(configContent).toContain(
+      "CertificateFile /tmp/azure/p0cli-azure-ad-ssh-cert.pub"
+    );
+  });
 
   it("omits ConnectTimeout when the provider does not set sshConnectTimeoutSeconds", async () => {
     await sshResolveAction({ ...baseArgs });

--- a/src/commands/shared/__tests__/ssh.test.ts
+++ b/src/commands/shared/__tests__/ssh.test.ts
@@ -1,0 +1,219 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { fetchIntegrationConfig } from "../../../drivers/api";
+import { print2 } from "../../../drivers/stdio";
+import { awsSshProvider } from "../../../plugins/aws/ssh";
+import { azureBastionSshProvider } from "../../../plugins/azure/ssh-bastion";
+import { TARGET_CONNECT_TIMEOUT_SECONDS } from "../../../plugins/azure/ssh-jump-host";
+import { gcpSshProvider } from "../../../plugins/google/ssh";
+import { selfHostedSshProvider } from "../../../plugins/self-hosted/ssh";
+import { Authn } from "../../../types/identity";
+import {
+  getDefaultSudo,
+  newSshProvider,
+  newSshRequestErrorHandler,
+  validateSshInstall,
+} from "../ssh";
+import { sys } from "typescript";
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+
+vi.mock("../../../drivers/api");
+vi.mock("../../../drivers/stdio", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../drivers/stdio")>()),
+  print2: vi.fn(),
+}));
+vi.mock("typescript", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("typescript")>()),
+  sys: { exit: vi.fn() },
+}));
+
+const mockFetchIntegrationConfig = fetchIntegrationConfig as Mock;
+const mockPrint2 = print2 as Mock;
+const mockExit = sys.exit as Mock;
+
+const mockAuthn = {} as Authn;
+
+const permissionShape = (permission: object) =>
+  ({ permission }) as Parameters<typeof newSshProvider>[0];
+
+const cliShape = (request: object) =>
+  request as Parameters<typeof newSshProvider>[0];
+
+const JUMP_HOST = { id: "jump-1", roleId: "jrole-1", publicIp: "4.154.21.27" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("newSshProvider", () => {
+  describe("from the backend permission shape", () => {
+    it.each([
+      ["aws", awsSshProvider],
+      ["gcloud", gcpSshProvider],
+      ["self-hosted", selfHostedSshProvider],
+    ] as const)("selects the %s provider", (provider, expected) => {
+      expect(newSshProvider(permissionShape({ provider }))).toBe(expected);
+    });
+
+    it("selects the azure Bastion provider when the permission has no jump host", () => {
+      expect(newSshProvider(permissionShape({ provider: "azure" }))).toBe(
+        azureBastionSshProvider
+      );
+    });
+
+    it("selects the azure jump-host provider when the permission has a jump host", () => {
+      const provider = newSshProvider(
+        permissionShape({ provider: "azure", jumpHost: JUMP_HOST })
+      );
+
+      expect(provider).not.toBe(azureBastionSshProvider);
+      expect(provider.sshConnectTimeoutSeconds).toBe(
+        TARGET_CONNECT_TIMEOUT_SECONDS
+      );
+    });
+  });
+
+  describe("from the CLI request shape", () => {
+    it.each([
+      ["aws", awsSshProvider],
+      ["gcloud", gcpSshProvider],
+      ["self-hosted", selfHostedSshProvider],
+    ] as const)("selects the %s provider", (type, expected) => {
+      expect(newSshProvider(cliShape({ type }))).toBe(expected);
+    });
+
+    it("selects the azure Bastion provider when the request has no jump host", () => {
+      expect(
+        newSshProvider(cliShape({ type: "azure", bastionId: "bastion-1" }))
+      ).toBe(azureBastionSshProvider);
+    });
+
+    it("selects the azure jump-host provider when the request has a jump host", () => {
+      const provider = newSshProvider(
+        cliShape({ type: "azure", jumpHost: JUMP_HOST })
+      );
+
+      expect(provider).not.toBe(azureBastionSshProvider);
+      expect(provider.sshConnectTimeoutSeconds).toBe(
+        TARGET_CONNECT_TIMEOUT_SECONDS
+      );
+    });
+  });
+
+  it("returns the same jump-host provider singleton on every call, like every other provider", () => {
+    const request = permissionShape({ provider: "azure", jumpHost: JUMP_HOST });
+
+    expect(newSshProvider(request)).toBe(newSshProvider(request));
+  });
+
+  it("throws on an unknown provider", () => {
+    expect(() => newSshProvider(cliShape({ type: "nonsense" }))).toThrow(
+      /unexpected/i
+    );
+  });
+});
+
+describe("validateSshInstall", () => {
+  const args = { debug: false } as Parameters<typeof validateSshInstall>[1];
+
+  it("resolves when an installed item matches a supported provider", async () => {
+    mockFetchIntegrationConfig.mockResolvedValue({
+      config: { "iam-write": { "azure:sub-1": { state: "installed" } } },
+    });
+
+    await expect(validateSshInstall(mockAuthn, args)).resolves.toBeUndefined();
+  });
+
+  it("throws when no item is installed", async () => {
+    mockFetchIntegrationConfig.mockResolvedValue({
+      config: { "iam-write": { "aws:123": { state: "stale" } } },
+    });
+
+    await expect(validateSshInstall(mockAuthn, args)).rejects.toMatch(
+      /not configured for SSH access/
+    );
+  });
+
+  it("throws when the config document is missing entirely", async () => {
+    mockFetchIntegrationConfig.mockResolvedValue(undefined);
+
+    await expect(validateSshInstall(mockAuthn, args)).rejects.toMatch(
+      /not configured for SSH access/
+    );
+  });
+
+  it("only accepts items for the provider requested via --provider", async () => {
+    mockFetchIntegrationConfig.mockResolvedValue({
+      config: { "iam-write": { "aws:123": { state: "installed" } } },
+    });
+
+    await expect(
+      validateSshInstall(mockAuthn, {
+        ...args,
+        provider: "azure",
+      } as typeof args)
+    ).rejects.toMatch(/not configured for SSH access/);
+  });
+});
+
+describe("getDefaultSudo", () => {
+  const original = process.env.P0_SSH_SUDO;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.P0_SSH_SUDO;
+    else process.env.P0_SSH_SUDO = original;
+  });
+
+  it.each([
+    [undefined, false],
+    ["1", true],
+    ["true", true],
+    ["0", false],
+    ["false", false],
+    ["FALSE", false],
+  ])("returns %s → %s", (value, expected) => {
+    if (value === undefined) delete process.env.P0_SSH_SUDO;
+    else process.env.P0_SSH_SUDO = value;
+
+    expect(getDefaultSudo()).toBe(expected);
+  });
+});
+
+describe("newSshRequestErrorHandler", () => {
+  it("prints a username hint when no instance matches and the destination contains '@'", () => {
+    newSshRequestErrorHandler("user@my-vm")(
+      "Could not find any instances matching user@my-vm"
+    );
+
+    expect(mockPrint2).toHaveBeenCalledWith(
+      "Could not find any instances matching user@my-vm"
+    );
+    expect(mockPrint2).toHaveBeenCalledWith(
+      expect.stringMatching(/username should be omitted/i)
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("prints the error without a hint for other string errors", () => {
+    newSshRequestErrorHandler("my-vm")("Some other failure");
+
+    expect(mockPrint2).toHaveBeenCalledTimes(1);
+    expect(mockPrint2).toHaveBeenCalledWith("Some other failure");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits without printing for non-string errors", () => {
+    newSshRequestErrorHandler("my-vm")(new Error("boom"));
+
+    expect(mockPrint2).not.toHaveBeenCalled();
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -15,7 +15,8 @@ import { getContactMessage } from "../../drivers/config";
 import { print2 } from "../../drivers/stdio";
 import { traceSpan } from "../../opentelemetry/otel-helpers";
 import { awsSshProvider } from "../../plugins/aws/ssh";
-import { azureSshProvider } from "../../plugins/azure/ssh-bastion";
+import { azureBastionSshProvider } from "../../plugins/azure/ssh-bastion";
+import { azureJumpHostSshProvider } from "../../plugins/azure/ssh-jump-host";
 import { gcpSshProvider } from "../../plugins/google/ssh";
 import { selfHostedSshProvider } from "../../plugins/self-hosted/ssh";
 import { isSudoCommand } from "../../plugins/ssh/shared";
@@ -78,12 +79,21 @@ export type SshRequestOptions = {
   quiet?: boolean;
 };
 
-export type SshAdditionalSetup = {
-  /** A list of SSH configuration options, as would be used after '-o' in an SSH command */
-  sshOptions: string[];
-
+/** Identity file/certificate paths minted by setup/setupProxy, for providers
+ * whose proxy hop is itself an authenticated command (e.g. Azure's jump-host
+ * ProxyCommand, which is a full `ssh` invocation) and so needs them passed
+ * into proxyCommand explicitly rather than held as provider state. */
+export type SshProxyCredentials = {
   /** The path to the private key file to use for the SSH connection, instead of the default P0 CLI managed key */
   identityFile?: string;
+
+  /** The path to the certificate file to use for the SSH connection */
+  certificatePath?: string;
+};
+
+export type SshAdditionalSetup = SshProxyCredentials & {
+  /** A list of SSH configuration options, as would be used after '-o' in an SSH command */
+  sshOptions: string[];
 
   /** The port to connect to, overriding the default */
   port?: string;
@@ -105,8 +115,16 @@ export const newSshProvider = (
       return gcpSshProvider;
     case "self-hosted":
       return selfHostedSshProvider;
-    case "azure":
-      return azureSshProvider;
+    case "azure": {
+      // Narrowing `provider` doesn't narrow `request`, so re-check the shape's
+      // own discriminant before reading its Azure-only fields.
+      const jumpHost =
+        "permission" in request
+          ? request.permission.provider === "azure" &&
+            request.permission.jumpHost
+          : request.type === "azure" && request.jumpHost;
+      return jumpHost ? azureJumpHostSshProvider : azureBastionSshProvider;
+    }
     default:
       throw assertNever(provider);
   }

--- a/src/commands/shared/ssh.ts
+++ b/src/commands/shared/ssh.ts
@@ -18,6 +18,7 @@ import { awsSshProvider } from "../../plugins/aws/ssh";
 import { azureSshProvider } from "../../plugins/azure/ssh-bastion";
 import { gcpSshProvider } from "../../plugins/google/ssh";
 import { selfHostedSshProvider } from "../../plugins/self-hosted/ssh";
+import { isSudoCommand } from "../../plugins/ssh/shared";
 import { SshConfig } from "../../plugins/ssh/types";
 import { Authn } from "../../types/identity";
 import { PermissionRequest } from "../../types/request";
@@ -144,9 +145,6 @@ export const getDefaultSudo = (): boolean => {
   const sudo = process.env.P0_SSH_SUDO;
   return !!sudo && sudo !== "0" && sudo.toLowerCase?.() !== "false";
 };
-
-export const isSudoCommand = (args: { sudo?: boolean; command?: string }) =>
-  args.sudo || args.command === "sudo";
 
 export const provisionRequest = async (
   authn: Authn,

--- a/src/plugins/azure/__tests__/ssh-bastion.test.ts
+++ b/src/plugins/azure/__tests__/ssh-bastion.test.ts
@@ -1,0 +1,318 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { CliPermissionSpec } from "../../../types/ssh";
+import { exec } from "../../../util";
+import { createTempDirectoryForKeys } from "../../ssh/shared";
+import { azSetSubscription } from "../auth";
+import { azureBastionSshProvider } from "../ssh-bastion";
+import { AD_CERT_FILENAME, AD_SSH_KEY_PRIVATE } from "../ssh-shared";
+import { trySpawnBastionTunnel } from "../tunnel";
+import {
+  AzureLocalData,
+  AzureSshPermission,
+  AzureSshPermissionSpec,
+} from "../types";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Key minting shells out to the Azure CLI; stub the subprocess and login
+// boundaries (same style as ssh-shared.test.ts) and pin the temp key directory.
+vi.mock("../../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../util")>()),
+  exec: vi.fn(),
+}));
+
+vi.mock("../auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auth")>()),
+  azSetSubscription: vi.fn(),
+}));
+
+vi.mock("../../ssh/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../ssh/shared")>()),
+  createTempDirectoryForKeys: vi.fn(),
+}));
+
+vi.mock("../tunnel", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../tunnel")>()),
+  trySpawnBastionTunnel: vi.fn(),
+}));
+
+vi.mock("../../../drivers/stdio", () => ({
+  print2: vi.fn(),
+}));
+
+type AzureCliRequest = CliPermissionSpec<
+  AzureSshPermissionSpec,
+  AzureLocalData
+>;
+
+const LINUX_USER = "miguel.campos@permz.us";
+const KEY_PATH = "/tmp";
+
+const PERMISSION_BASE: AzureSshPermission = {
+  provider: "azure",
+  publicKey: "pub-key",
+  destination: "my-vm",
+  parent: undefined,
+  group: undefined,
+  principal: LINUX_USER,
+  resource: {
+    instanceName: "my-vm",
+    instanceId: "/subscriptions/sub-1/.../my-vm",
+    subscriptionId: "sub-1",
+    subscriptionName: "sub-name",
+    resourceGroupId: "rg-1",
+    region: "eastus",
+    networkInterface: {
+      id: "nic-1",
+      subnetId: "subnet-1",
+      privateIp: "10.1.0.4",
+    },
+  },
+};
+
+const bastionPermission = (): AzureSshPermission => ({
+  ...PERMISSION_BASE,
+  bastionHost: { id: "bastion-1" },
+});
+
+const cliRequest = (permission: AzureSshPermission): AzureCliRequest => ({
+  type: "ssh",
+  permission,
+  generated: { linuxUserName: LINUX_USER, directoryId: "dir-1" },
+  cliLocalData: { linuxUserName: LINUX_USER },
+});
+
+const bastionRequest = () =>
+  azureBastionSshProvider.requestToSsh(cliRequest(bastionPermission()));
+
+const tunnelMeta = (killTunnel: () => Promise<void> = vi.fn()) => ({
+  killTunnel,
+  tunnelLocalPort: "50123",
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(exec).mockResolvedValue({ stdout: "", stderr: "" } as any);
+  vi.mocked(azSetSubscription).mockResolvedValue(LINUX_USER);
+  vi.mocked(createTempDirectoryForKeys).mockResolvedValue({
+    path: KEY_PATH,
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  });
+  vi.mocked(trySpawnBastionTunnel).mockResolvedValue(tunnelMeta());
+});
+
+describe("requestToSsh", () => {
+  it("maps a bastion host request to localhost", () => {
+    const request = bastionRequest();
+
+    expect(request.id).toBe("localhost");
+    expect(request.bastionId).toBe("bastion-1");
+    expect(request.linuxUserName).toBe(LINUX_USER);
+  });
+
+  it("throws when no bastion host is present", () => {
+    expect(() =>
+      azureBastionSshProvider.requestToSsh(cliRequest(PERMISSION_BASE))
+    ).toThrow(/not reachable/i);
+  });
+});
+
+describe("proxyCommand", () => {
+  it("connects to the local Bastion tunnel on the given port", () => {
+    const command = azureBastionSshProvider.proxyCommand(
+      bastionRequest(),
+      "50022"
+    );
+
+    // nc on Unix/Mac, ncat on Windows; either way connects to the local tunnel port.
+    expect(command[0]).toMatch(/^nc(at)?$/);
+    expect(command.slice(1)).toEqual(["localhost", "50022"]);
+  });
+
+  it("falls back to port 22 when no port is given", () => {
+    const command = azureBastionSshProvider.proxyCommand(bastionRequest());
+
+    expect(command.slice(1)).toEqual(["localhost", "22"]);
+  });
+});
+
+describe("reproCommands", () => {
+  it("appends the az network bastion tunnel command for the setup-selected port", () => {
+    const request = bastionRequest();
+
+    const commands = azureBastionSshProvider.reproCommands(request, {
+      sshOptions: [],
+      identityFile: path.join(KEY_PATH, AD_SSH_KEY_PRIVATE),
+      port: "50123",
+      teardown: async () => {},
+    });
+
+    expect(commands?.join("\n")).toContain(
+      `az network bastion tunnel --ids bastion-1 --target-resource-id ${request.instanceId} --resource-port 22 --port 50123 --debug`
+    );
+  });
+
+  it("falls back to the default Bastion port when no additional data is present", () => {
+    const request = bastionRequest();
+
+    const commands = azureBastionSshProvider.reproCommands(request);
+
+    expect(commands?.join("\n")).toContain("--port 50022");
+  });
+});
+
+describe("generateKeys", () => {
+  it("sets the subscription and mints a key + cert in a temp directory", async () => {
+    const request = bastionRequest();
+
+    await expect(
+      azureBastionSshProvider.generateKeys!({} as any, request, {
+        requestId: "request-1",
+        debug: false,
+      })
+    ).resolves.toEqual({
+      privateKeyPath: path.join(KEY_PATH, AD_SSH_KEY_PRIVATE),
+      certificatePath: path.join(KEY_PATH, AD_CERT_FILENAME),
+    });
+
+    expect(azSetSubscription).toHaveBeenCalledWith(
+      request,
+      expect.objectContaining({ debug: false })
+    );
+  });
+});
+
+describe("setupProxy", () => {
+  it("spawns the Bastion tunnel and returns its teardown and local port", async () => {
+    const killTunnel = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(trySpawnBastionTunnel).mockResolvedValue(tunnelMeta(killTunnel));
+
+    const request = bastionRequest();
+    const result = await azureBastionSshProvider.setupProxy!(request, {
+      debug: false,
+      abortController: new AbortController(),
+    });
+
+    expect(result.port).toBe("50123");
+    await result.teardown();
+    expect(killTunnel).toHaveBeenCalled();
+  });
+});
+
+describe("setup", () => {
+  const setupOptions = () => ({
+    requestId: "request-1",
+    abortController: new AbortController(),
+    debug: false,
+  });
+
+  it("mints keys, spawns the tunnel, and returns the resulting connection options", async () => {
+    const request = bastionRequest();
+
+    const result = await azureBastionSshProvider.setup!(
+      {} as any,
+      request,
+      setupOptions()
+    );
+
+    expect(result.identityFile).toBe(path.join(KEY_PATH, AD_SSH_KEY_PRIVATE));
+    expect(result.port).toBe("50123");
+    expect(result.sshOptions).toEqual([
+      `CertificateFile=${path.join(KEY_PATH, AD_CERT_FILENAME)}`,
+      "StrictHostKeyChecking=no",
+      "UserKnownHostsFile=/dev/null",
+    ]);
+  });
+
+  it("tears down both the tunnel and the temp key directory", async () => {
+    const killTunnel = vi.fn().mockResolvedValue(undefined);
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(trySpawnBastionTunnel).mockResolvedValue(tunnelMeta(killTunnel));
+    vi.mocked(createTempDirectoryForKeys).mockResolvedValue({
+      path: KEY_PATH,
+      cleanup,
+    });
+
+    const result = await azureBastionSshProvider.setup!(
+      {} as any,
+      bastionRequest(),
+      setupOptions()
+    );
+    await result.teardown();
+
+    expect(killTunnel).toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalled();
+  });
+
+  it("throws when the Azure CLI login resolves to an unexpected linux user", async () => {
+    vi.mocked(azSetSubscription).mockResolvedValue("someone-else@example.com");
+
+    await expect(
+      azureBastionSshProvider.setup!(
+        {} as any,
+        bastionRequest(),
+        setupOptions()
+      )
+    ).rejects.toMatch(/different user name/i);
+  });
+
+  it("cleans up the temp key directory when cert generation fails", async () => {
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createTempDirectoryForKeys).mockResolvedValue({
+      path: KEY_PATH,
+      cleanup,
+    });
+    vi.mocked(exec).mockRejectedValue(
+      Object.assign(new Error("boom"), { stdout: "", stderr: "" })
+    );
+
+    await expect(
+      azureBastionSshProvider.setup!(
+        {} as any,
+        bastionRequest(),
+        setupOptions()
+      )
+    ).rejects.toThrow();
+
+    expect(cleanup).toHaveBeenCalled();
+    expect(trySpawnBastionTunnel).not.toHaveBeenCalled();
+  });
+});
+
+describe("unprovisionedAccessPatterns / provisionedAccessPatterns", () => {
+  const matches = (patterns: readonly { pattern: RegExp }[], stderr: string) =>
+    patterns.some((p) => p.pattern.test(stderr));
+
+  it("retries only on the sudo propagation message", () => {
+    expect(
+      matches(
+        azureBastionSshProvider.unprovisionedAccessPatterns,
+        "Sorry, user miguel may not run sudo on my-vm."
+      )
+    ).toBe(true);
+    expect(
+      matches(
+        azureBastionSshProvider.unprovisionedAccessPatterns,
+        "Permission denied (publickey)."
+      )
+    ).toBe(false);
+  });
+
+  it("treats a sudo password prompt as evidence that sudo access has propagated", () => {
+    expect(
+      matches(
+        azureBastionSshProvider.provisionedAccessPatterns ?? [],
+        "sudo: a password is required"
+      )
+    ).toBe(true);
+  });
+});

--- a/src/plugins/azure/__tests__/ssh-jump-host.test.ts
+++ b/src/plugins/azure/__tests__/ssh-jump-host.test.ts
@@ -1,0 +1,370 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { CliPermissionSpec } from "../../../types/ssh";
+import { exec } from "../../../util";
+import { createTempDirectoryForKeys } from "../../ssh/shared";
+import { azSetSubscription } from "../auth";
+import {
+  JUMP_HOST_CONNECT_TIMEOUT_SECONDS,
+  TARGET_CONNECT_TIMEOUT_SECONDS,
+  azureJumpHostSshProvider,
+} from "../ssh-jump-host";
+import { AD_CERT_FILENAME, AD_SSH_KEY_PRIVATE } from "../ssh-shared";
+import {
+  AzureLocalData,
+  AzureSshPermission,
+  AzureSshPermissionSpec,
+} from "../types";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Key minting shells out to the Azure CLI; stub the subprocess and login
+// boundaries (same style as ssh-shared.test.ts) and pin the temp key directory.
+vi.mock("../../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../util")>()),
+  exec: vi.fn(),
+}));
+
+vi.mock("../auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auth")>()),
+  azSetSubscription: vi.fn(),
+}));
+
+vi.mock("../../ssh/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../ssh/shared")>()),
+  createTempDirectoryForKeys: vi.fn(),
+}));
+
+vi.mock("../../../drivers/stdio", () => ({
+  print2: vi.fn(),
+}));
+
+type AzureCliRequest = CliPermissionSpec<
+  AzureSshPermissionSpec,
+  AzureLocalData
+>;
+
+const LINUX_USER = "miguel.campos@permz.us";
+const PRIVATE_IP = "10.1.0.4";
+const JUMP_IP = "4.154.21.27";
+const KEY_PATH = "/tmp";
+
+const PERMISSION_BASE: AzureSshPermission = {
+  provider: "azure",
+  publicKey: "pub-key",
+  destination: "my-vm",
+  parent: undefined,
+  group: undefined,
+  principal: LINUX_USER,
+  resource: {
+    instanceName: "my-vm",
+    instanceId: "/subscriptions/sub-1/.../my-vm",
+    subscriptionId: "sub-1",
+    subscriptionName: "sub-name",
+    resourceGroupId: "rg-1",
+    region: "eastus",
+    networkInterface: {
+      id: "nic-1",
+      subnetId: "subnet-1",
+      privateIp: PRIVATE_IP,
+    },
+  },
+};
+
+const cliRequest = (permission: AzureSshPermission): AzureCliRequest => ({
+  type: "ssh",
+  permission,
+  generated: { linuxUserName: LINUX_USER, directoryId: "dir-1" },
+  cliLocalData: { linuxUserName: LINUX_USER },
+});
+
+const jumpHostPermission = (
+  overrides: Partial<AzureSshPermission> = {}
+): AzureSshPermission => ({
+  ...PERMISSION_BASE,
+  jumpHost: { id: "jump-1", roleId: "jrole-1", publicIp: JUMP_IP },
+  ...overrides,
+});
+
+const jumpHostRequest = (overrides: Partial<AzureSshPermission> = {}) =>
+  azureJumpHostSshProvider.requestToSsh(
+    cliRequest(jumpHostPermission(overrides))
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(exec).mockResolvedValue({ stdout: "", stderr: "" } as any);
+  vi.mocked(azSetSubscription).mockResolvedValue(LINUX_USER);
+  vi.mocked(createTempDirectoryForKeys).mockResolvedValue({
+    path: KEY_PATH,
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  });
+});
+
+describe("sshConnectTimeoutSeconds", () => {
+  it("exceeds the inner jump-host hop's own ConnectTimeout, leaving it headroom for its own banner exchange", () => {
+    expect(azureJumpHostSshProvider.sshConnectTimeoutSeconds).toBe(
+      TARGET_CONNECT_TIMEOUT_SECONDS
+    );
+    expect(TARGET_CONNECT_TIMEOUT_SECONDS).toBeGreaterThan(
+      JUMP_HOST_CONNECT_TIMEOUT_SECONDS
+    );
+  });
+});
+
+describe("requestToSsh", () => {
+  it("maps a jump host request to the target's private IP", () => {
+    const request = jumpHostRequest();
+
+    expect(request.id).toBe(PRIVATE_IP);
+    expect(request.jumpHost).toEqual({
+      id: "jump-1",
+      roleId: "jrole-1",
+      publicIp: JUMP_IP,
+    });
+    expect(request.bastionId).toBeUndefined();
+    expect(request.privateIp).toBe(PRIVATE_IP);
+    expect(request.linuxUserName).toBe(LINUX_USER);
+  });
+
+  it("throws when a jump host target has no private IP", () => {
+    expect(() =>
+      jumpHostRequest({
+        resource: {
+          ...PERMISSION_BASE.resource,
+          networkInterface: {
+            ...PERMISSION_BASE.resource.networkInterface,
+            privateIp: undefined,
+          },
+        },
+      })
+    ).toThrow(/private IP/i);
+  });
+
+  it("throws when the jump host has no IP address", () => {
+    expect(() =>
+      jumpHostRequest({
+        jumpHost: { id: "jump-1", roleId: "jrole-1", publicIp: "" },
+      })
+    ).toThrow(/jump host .* no IP/i);
+  });
+});
+
+describe("setup", () => {
+  const setupOptions = () => ({
+    requestId: "request-1",
+    abortController: new AbortController(),
+    debug: false,
+  });
+
+  it("mints keys and bounds the outer hop's ConnectTimeout with headroom over the inner hop's", async () => {
+    const result = await azureJumpHostSshProvider.setup!(
+      {} as any,
+      jumpHostRequest(),
+      setupOptions()
+    );
+
+    expect(result.identityFile).toBe(path.join(KEY_PATH, AD_SSH_KEY_PRIVATE));
+    expect(result.certificatePath).toBe(path.join(KEY_PATH, AD_CERT_FILENAME));
+    expect(result.sshOptions).toEqual([
+      `CertificateFile=${path.join(KEY_PATH, AD_CERT_FILENAME)}`,
+      "StrictHostKeyChecking=no",
+      "UserKnownHostsFile=/dev/null",
+      `ConnectTimeout=${TARGET_CONNECT_TIMEOUT_SECONDS}`,
+    ]);
+  });
+
+  it("tears down the temp key directory", async () => {
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createTempDirectoryForKeys).mockResolvedValue({
+      path: KEY_PATH,
+      cleanup,
+    });
+
+    const result = await azureJumpHostSshProvider.setup!(
+      {} as any,
+      jumpHostRequest(),
+      setupOptions()
+    );
+    await result.teardown();
+
+    expect(cleanup).toHaveBeenCalled();
+  });
+
+  it("throws when the Azure CLI login resolves to an unexpected linux user", async () => {
+    vi.mocked(azSetSubscription).mockResolvedValue("someone-else@example.com");
+
+    await expect(
+      azureJumpHostSshProvider.setup!(
+        {} as any,
+        jumpHostRequest(),
+        setupOptions()
+      )
+    ).rejects.toMatch(/different user name/i);
+  });
+
+  it("cleans up the temp key directory when cert generation fails", async () => {
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createTempDirectoryForKeys).mockResolvedValue({
+      path: KEY_PATH,
+      cleanup,
+    });
+    vi.mocked(exec).mockRejectedValue(
+      Object.assign(new Error("boom"), { stdout: "", stderr: "" })
+    );
+
+    await expect(
+      azureJumpHostSshProvider.setup!(
+        {} as any,
+        jumpHostRequest(),
+        setupOptions()
+      )
+    ).rejects.toThrow();
+
+    expect(cleanup).toHaveBeenCalled();
+  });
+});
+
+describe("setupProxy", () => {
+  it("mints a fresh cert for the jump-host hop and pins the port to 22", async () => {
+    const result = await azureJumpHostSshProvider.setupProxy!(
+      jumpHostRequest(),
+      { debug: false, abortController: new AbortController() }
+    );
+
+    expect(result.port).toBe("22");
+    expect(result.identityFile).toBe(path.join(KEY_PATH, AD_SSH_KEY_PRIVATE));
+    expect(result.certificatePath).toBe(path.join(KEY_PATH, AD_CERT_FILENAME));
+    await expect(result.teardown()).resolves.toBeUndefined();
+  });
+
+  it("mints keys independently from setup (ssh-proxy runs in a separate process)", async () => {
+    await azureJumpHostSshProvider.setupProxy!(jumpHostRequest(), {
+      debug: false,
+      abortController: new AbortController(),
+    });
+
+    expect(azSetSubscription).toHaveBeenCalledTimes(1);
+    expect(createTempDirectoryForKeys).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("proxyCommand", () => {
+  it("builds an SSH `-W` proxy through the jump host using the setup-minted credentials", () => {
+    const request = jumpHostRequest();
+
+    const command = azureJumpHostSshProvider.proxyCommand(request, undefined, {
+      identityFile: `/tmp/${AD_SSH_KEY_PRIVATE}`,
+      certificatePath: `/tmp/${AD_CERT_FILENAME}`,
+    });
+
+    expect(command).toEqual([
+      "ssh",
+      "-F",
+      "/dev/null",
+      "-i",
+      `/tmp/${AD_SSH_KEY_PRIVATE}`,
+      "-o",
+      `CertificateFile=/tmp/${AD_CERT_FILENAME}`,
+      "-o",
+      "StrictHostKeyChecking=no",
+      "-o",
+      "UserKnownHostsFile=/dev/null",
+      "-o",
+      `ConnectTimeout=${JUMP_HOST_CONNECT_TIMEOUT_SECONDS}`,
+      "-o",
+      "BatchMode=yes",
+      "-W",
+      `${PRIVATE_IP}:22`,
+      `${LINUX_USER}@${JUMP_IP}`,
+    ]);
+  });
+
+  it("throws if no credentials were minted for this jump-host connection", () => {
+    expect(() =>
+      azureJumpHostSshProvider.proxyCommand(jumpHostRequest())
+    ).toThrow(/keys were not generated/i);
+  });
+});
+
+describe("connectionErrorMessage", () => {
+  const request = jumpHostRequest();
+
+  it("classifies a connect timeout to the jump host as the jump host being unreachable", () => {
+    const message = azureJumpHostSshProvider.connectionErrorMessage!(
+      `debug1: Connecting to ${JUMP_IP} [${JUMP_IP}] port 22.\n` +
+        `ssh: connect to host ${JUMP_IP} port 22: Connection timed out`,
+      request
+    );
+
+    expect(message).toMatch(/jump host/i);
+    expect(message).toContain(JUMP_IP);
+  });
+
+  it("does not attribute a connect failure for some other host to the jump host", () => {
+    const message = azureJumpHostSshProvider.connectionErrorMessage!(
+      "ssh: connect to host 192.0.2.99 port 22: Connection refused",
+      request
+    );
+
+    expect(message).toBeUndefined();
+  });
+
+  it("classifies a failed `-W` forward as the target VM being unreachable", () => {
+    const message = azureJumpHostSshProvider.connectionErrorMessage!(
+      "channel 0: open failed: connect failed: Connection timed out",
+      request
+    );
+
+    expect(message).toMatch(/target VM/i);
+    expect(message).toContain(PRIVATE_IP);
+  });
+
+  it("falls through to the raw error for unrelated stderr", () => {
+    expect(
+      azureJumpHostSshProvider.connectionErrorMessage!(
+        "some unrelated ssh noise",
+        request
+      )
+    ).toBeUndefined();
+  });
+});
+
+describe("unprovisionedAccessPatterns", () => {
+  const matches = (stderr: string) =>
+    azureJumpHostSshProvider.unprovisionedAccessPatterns.some((p) =>
+      p.pattern.test(stderr)
+    );
+
+  it("retries on a certificate rejection while the access role propagates", () => {
+    expect(matches("Permission denied (publickey).")).toBe(true);
+  });
+
+  it("retries when the connection drops before the SSH banner (e.g. jump host unreachable)", () => {
+    expect(
+      matches("kex_exchange_identification: Connection closed by remote host")
+    ).toBe(true);
+    expect(matches("Connection closed by UNKNOWN port 65535")).toBe(true);
+  });
+
+  it("retries when the outer hop's ConnectTimeout expires during the target's banner exchange", () => {
+    expect(
+      matches(
+        "ssh_exchange_identification: Connection timed out during banner exchange"
+      )
+    ).toBe(true);
+    expect(matches("Connection to UNKNOWN port 65535 timed out")).toBe(true);
+  });
+
+  it("retries on the sudo propagation message", () => {
+    expect(matches("Sorry, user miguel may not run sudo on my-vm.")).toBe(true);
+  });
+});

--- a/src/plugins/azure/__tests__/ssh-shared.test.ts
+++ b/src/plugins/azure/__tests__/ssh-shared.test.ts
@@ -10,13 +10,19 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { print2 } from "../../../drivers/stdio";
 import { exec } from "../../../util";
+import { createTempDirectoryForKeys } from "../../ssh/shared";
+import { azSetSubscription } from "../auth";
+import { ensureAzInstall } from "../install";
 import {
   AD_CERT_FILENAME,
+  AD_SSH_KEY_PRIVATE,
   azSshCertCommand,
+  azureSshLoginReproCommands,
+  azureSshProviderBase,
   generateSshKeyAndAzureAdCert,
 } from "../ssh-shared";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../drivers/stdio", () => ({
   print2: vi.fn(),
@@ -29,13 +35,36 @@ vi.mock("../../../util", async (importOriginal) => ({
   exec: vi.fn(),
 }));
 
+// Spread the original so the real az command builders (used by
+// azureSshLoginReproCommands) keep working; only stub the login flow.
+vi.mock("../auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auth")>()),
+  azSetSubscription: vi.fn(),
+}));
+
+vi.mock("../install", () => ({
+  ensureAzInstall: vi.fn(),
+}));
+
+vi.mock("../../ssh/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../ssh/shared")>()),
+  createTempDirectoryForKeys: vi.fn(),
+}));
+
 const mockExec = vi.mocked(exec);
 const mockPrint2 = vi.mocked(print2);
+const mockAzSetSubscription = vi.mocked(azSetSubscription);
+const mockEnsureAzInstall = vi.mocked(ensureAzInstall);
+const mockCreateTempDirectoryForKeys = vi.mocked(createTempDirectoryForKeys);
 
 const KEY_PATH = path.join("tmp", "p0cli-keys");
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("azSshCertCommand", () => {
@@ -90,5 +119,157 @@ describe("generateSshKeyAndAzureAdCert", () => {
 
     expect(mockPrint2).toHaveBeenCalledWith("az stdout");
     expect(mockPrint2).toHaveBeenCalledWith("az stderr");
+  });
+});
+
+describe("azureSshLoginReproCommands", () => {
+  const request = {
+    directoryId: "my-tenant-id",
+    subscriptionId: "my-subscription-id",
+  };
+
+  it("returns the login and cert-generation commands using the identity file's directory", () => {
+    const commands = azureSshLoginReproCommands(request, {
+      sshOptions: [],
+      identityFile: path.join(KEY_PATH, AD_SSH_KEY_PRIVATE),
+      port: "50022",
+      teardown: async () => {},
+    });
+
+    expect(commands).toEqual([
+      "az account clear",
+      "az login --scope https://management.core.windows.net//.default --tenant my-tenant-id",
+      "az account set --subscription my-subscription-id",
+      `mkdir ${KEY_PATH}`,
+      `az ssh cert --file ${path.join(KEY_PATH, AD_CERT_FILENAME)}`,
+    ]);
+  });
+
+  it("falls back to a key path in the home directory without additional data", () => {
+    vi.stubEnv("HOME", path.join("home", "p0user"));
+
+    const commands = azureSshLoginReproCommands(request);
+
+    const keyPath = path.join("home", "p0user", "p0cli-azure-ssh-keys");
+    expect(commands).toContain(`mkdir ${keyPath}`);
+    expect(commands).toContain(
+      `az ssh cert --file ${path.join(keyPath, AD_CERT_FILENAME)}`
+    );
+  });
+
+  it("uses USERPROFILE for the key path when HOME is not set", () => {
+    vi.stubEnv("HOME", undefined);
+    vi.stubEnv("USERPROFILE", path.join("Users", "p0user"));
+
+    const commands = azureSshLoginReproCommands(request);
+
+    expect(commands).toContain(
+      `mkdir ${path.join("Users", "p0user", "p0cli-azure-ssh-keys")}`
+    );
+  });
+});
+
+describe("azureSshProviderBase", () => {
+  describe("cloudProviderLogin", () => {
+    it("is a no-op since login happens during provider setup", async () => {
+      await expect(
+        azureSshProviderBase.cloudProviderLogin()
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("ensureInstall", () => {
+    it("resolves when the Azure CLI is installed", async () => {
+      mockEnsureAzInstall.mockResolvedValue(true);
+
+      await expect(
+        azureSshProviderBase.ensureInstall()
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects with an install prompt when the Azure CLI is missing", async () => {
+      mockEnsureAzInstall.mockResolvedValue(false);
+
+      await expect(azureSshProviderBase.ensureInstall()).rejects.toMatch(
+        /installing the Azure CLI/
+      );
+    });
+  });
+
+  describe("preTestAccessPropagationArgs", () => {
+    it("returns a non-interactive `sudo -nv` pre-test for sudo commands", () => {
+      expect(
+        azureSshProviderBase.preTestAccessPropagationArgs({
+          sudo: true,
+          destination: "my-vm",
+          arguments: ["whoami"],
+        })
+      ).toEqual({
+        sudo: true,
+        destination: "my-vm",
+        command: "sudo",
+        arguments: ["-nv"],
+      });
+    });
+
+    it("skips pre-testing for non-sudo commands", () => {
+      expect(
+        azureSshProviderBase.preTestAccessPropagationArgs({
+          destination: "my-vm",
+          arguments: [],
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  describe("generateKeys", () => {
+    it("sets the subscription and generates keys in a temporary directory", async () => {
+      mockCreateTempDirectoryForKeys.mockResolvedValue({
+        path: KEY_PATH,
+        cleanup: vi.fn(),
+      });
+      mockExec.mockResolvedValue({ stdout: "", stderr: "" } as any);
+
+      const request = {
+        subscriptionId: "my-subscription-id",
+        directoryId: "my-tenant-id",
+      } as any;
+      const options = { requestId: "request-1", debug: false };
+
+      await expect(
+        azureSshProviderBase.generateKeys({} as any, request, options)
+      ).resolves.toEqual({
+        privateKeyPath: path.join(KEY_PATH, AD_SSH_KEY_PRIVATE),
+        certificatePath: path.join(KEY_PATH, AD_CERT_FILENAME),
+      });
+
+      expect(mockAzSetSubscription).toHaveBeenCalledWith(request, options);
+    });
+  });
+
+  describe("toCliRequest", () => {
+    const request = {
+      principal: "user@example.com",
+      generated: { linuxUserName: "generated-user" },
+    } as any;
+
+    it("copies the generated linux user name into cliLocalData", async () => {
+      await expect(
+        azureSshProviderBase.toCliRequest(request)
+      ).resolves.toMatchObject({
+        cliLocalData: { linuxUserName: "generated-user" },
+      });
+    });
+
+    it("falls back to the principal when no linux user name was generated", async () => {
+      await expect(
+        azureSshProviderBase.toCliRequest({
+          ...request,
+          generated: {},
+        })
+      ).resolves.toMatchObject({
+        cliLocalData: { linuxUserName: "user@example.com" },
+      });
+    });
   });
 });

--- a/src/plugins/azure/__tests__/ssh.test.ts
+++ b/src/plugins/azure/__tests__/ssh.test.ts
@@ -1,0 +1,364 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { newSshProvider } from "../../../commands/shared/ssh";
+import { PermissionRequest } from "../../../types/request";
+import { CliPermissionSpec } from "../../../types/ssh";
+import { exec } from "../../../util";
+import { createTempDirectoryForKeys } from "../../ssh/shared";
+import { azSetSubscription } from "../auth";
+import { azureBastionSshProvider } from "../ssh-bastion";
+import {
+  JUMP_HOST_CONNECT_TIMEOUT_SECONDS,
+  TARGET_CONNECT_TIMEOUT_SECONDS,
+  azureJumpHostSshProvider,
+} from "../ssh-jump-host";
+import { AD_CERT_FILENAME, AD_SSH_KEY_PRIVATE } from "../ssh-shared";
+import {
+  AzureLocalData,
+  AzureSshPermission,
+  AzureSshPermissionSpec,
+} from "../types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Key minting shells out to the Azure CLI; stub the subprocess and login
+// boundaries (same style as ssh-shared.test.ts) and pin the temp key directory.
+vi.mock("../../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../util")>()),
+  exec: vi.fn(),
+}));
+
+vi.mock("../auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auth")>()),
+  azSetSubscription: vi.fn(),
+}));
+
+vi.mock("../../ssh/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../ssh/shared")>()),
+  createTempDirectoryForKeys: vi.fn(),
+}));
+
+type AzureCliRequest = CliPermissionSpec<
+  AzureSshPermissionSpec,
+  AzureLocalData
+>;
+
+const LINUX_USER = "miguel.campos@permz.us";
+const PRIVATE_IP = "10.1.0.4";
+const JUMP_IP = "4.154.21.27";
+
+const PERMISSION_BASE: AzureSshPermission = {
+  provider: "azure",
+  publicKey: "pub-key",
+  destination: "my-vm",
+  parent: undefined,
+  group: undefined,
+  principal: LINUX_USER,
+  resource: {
+    instanceName: "my-vm",
+    instanceId: "/subscriptions/sub-1/.../my-vm",
+    subscriptionId: "sub-1",
+    subscriptionName: "sub-name",
+    resourceGroupId: "rg-1",
+    region: "eastus",
+    networkInterface: {
+      id: "nic-1",
+      subnetId: "subnet-1",
+      privateIp: PRIVATE_IP,
+    },
+  },
+};
+
+const cliRequest = (permission: AzureSshPermission): AzureCliRequest => ({
+  type: "ssh",
+  permission,
+  generated: { linuxUserName: LINUX_USER, directoryId: "dir-1" },
+  cliLocalData: { linuxUserName: LINUX_USER },
+});
+
+const permissionRequest = (
+  permission: AzureSshPermission
+): PermissionRequest<AzureSshPermissionSpec> => ({
+  type: "ssh",
+  permission,
+  generated: { linuxUserName: LINUX_USER, directoryId: "dir-1" },
+  status: "DONE",
+  principal: LINUX_USER,
+});
+
+const jumpHostPermission = (
+  overrides: Partial<AzureSshPermission> = {}
+): AzureSshPermission => ({
+  ...PERMISSION_BASE,
+  jumpHost: { id: "jump-1", roleId: "jrole-1", publicIp: JUMP_IP },
+  ...overrides,
+});
+
+const bastionPermission = (): AzureSshPermission => ({
+  ...PERMISSION_BASE,
+  bastionHost: { id: "bastion-1" },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(exec).mockResolvedValue({ stdout: "", stderr: "" } as any);
+  vi.mocked(azSetSubscription).mockResolvedValue(LINUX_USER);
+  vi.mocked(createTempDirectoryForKeys).mockResolvedValue({
+    path: "/tmp",
+    cleanup: async () => {},
+  });
+});
+
+describe("newSshProvider", () => {
+  it("selects the jump-host provider when the permission has a jump host", () => {
+    const provider = newSshProvider(permissionRequest(jumpHostPermission()));
+
+    expect(provider).not.toBe(azureBastionSshProvider);
+    expect(provider.sshConnectTimeoutSeconds).toBe(
+      TARGET_CONNECT_TIMEOUT_SECONDS
+    );
+  });
+
+  it("selects the Bastion provider when the permission has no jump host", () => {
+    const provider = newSshProvider(permissionRequest(bastionPermission()));
+
+    expect(provider).toBe(azureBastionSshProvider);
+  });
+
+  it("selects by the CLI request shape as well (used by ssh-proxy and spawned sessions)", () => {
+    const jumpProvider = newSshProvider({
+      type: "azure",
+      jumpHost: { id: "jump-1", roleId: "jrole-1", publicIp: JUMP_IP },
+    } as any);
+    const bastionProvider = newSshProvider({
+      type: "azure",
+      bastionId: "bastion-1",
+    } as any);
+
+    expect(jumpProvider.sshConnectTimeoutSeconds).toBe(
+      TARGET_CONNECT_TIMEOUT_SECONDS
+    );
+    expect(bastionProvider).toBe(azureBastionSshProvider);
+  });
+});
+
+describe("requestToSsh", () => {
+  it("maps a jump host request to the target's private IP", () => {
+    const request = azureJumpHostSshProvider.requestToSsh(
+      cliRequest(jumpHostPermission())
+    );
+
+    expect(request.id).toBe(PRIVATE_IP);
+    expect(request.jumpHost).toEqual({
+      id: "jump-1",
+      roleId: "jrole-1",
+      publicIp: JUMP_IP,
+    });
+    expect(request.bastionId).toBeUndefined();
+    expect(request.privateIp).toBe(PRIVATE_IP);
+    expect(request.linuxUserName).toBe(LINUX_USER);
+  });
+
+  it("maps a bastion host request to localhost", () => {
+    const request = azureBastionSshProvider.requestToSsh(
+      cliRequest(bastionPermission())
+    );
+
+    expect(request.id).toBe("localhost");
+    expect(request.bastionId).toBe("bastion-1");
+    expect(request.jumpHost).toBeUndefined();
+  });
+
+  it("throws when neither a jump host nor a bastion host is present", () => {
+    expect(() =>
+      azureBastionSshProvider.requestToSsh(cliRequest(PERMISSION_BASE))
+    ).toThrow(/not reachable/i);
+  });
+
+  it("throws when a jump host target has no private IP", () => {
+    const permission = jumpHostPermission({
+      resource: {
+        ...PERMISSION_BASE.resource,
+        networkInterface: {
+          ...PERMISSION_BASE.resource.networkInterface,
+          privateIp: undefined,
+        },
+      },
+    });
+
+    expect(() =>
+      azureJumpHostSshProvider.requestToSsh(cliRequest(permission))
+    ).toThrow(/private IP/i);
+  });
+
+  it("throws when the jump host has no IP address", () => {
+    const permission = jumpHostPermission({
+      jumpHost: { id: "jump-1", roleId: "jrole-1", publicIp: "" },
+    });
+
+    expect(() =>
+      azureJumpHostSshProvider.requestToSsh(cliRequest(permission))
+    ).toThrow(/jump host .* no IP/i);
+  });
+});
+
+describe("proxyCommand", () => {
+  it("builds an SSH `-W` proxy through the jump host using the setup-minted credentials", () => {
+    const provider = azureJumpHostSshProvider;
+    const request = provider.requestToSsh(cliRequest(jumpHostPermission()));
+
+    const command = provider.proxyCommand(request, undefined, {
+      identityFile: `/tmp/${AD_SSH_KEY_PRIVATE}`,
+      certificatePath: `/tmp/${AD_CERT_FILENAME}`,
+    });
+
+    expect(command).toEqual([
+      "ssh",
+      "-F",
+      "/dev/null",
+      "-i",
+      `/tmp/${AD_SSH_KEY_PRIVATE}`,
+      "-o",
+      `CertificateFile=/tmp/${AD_CERT_FILENAME}`,
+      "-o",
+      "StrictHostKeyChecking=no",
+      "-o",
+      "UserKnownHostsFile=/dev/null",
+      "-o",
+      `ConnectTimeout=${JUMP_HOST_CONNECT_TIMEOUT_SECONDS}`,
+      "-o",
+      "BatchMode=yes",
+      "-W",
+      `${PRIVATE_IP}:22`,
+      `${LINUX_USER}@${JUMP_IP}`,
+    ]);
+  });
+
+  it("throws if no credentials were minted for this jump-host connection", () => {
+    const provider = azureJumpHostSshProvider;
+    const request = provider.requestToSsh(cliRequest(jumpHostPermission()));
+
+    expect(() => provider.proxyCommand(request)).toThrow(
+      /keys were not generated/i
+    );
+  });
+
+  it("connects to the local Bastion tunnel for a bastion request", () => {
+    const request = azureBastionSshProvider.requestToSsh(
+      cliRequest(bastionPermission())
+    );
+
+    const command = azureBastionSshProvider.proxyCommand(request, "50022");
+
+    // nc on Unix/Mac, ncat on Windows; either way connects to the local tunnel port.
+    expect(command[0]).toMatch(/^nc(at)?$/);
+    expect(command.slice(1)).toEqual(["localhost", "50022"]);
+  });
+});
+
+describe("connectionErrorMessage", () => {
+  const provider = azureJumpHostSshProvider;
+  const request = provider.requestToSsh(cliRequest(jumpHostPermission()));
+
+  it("classifies a connect timeout to the jump host as the jump host being unreachable", () => {
+    const message = provider.connectionErrorMessage!(
+      `debug1: Connecting to ${JUMP_IP} [${JUMP_IP}] port 22.\n` +
+        `ssh: connect to host ${JUMP_IP} port 22: Connection timed out`,
+      request
+    );
+
+    expect(message).toMatch(/jump host/i);
+    expect(message).toContain(JUMP_IP);
+  });
+
+  it("does not attribute a connect failure for some other host to the jump host", () => {
+    const message = provider.connectionErrorMessage!(
+      "ssh: connect to host 192.0.2.99 port 22: Connection refused",
+      request
+    );
+
+    expect(message).toBeUndefined();
+  });
+
+  it("classifies a failed `-W` forward as the target VM being unreachable", () => {
+    const message = provider.connectionErrorMessage!(
+      "channel 0: open failed: connect failed: Connection timed out",
+      request
+    );
+
+    expect(message).toMatch(/target VM/i);
+    expect(message).toContain(PRIVATE_IP);
+  });
+
+  it("falls through to the raw error for unrelated stderr", () => {
+    expect(
+      provider.connectionErrorMessage!("some unrelated ssh noise", request)
+    ).toBeUndefined();
+  });
+});
+
+describe("unprovisionedAccessPatterns", () => {
+  const matches = (
+    provider: { unprovisionedAccessPatterns: readonly { pattern: RegExp }[] },
+    stderr: string
+  ) => provider.unprovisionedAccessPatterns.some((p) => p.pattern.test(stderr));
+
+  describe("jump host", () => {
+    const provider = azureJumpHostSshProvider;
+
+    it("retries on a certificate rejection while the access role propagates", () => {
+      expect(matches(provider, "Permission denied (publickey).")).toBe(true);
+    });
+
+    it("retries when the connection drops before the SSH banner (e.g. jump host unreachable)", () => {
+      expect(
+        matches(
+          provider,
+          "kex_exchange_identification: Connection closed by remote host"
+        )
+      ).toBe(true);
+      expect(matches(provider, "Connection closed by UNKNOWN port 65535")).toBe(
+        true
+      );
+    });
+
+    it("retries when the outer hop's ConnectTimeout expires during the target's banner exchange", () => {
+      expect(
+        matches(
+          provider,
+          "ssh_exchange_identification: Connection timed out during banner exchange"
+        )
+      ).toBe(true);
+      expect(
+        matches(provider, "Connection to UNKNOWN port 65535 timed out")
+      ).toBe(true);
+    });
+
+    it("retries on the sudo propagation message", () => {
+      expect(
+        matches(provider, "Sorry, user miguel may not run sudo on my-vm.")
+      ).toBe(true);
+    });
+  });
+
+  describe("bastion", () => {
+    it("retries on the sudo propagation message only", () => {
+      expect(
+        matches(
+          azureBastionSshProvider,
+          "Sorry, user miguel may not run sudo on my-vm."
+        )
+      ).toBe(true);
+      expect(
+        matches(azureBastionSshProvider, "Permission denied (publickey).")
+      ).toBe(false);
+    });
+  });
+});

--- a/src/plugins/azure/ssh-bastion.ts
+++ b/src/plugins/azure/ssh-bastion.ts
@@ -8,21 +8,15 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { isSudoCommand } from "../../commands/shared/ssh";
 import { SshProvider } from "../../types/ssh";
 import { getOperatingSystem } from "../../util";
 import { createTempDirectoryForKeys } from "../ssh/shared";
-import {
-  azAccountClearCommand,
-  azAccountSetCommand,
-  azLoginCommand,
-  azSetSubscription,
-} from "./auth";
-import { ensureAzInstall } from "./install";
+import { azSetSubscription } from "./auth";
 import {
   AD_CERT_FILENAME,
   AD_SSH_KEY_PRIVATE,
-  azSshCertCommand,
+  azureSshLoginReproCommands,
+  azureSshProviderBase,
   generateSshKeyAndAzureAdCert,
 } from "./ssh-shared";
 import { azBastionTunnelCommand, trySpawnBastionTunnel } from "./tunnel";
@@ -33,64 +27,12 @@ import {
 } from "./types";
 import path from "node:path";
 
-const unprovisionedAccessPatterns = [
-  {
-    // The output of `sudo -v` when the user is not allowed to run sudo
-    pattern: /Sorry, user .+ may not run sudo on .+/,
-  },
-] as const;
-
-const provisionedAccessPatterns = [
-  {
-    pattern: /sudo: a password is required/,
-  },
-] as const;
-
-// Azure user access is subject to significant propagation delays of up to 10 minutes
-// when elevating access to sudo. If the user starts with sudo access, there is no
-// propagation delay. The typical time for propagation is less than 1 minute, but
-// we want to be safe, so we set the timeout to 3 minutes. With a longer timeout a
-// user doesn't have to retry the command too many times.
-const PROPAGATION_TIMEOUT_LIMIT_MS = 3 * 60 * 1000;
-
 export const azureSshProvider: SshProvider<
   AzureSshPermissionSpec,
   AzureLocalData,
   AzureSshRequest
 > = {
-  // TODO: Natively support Azure login in P0 CLI
-  cloudProviderLogin: async () => {
-    // Login is handled as part of setup() below
-    return undefined;
-  },
-
-  ensureInstall: async () => {
-    if (!(await ensureAzInstall())) {
-      throw "Please try again after installing the Azure CLI tool.";
-    }
-  },
-
-  friendlyName: "Microsoft Azure",
-
-  loginRequiredMessage: "Please log in to Azure with 'az login' to continue.",
-
-  // TODO: Determine value
-  loginRequiredPattern: undefined,
-
-  propagationTimeoutMs: PROPAGATION_TIMEOUT_LIMIT_MS,
-
-  preTestAccessPropagationArgs: (cmdArgs) => {
-    if (isSudoCommand(cmdArgs)) {
-      return {
-        ...cmdArgs,
-        // `sudo -v` prints `Sorry, user <user> may not run sudo on <hostname>.` to stderr when user is not a sudoer.
-        // we have to use `-n` flag to avoid the oauth prompt on azure cli.
-        command: "sudo",
-        arguments: ["-nv"],
-      };
-    }
-    return undefined;
-  },
+  ...azureSshProviderBase,
 
   proxyCommand: (_, port) => {
     const targetPort = port ?? "22";
@@ -101,45 +43,15 @@ export const azureSshProvider: SshProvider<
   },
 
   reproCommands: (request, additionalData) => {
-    const { command: azAccountClearExe, args: azAccountClearArgs } =
-      azAccountClearCommand();
-    const { command: azLoginExe, args: azLoginArgs } = azLoginCommand(
-      request.directoryId
-    );
-    const { command: azAccountSetExe, args: azAccountSetArgs } =
-      azAccountSetCommand(request.subscriptionId);
-
-    const getKeyPath = () => {
-      // Use the same key path as the one generated in setup() so it matches the ssh command that is generated
-      // elsewhere. It'll be an annoying long temporary directory name, but it strictly will work for reproduction. If
-      // additionalData isn't present (which it always should be for the azureSshProvider), we'll use the user's home
-      // directory.
-      if (additionalData?.identityFile) {
-        return path.dirname(additionalData.identityFile);
-      } else {
-        const basePath = process.env.HOME || process.env.USERPROFILE || "";
-        return path.join(basePath, "p0cli-azure-ssh-keys");
-      }
-    };
-
-    const keyPath = getKeyPath();
-
-    const { command: azCertGenExe, args: azCertGenArgs } =
-      azSshCertCommand(keyPath);
-
-    // If additionalData is undefined (which, again, should be never), use the default port for Azure Network Bastion
-    // tunnels instead of generating a random one
+    // If additionalData is undefined (which should be never for the azureSshProvider), use the default port for Azure
+    // Network Bastion tunnels instead of generating a random one
     const { command: azTunnelExe, args: azTunnelArgs } = azBastionTunnelCommand(
       request,
       additionalData?.port ?? "50022"
     );
 
     return [
-      `${azAccountClearExe} ${azAccountClearArgs.join(" ")}`,
-      `${azLoginExe} ${azLoginArgs.join(" ")}`,
-      `${azAccountSetExe} ${azAccountSetArgs.join(" ")}`,
-      `mkdir ${keyPath}`,
-      `${azCertGenExe} ${azCertGenArgs.join(" ")}`,
+      ...azureSshLoginReproCommands(request, additionalData),
       `${azTunnelExe} ${azTunnelArgs.join(" ")}`,
     ];
   },
@@ -238,18 +150,6 @@ export const azureSshProvider: SshProvider<
       instanceResourceGroup: request.permission.resource.resourceGroupId,
       bastionId: bastionHost.id,
       directoryId: request.generated.directoryId,
-    };
-  },
-
-  unprovisionedAccessPatterns,
-  provisionedAccessPatterns,
-
-  toCliRequest: async (request) => {
-    return {
-      ...request,
-      cliLocalData: {
-        linuxUserName: request.generated.linuxUserName ?? request.principal,
-      },
     };
   },
 };

--- a/src/plugins/azure/ssh-bastion.ts
+++ b/src/plugins/azure/ssh-bastion.ts
@@ -27,7 +27,9 @@ import {
 } from "./types";
 import path from "node:path";
 
-export const azureSshProvider: SshProvider<
+/** Connects to an Azure VM through an Azure Bastion tunnel: a local port is
+ * forwarded to the VM's SSH port over the Bastion host's HTTPS tunnel. */
+export const azureBastionSshProvider: SshProvider<
   AzureSshPermissionSpec,
   AzureLocalData,
   AzureSshRequest
@@ -43,8 +45,8 @@ export const azureSshProvider: SshProvider<
   },
 
   reproCommands: (request, additionalData) => {
-    // If additionalData is undefined (which should be never for the azureSshProvider), use the default port for Azure
-    // Network Bastion tunnels instead of generating a random one
+    // If additionalData is undefined (which should be never for the azureBastionSshProvider), use the default port for
+    // Azure Network Bastion tunnels instead of generating a random one
     const { command: azTunnelExe, args: azTunnelArgs } = azBastionTunnelCommand(
       request,
       additionalData?.port ?? "50022"
@@ -135,11 +137,11 @@ export const azureSshProvider: SshProvider<
   },
 
   requestToSsh: (request) => {
-    const { bastionHost, jumpHost } = request.permission;
+    const { bastionHost } = request.permission;
     if (!bastionHost) {
-      throw jumpHost
-        ? "This SSH session uses an Azure jump host, which is not yet supported by this CLI version. Please request a Bastion-based session or retry after upgrading."
-        : "Backend did not provide an Azure Bastion host for SSH session.";
+      // Jump-host requests are routed to the jump-host provider by newSshProvider, so reaching this provider
+      // without a bastion host means the VM has no connection method at all.
+      throw "This Azure VM is not reachable: no jump host or bastion host is associated with it.";
     }
     return {
       type: "azure",

--- a/src/plugins/azure/ssh-jump-host.ts
+++ b/src/plugins/azure/ssh-jump-host.ts
@@ -1,0 +1,272 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { getContactMessage } from "../../drivers/config";
+import { SshProvider } from "../../types/ssh";
+import { createTempDirectoryForKeys } from "../ssh/shared";
+import { azSetSubscription } from "./auth";
+import {
+  AD_CERT_FILENAME,
+  AD_SSH_KEY_PRIVATE,
+  azureSshLoginReproCommands,
+  azureSshProviderBase,
+  generateSshKeyAndAzureAdCert,
+} from "./ssh-shared";
+import {
+  AzureLocalData,
+  AzureSshPermissionSpec,
+  AzureSshRequest,
+} from "./types";
+import path from "node:path";
+
+// When connecting through a jump host we fail fast (instead of hanging) if the jump host or the target VM is
+// unreachable or not yet ready; the resulting connection error is treated as unprovisioned access below and retried
+// within the access propagation window.
+export const JUMP_HOST_CONNECT_TIMEOUT_SECONDS = 20;
+
+// The outer (target) hop's ConnectTimeout also bounds its own SSH banner exchange when a ProxyCommand is used, and
+// that exchange only starts once the inner jump-host hop has finished connecting *and* authenticating. Since both
+// hops' ConnectTimeout clocks start at essentially the same instant, an outer timeout equal to the inner one would
+// leave no time for the outer's own banner exchange whenever the jump-host hop uses any meaningful fraction of its
+// budget — exactly what happens while access is still propagating. Give the outer hop extra headroom.
+export const TARGET_CONNECT_TIMEOUT_SECONDS =
+  JUMP_HOST_CONNECT_TIMEOUT_SECONDS + 10;
+
+/** The inner (ProxyCommand) ssh's error when the TCP connection to the jump
+ * host itself cannot be established (offline, still booting, or filtered). */
+const JUMP_HOST_CONNECT_FAILED_PATTERN =
+  /ssh: connect to host (\S+) port \d+: (?:Connection timed out|Operation timed out|Connection refused|No route to host)/;
+
+/** The jump host was reached, but its `-W` forward to the target VM failed. */
+const TARGET_CONNECT_FAILED_PATTERN =
+  /channel \d+: open failed: connect (?:timeout|failed)/;
+
+const jumpHostUnprovisionedAccessPatterns = [
+  {
+    // The host rejected our certificate. Until the access role finishes propagating to the jump host / target VM,
+    // public key auth is refused; retry within the propagation window rather than failing immediately.
+    pattern: /Permission denied \(publickey\)/,
+  },
+  {
+    // The connection dropped before the SSH banner — e.g. the jump host ProxyCommand exited after a connect timeout,
+    // or the host isn't reachable/ready yet. Retry within the propagation window instead of failing hard.
+    pattern: /\bConnection closed\b.*\b(?:by UNKNOWN port \d+|by remote host)?/,
+  },
+  {
+    // The outer hop's own ConnectTimeout expired before the target's banner arrived (reported against "UNKNOWN"
+    // since the connection is piped through a ProxyCommand rather than a real socket) — typically because the inner
+    // jump-host hop used up most of the shared propagation-window budget. Retry rather than failing hard.
+    pattern:
+      /Connection (?:timed out during banner exchange|to UNKNOWN port \d+ timed out)/,
+  },
+] as const;
+
+/** Mints a fresh key + Azure AD certificate for the jump-host hop. The caller
+ * owns `cleanup`, and is responsible for passing the returned paths along to
+ * proxyCommand (e.g. via the setup/setupProxy return value) — this provider
+ * holds no state of its own. */
+const mintKeys = async (
+  request: AzureSshRequest,
+  options: { debug?: boolean } = {}
+) => {
+  // The subscription ID here is used to ensure that the user is logged in to the correct tenant/directory.
+  // As long as a subscription ID in the correct tenant is provided, this will work; it need not be the same
+  // subscription as which contains the jump host or the target VM.
+  const linuxUserName = await azSetSubscription(request, options);
+
+  if (linuxUserName !== request.linuxUserName) {
+    throw `Azure CLI login returned a different user name than expected. Expected: ${request.linuxUserName}, Actual: ${linuxUserName}`;
+  }
+
+  const { path: keyPath, cleanup } = await createTempDirectoryForKeys();
+
+  try {
+    await generateSshKeyAndAzureAdCert(keyPath, options);
+  } catch (error: any) {
+    await cleanup();
+    throw error;
+  }
+
+  return {
+    privateKeyPath: path.join(keyPath, AD_SSH_KEY_PRIVATE),
+    certificatePath: path.join(keyPath, AD_CERT_FILENAME),
+    cleanup,
+  };
+};
+
+/** Connects to an Azure VM by SSH-ing through a jump host (a regular VM acting
+ * as an SSH bastion) with a `ssh -W` ProxyCommand.
+ *
+ * Both the jump-host hop and the target hop authenticate with a locally minted
+ * key + Azure AD certificate. Like every other provider, this is a stateless
+ * singleton: the keys minted by setup/setupProxy are threaded to proxyCommand
+ * as an explicit argument rather than held on the provider instance.
+ */
+export const azureJumpHostSshProvider: SshProvider<
+  AzureSshPermissionSpec,
+  AzureLocalData,
+  AzureSshRequest
+> = {
+  ...azureSshProviderBase,
+
+  setup: async (_authn, request, options) => {
+    // Both hops authenticate with the same key + certificate: the outer (target) hop reads it from
+    // identityFile/sshOptions below, and the embedded ProxyCommand reads it from the setup data (see proxyCommand).
+    const { privateKeyPath, certificatePath, cleanup } = await mintKeys(
+      request,
+      options
+    );
+
+    return {
+      sshOptions: [
+        `CertificateFile=${certificatePath}`,
+
+        // Target VMs behind a jump host are ephemeral, and re-used private IPs would trip host key checks, so we
+        // disable them. This is ordinarily dangerous, but the connection's integrity is ensured by the authenticated
+        // jump host SSH hop.
+        "StrictHostKeyChecking=no",
+        "UserKnownHostsFile=/dev/null",
+
+        // Fail fast (with a retryable error) instead of hanging when the target VM is offline or not yet reachable
+        // through the jump host. ConnectTimeout also bounds the SSH banner exchange when a ProxyCommand is used, so
+        // this must exceed the inner jump-host hop's own ConnectTimeout (see TARGET_CONNECT_TIMEOUT_SECONDS above).
+        `ConnectTimeout=${TARGET_CONNECT_TIMEOUT_SECONDS}`,
+      ],
+      identityFile: privateKeyPath,
+      certificatePath,
+      teardown: cleanup,
+    };
+  },
+
+  setupProxy: async (request, options) => {
+    // ssh-proxy runs in a separate process from ssh-resolve, so the certificate minted there (which authenticates
+    // the outer, target hop) isn't available here; mint a fresh one for the jump-host hop.
+    const { privateKeyPath, certificatePath, cleanup } = await mintKeys(
+      request,
+      options
+    );
+
+    return {
+      teardown: cleanup,
+      // Azure SSH connections only support the default port 22 (enforced by ssh-proxy).
+      port: "22",
+      identityFile: privateKeyPath,
+      certificatePath,
+    };
+  },
+
+  // Bound the outer SSH handshake in generated configs so an offline/unreachable target VM surfaces a prompt,
+  // retryable error instead of hanging indefinitely (the ProxyCommand below is separately bounded). Must exceed
+  // JUMP_HOST_CONNECT_TIMEOUT_SECONDS — see TARGET_CONNECT_TIMEOUT_SECONDS above.
+  sshConnectTimeoutSeconds: TARGET_CONNECT_TIMEOUT_SECONDS,
+
+  // Reach the target VM by SSH-ing through the jump host with `-W`. We connect to the target's private IP
+  // (request.id) literally rather than using `%h:%p`, so the command works both when embedded as the outer ssh's
+  // ProxyCommand (direct `p0 ssh` flow) and when run directly by `p0 ssh-proxy` (native ssh flow). `credentials` is
+  // the identityFile/certificatePath minted by setup/setupProxy above, passed in by the caller.
+  proxyCommand: (request, port, credentials) => {
+    if (!request.jumpHost?.publicIp) {
+      throw "The jump host for this Azure VM has no IP address; cannot establish a connection.";
+    }
+    if (!credentials?.identityFile || !credentials?.certificatePath) {
+      throw `SSH keys were not generated before connecting through the jump host. ${getContactMessage()}`;
+    }
+
+    const targetPort = port ?? "22";
+    return [
+      "ssh",
+      // Unlike the outer hop (which always sets its own -o ProxyCommand, so it can't be redirected by a config
+      // file — command-line -o options take precedence over anything in ssh_config), this inner hop sets no
+      // ProxyCommand of its own. If the user's ~/.ssh/config has a `Match exec` hook delegating to `p0 ssh-resolve`
+      // (the documented native-ssh integration), this ssh invocation would otherwise re-trigger it for the jump
+      // host's IP, and any ProxyCommand that resolution supplies *would* apply here — recursing if it resolves to
+      // another jump-host hop. This hop is already fully self-parameterized, so skip the user's config entirely.
+      "-F",
+      "/dev/null",
+      "-i",
+      credentials.identityFile,
+      "-o",
+      `CertificateFile=${credentials.certificatePath}`,
+      // Avoid any interactive host key prompt, which would hang a non-interactive ProxyCommand.
+      "-o",
+      "StrictHostKeyChecking=no",
+      "-o",
+      "UserKnownHostsFile=/dev/null",
+      // Fail fast instead of hanging if the jump host is unreachable, and never wait on an auth prompt (stdin is the
+      // tunnel here, so a prompt would hang forever). A surfaced error is retried within the propagation window.
+      "-o",
+      `ConnectTimeout=${JUMP_HOST_CONNECT_TIMEOUT_SECONDS}`,
+      "-o",
+      "BatchMode=yes",
+      "-W",
+      `${request.id}:${targetPort}`,
+      `${request.linuxUserName}@${request.jumpHost.publicIp}`,
+    ];
+  },
+
+  // Jump host connections don't use an Azure Bastion tunnel; the SSH ProxyCommand (appended by the caller) handles
+  // reaching the target through the jump host.
+  reproCommands: (request, additionalData) =>
+    azureSshLoginReproCommands(request, additionalData),
+
+  requestToSsh: (request) => {
+    const { jumpHost, resource } = request.permission;
+    const privateIp = resource.networkInterface.privateIp;
+
+    if (!privateIp) {
+      throw "This Azure VM has no private IP address; cannot connect through the jump host.";
+    }
+    if (!jumpHost?.publicIp) {
+      throw "The jump host for this Azure VM has no IP address; cannot establish a connection.";
+    }
+
+    return {
+      type: "azure",
+      // Connect to the target VM's private IP through the jump host (see proxyCommand).
+      id: privateIp,
+      ...request.cliLocalData,
+      instanceId: resource.instanceId,
+      subscriptionId: resource.subscriptionId,
+      instanceResourceGroup: resource.resourceGroupId,
+      directoryId: request.generated.directoryId,
+      jumpHost,
+      privateIp,
+    };
+  },
+
+  // The ConnectTimeouts above make an offline jump host / target VM fail fast on each attempt, but such a failure is
+  // indistinguishable from access still propagating, so it is retried until the propagation window expires. At that
+  // point the generic "access did not propagate" error would misattribute the cause; classify it instead. The
+  // messages never claim certainty: a connect timeout can also be a network path issue (e.g. a firewall).
+  connectionErrorMessage: (stderr, request) => {
+    const jumpHostIp = request.jumpHost?.publicIp;
+    const jumpHostConnect = stderr.match(JUMP_HOST_CONNECT_FAILED_PATTERN);
+    if (jumpHostConnect && jumpHostIp && jumpHostConnect[1] === jumpHostIp) {
+      return (
+        `\nCould not connect to the jump host for this instance (${jumpHostIp}). ` +
+        `The jump host may be offline, still starting up, or unreachable from your network. ` +
+        `Verify that the jump host VM is running, then retry.`
+      );
+    }
+    if (TARGET_CONNECT_FAILED_PATTERN.test(stderr)) {
+      return (
+        `\nConnected to the jump host, but it could not reach the target VM (${request.id}). ` +
+        `The VM may be offline or not yet accepting SSH connections. ` +
+        `Verify that the VM is running, then retry.`
+      );
+    }
+    return undefined;
+  },
+
+  unprovisionedAccessPatterns: [
+    ...azureSshProviderBase.unprovisionedAccessPatterns,
+    ...jumpHostUnprovisionedAccessPatterns,
+  ],
+};

--- a/src/plugins/azure/ssh-shared.ts
+++ b/src/plugins/azure/ssh-shared.ts
@@ -8,8 +8,26 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+// Import types only: a value import would create a require cycle back through
+// commands/shared/ssh.ts -> ssh-bastion.ts, which spreads azureSshProviderBase
+// at module load time.
+import { type SshAdditionalSetup } from "../../commands/shared/ssh";
 import { print2 } from "../../drivers/stdio";
+import { SshProvider } from "../../types/ssh";
 import { exec, osSafeCommand } from "../../util";
+import { createTempDirectoryForKeys, isSudoCommand } from "../ssh/shared";
+import {
+  azAccountClearCommand,
+  azAccountSetCommand,
+  azLoginCommand,
+  azSetSubscription,
+} from "./auth";
+import { ensureAzInstall } from "./install";
+import {
+  AzureLocalData,
+  AzureSshPermissionSpec,
+  AzureSshRequest,
+} from "./types";
 import path from "node:path";
 
 // We pass in the name of the certificate file to generate
@@ -17,6 +35,26 @@ export const AD_CERT_FILENAME = "p0cli-azure-ad-ssh-cert.pub";
 
 // The `az ssh cert` command manages key generation, and generates SSH RSA keys with the standard names
 export const AD_SSH_KEY_PRIVATE = "id_rsa";
+
+// Azure user access is subject to significant propagation delays of up to 10 minutes
+// when elevating access to sudo. If the user starts with sudo access, there is no
+// propagation delay. The typical time for propagation is less than 1 minute, but
+// we want to be safe, so we set the timeout to 3 minutes. With a longer timeout a
+// user doesn't have to retry the command too many times.
+const PROPAGATION_TIMEOUT_LIMIT_MS = 3 * 60 * 1000;
+
+const unprovisionedAccessPatterns = [
+  {
+    // The output of `sudo -v` when the user is not allowed to run sudo
+    pattern: /Sorry, user .+ may not run sudo on .+/,
+  },
+] as const;
+
+const provisionedAccessPatterns = [
+  {
+    pattern: /sudo: a password is required/,
+  },
+] as const;
 
 export const azSshCertCommand = (keyPath: string) =>
   osSafeCommand("az", [
@@ -48,3 +86,111 @@ export const generateSshKeyAndAzureAdCert = async (
     throw `Failed to generate Azure AD SSH certificate: ${error}`;
   }
 };
+
+/** The commands to log in to Azure and generate the SSH certificate; shared by
+ * every Azure SSH provider's reproCommands. Providers append their own
+ * connection (e.g. tunnel) commands. */
+export const azureSshLoginReproCommands = (
+  request: Pick<AzureSshRequest, "directoryId" | "subscriptionId">,
+  additionalData?: SshAdditionalSetup
+): string[] => {
+  const { command: azAccountClearExe, args: azAccountClearArgs } =
+    azAccountClearCommand();
+  const { command: azLoginExe, args: azLoginArgs } = azLoginCommand(
+    request.directoryId
+  );
+  const { command: azAccountSetExe, args: azAccountSetArgs } =
+    azAccountSetCommand(request.subscriptionId);
+
+  const getKeyPath = () => {
+    // Use the same key path as the one generated in setup() so it matches the ssh command that is generated
+    // elsewhere. It'll be an annoying long temporary directory name, but it strictly will work for reproduction. If
+    // additionalData isn't present (which it always should be for Azure SSH providers), we'll use the user's home
+    // directory.
+    if (additionalData?.identityFile) {
+      return path.dirname(additionalData.identityFile);
+    } else {
+      const basePath = process.env.HOME || process.env.USERPROFILE || "";
+      return path.join(basePath, "p0cli-azure-ssh-keys");
+    }
+  };
+
+  const keyPath = getKeyPath();
+
+  const { command: azCertGenExe, args: azCertGenArgs } =
+    azSshCertCommand(keyPath);
+
+  return [
+    `${azAccountClearExe} ${azAccountClearArgs.join(" ")}`,
+    `${azLoginExe} ${azLoginArgs.join(" ")}`,
+    `${azAccountSetExe} ${azAccountSetArgs.join(" ")}`,
+    `mkdir ${keyPath}`,
+    `${azCertGenExe} ${azCertGenArgs.join(" ")}`,
+  ];
+};
+
+/** SshProvider members shared by every Azure SSH provider, regardless of how
+ * the connection to the target is established (Bastion tunnel, jump host, ...) */
+export const azureSshProviderBase = {
+  // TODO: Natively support Azure login in P0 CLI
+  cloudProviderLogin: async () => {
+    // Login is handled as part of the provider's setup
+    return undefined;
+  },
+
+  ensureInstall: async () => {
+    if (!(await ensureAzInstall())) {
+      throw "Please try again after installing the Azure CLI tool.";
+    }
+  },
+
+  friendlyName: "Microsoft Azure",
+
+  loginRequiredMessage: "Please log in to Azure with 'az login' to continue.",
+
+  // TODO: Determine value
+  loginRequiredPattern: undefined,
+
+  propagationTimeoutMs: PROPAGATION_TIMEOUT_LIMIT_MS,
+
+  preTestAccessPropagationArgs: (cmdArgs) => {
+    if (isSudoCommand(cmdArgs)) {
+      return {
+        ...cmdArgs,
+        // `sudo -v` prints `Sorry, user <user> may not run sudo on <hostname>.` to stderr when user is not a sudoer.
+        // we have to use `-n` flag to avoid the oauth prompt on azure cli.
+        command: "sudo",
+        arguments: ["-nv"],
+      };
+    }
+    return undefined;
+  },
+
+  generateKeys: async (_authn, request, options) => {
+    const { debug } = options;
+    const { path: keyPath } = await createTempDirectoryForKeys();
+    await azSetSubscription(request, options);
+    await generateSshKeyAndAzureAdCert(keyPath, { debug });
+    const sshPrivateKeyPath = path.join(keyPath, AD_SSH_KEY_PRIVATE);
+    const sshCertificateKeyPath = path.join(keyPath, AD_CERT_FILENAME);
+
+    return {
+      privateKeyPath: sshPrivateKeyPath,
+      certificatePath: sshCertificateKeyPath,
+    };
+  },
+
+  unprovisionedAccessPatterns,
+  provisionedAccessPatterns,
+
+  toCliRequest: async (request) => {
+    return {
+      ...request,
+      cliLocalData: {
+        linuxUserName: request.generated.linuxUserName ?? request.principal,
+      },
+    };
+  },
+} satisfies Partial<
+  SshProvider<AzureSshPermissionSpec, AzureLocalData, AzureSshRequest>
+>;

--- a/src/plugins/azure/types.ts
+++ b/src/plugins/azure/types.ts
@@ -35,7 +35,7 @@ export type AzureBastionHost = {
 export type AzureJumpHost = {
   id: string;
   roleId: string;
-  ip: string;
+  publicIp: string;
 };
 
 export type AzureSshPermission = CommonSshPermissionSpec & {
@@ -69,17 +69,20 @@ export type AzureNodeSpec = {
   sudo?: boolean;
 };
 
-export type AzureBastionSpec = {
-  bastionId: string;
-};
-
 export type AzureSshRequest = AzureNodeSpec &
-  AzureBastionSpec &
   AzureLocalData & {
     type: "azure";
-    id: "localhost"; // Azure SSH always connects to the local tunnel
+    // "localhost" for the Azure Bastion tunnel flow; the target VM's private
+    // IP for the jump-host flow.
+    id: string;
     subscriptionId: string;
     directoryId: string;
+    // Present for the Azure Bastion flow.
+    bastionId?: string;
+    // Present for the jump-host flow.
+    jumpHost?: AzureJumpHost;
+    // The target VM's private IP (used as `id` for the jump-host flow).
+    privateIp?: string;
   };
 
 export type AzureLocalData = {

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -8,9 +8,9 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { isSudoCommand } from "../../commands/shared/ssh";
 import { PRIVATE_KEY_PATH } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
+import { isSudoCommand } from "../ssh/shared";
 import { ensureGcloudLogin } from "./auth";
 import { classifyGcpConnectionError } from "./connection-error";
 import { ensureGcpSshInstall } from "./install";

--- a/src/plugins/self-hosted/ssh.ts
+++ b/src/plugins/self-hosted/ssh.ts
@@ -8,11 +8,10 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { isSudoCommand } from "../../commands/shared/ssh";
 import { createKeyPair } from "../../common/keys";
 import { SshProvider } from "../../types/ssh";
 import { getAppName, getOperatingSystem } from "../../util";
-import { createTempDirectoryForKeys } from "../ssh/shared";
+import { createTempDirectoryForKeys, isSudoCommand } from "../ssh/shared";
 import { generateSelfHostedCertificate } from "./keygen";
 import { SelfHostedSshPermissionSpec, SelfHostedSshRequest } from "./types";
 import * as fs from "fs/promises";

--- a/src/plugins/ssh/__tests__/index.test.ts
+++ b/src/plugins/ssh/__tests__/index.test.ts
@@ -9,7 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { print2 } from "../../../drivers/stdio";
-import { sshProxy } from "../index";
+import { sshOrScp, sshProxy } from "../index";
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
@@ -217,5 +217,110 @@ describe("GCP connection failure diagnostics", () => {
     expect(exitCode).toBe(1);
     const printed = (print2 as Mock).mock.calls.map((call) => String(call[0]));
     expect(printed.some((line) => line.includes("OS Login"))).toBe(false);
+  });
+});
+
+// Providers like the Azure jump host build their ProxyCommand as an authenticated `ssh`
+// invocation, so it needs the identity file/certificate minted by setup/setupProxy. That data
+// is threaded to proxyCommand as an explicit argument (not held as provider state), and these
+// tests pin down that both sshOrScp and sshProxy actually pass it through, for both SSH and SCP.
+describe("proxyCommand receives setup/setupProxy credentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSpawn.mockImplementation(() => makeFakeChild());
+  });
+
+  const credentials = {
+    identityFile: "/tmp/jump-host-key",
+    certificatePath: "/tmp/jump-host-cert",
+  };
+
+  const fakeJumpHostLikeProvider = () => ({
+    cloudProviderLogin: vi.fn(async () => undefined),
+    setup: vi.fn(async () => ({
+      sshOptions: [],
+      teardown: vi.fn(async () => {}),
+      ...credentials,
+    })),
+    setupProxy: vi.fn(async () => ({
+      port: "22",
+      teardown: vi.fn(async () => {}),
+      ...credentials,
+    })),
+    proxyCommand: vi.fn(() => ["ssh", "-W", "10.0.0.1:22", "jump-host"]),
+    reproCommands: () => undefined,
+    preTestAccessPropagationArgs: () => undefined,
+    propagationTimeoutMs: 1000,
+    unprovisionedAccessPatterns: [],
+  });
+
+  const request = {
+    type: "azure",
+    id: "10.0.0.1",
+    linuxUserName: "user",
+  } as any;
+
+  it("sshOrScp passes setup()'s credentials to proxyCommand for an SSH session", async () => {
+    const sshProvider = fakeJumpHostLikeProvider();
+
+    await sshOrScp({
+      authn: {} as any,
+      request,
+      requestId: "req-1",
+      cmdArgs: { destination: "10.0.0.1", arguments: [] } as any,
+      privateKey: "pk",
+      sshProvider: sshProvider as any,
+      sshHostKeys: undefined,
+    });
+
+    expect(sshProvider.proxyCommand).toHaveBeenCalledWith(
+      request,
+      undefined,
+      expect.objectContaining(credentials)
+    );
+  });
+
+  it("sshOrScp passes setup()'s credentials to proxyCommand for an SCP transfer", async () => {
+    const sshProvider = fakeJumpHostLikeProvider();
+
+    await sshOrScp({
+      authn: {} as any,
+      request,
+      requestId: "req-1",
+      cmdArgs: {
+        source: "/local/file",
+        destination: "10.0.0.1:/remote/file",
+      } as any,
+      privateKey: "pk",
+      sshProvider: sshProvider as any,
+      sshHostKeys: undefined,
+    });
+
+    expect(sshProvider.proxyCommand).toHaveBeenCalledWith(
+      request,
+      undefined,
+      expect.objectContaining(credentials)
+    );
+  });
+
+  it("sshProxy passes setupProxy()'s credentials to proxyCommand", async () => {
+    const sshProvider = fakeJumpHostLikeProvider();
+
+    await sshProxy({
+      authn: {} as any,
+      request,
+      requestId: "req-1",
+      cmdArgs: {} as any,
+      privateKey: "pk",
+      sshProvider: sshProvider as any,
+      debug: false,
+      port: "22",
+    });
+
+    expect(sshProvider.proxyCommand).toHaveBeenCalledWith(
+      request,
+      "22",
+      expect.objectContaining(credentials)
+    );
   });
 });

--- a/src/plugins/ssh/__tests__/shared.test.ts
+++ b/src/plugins/ssh/__tests__/shared.test.ts
@@ -1,0 +1,26 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { isSudoCommand } from "../shared";
+import { describe, expect, it } from "vitest";
+
+describe("isSudoCommand", () => {
+  it("is true for the --sudo flag", () => {
+    expect(isSudoCommand({ sudo: true })).toBe(true);
+  });
+
+  it("is true when the remote command is sudo", () => {
+    expect(isSudoCommand({ command: "sudo" })).toBe(true);
+  });
+
+  it("is false otherwise", () => {
+    expect(isSudoCommand({ command: "ls" })).toBeFalsy();
+  });
+});

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -609,7 +609,11 @@ export const sshOrScp = async (args: {
       debug,
     });
 
-    const proxyCommand = sshProvider.proxyCommand(request, setupData?.port);
+    const proxyCommand = sshProvider.proxyCommand(
+      request,
+      setupData?.port,
+      setupData
+    );
 
     const { command, args: commandArgs } = createCommand(
       request,
@@ -731,7 +735,8 @@ export const sshProxy = async (args: {
 
   const proxyCommand = sshProvider.proxyCommand(
     request,
-    setupData?.port ?? args.port
+    setupData?.port ?? args.port,
+    setupData
   );
 
   const command = proxyCommand[0];

--- a/src/plugins/ssh/shared.ts
+++ b/src/plugins/ssh/shared.ts
@@ -24,3 +24,6 @@ export const createTempDirectoryForKeys = async (): Promise<{
 
   return { path, cleanup };
 };
+
+export const isSudoCommand = (args: { sudo?: boolean; command?: string }) =>
+  args.sudo || args.command === "sudo";

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -8,7 +8,11 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import type { CommandArgs, SshAdditionalSetup } from "../commands/shared/ssh";
+import type {
+  CommandArgs,
+  SshAdditionalSetup,
+  SshProxyCredentials,
+} from "../commands/shared/ssh";
 import {
   AwsSsh,
   AwsSshPermissionSpec,
@@ -120,10 +124,12 @@ export type SshProvider<
   setupProxy?: (
     request: SR,
     options: { debug?: boolean; abortController: AbortController }
-  ) => Promise<{
-    teardown: () => Promise<void>;
-    port: string;
-  }>;
+  ) => Promise<
+    SshProxyCredentials & {
+      teardown: () => Promise<void>;
+      port: string;
+    }
+  >;
 
   resolveHostKeys?: (
     request: SR,
@@ -147,8 +153,14 @@ export type SshProvider<
     certificatePath?: string;
   }>;
 
-  /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option */
-  proxyCommand: (request: SR, port?: string) => string[];
+  /** Returns the command and its arguments that are going to be injected as the ssh ProxyCommand option.
+   * `credentials` carries any identity file/certificate minted by setup/setupProxy, for providers whose proxy
+   * hop is itself an authenticated command (e.g. an embedded `ssh` jump-host hop). */
+  proxyCommand: (
+    request: SR,
+    port?: string,
+    credentials?: SshProxyCredentials
+  ) => string[];
 
   /** When set, generated SSH configs bound the handshake with this timeout so an unreachable target surfaces a
    * prompt, retryable error instead of hanging indefinitely. Used by providers whose ProxyCommand cannot itself

--- a/src/types/ssh.ts
+++ b/src/types/ssh.ts
@@ -8,7 +8,7 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
-import { CommandArgs, SshAdditionalSetup } from "../commands/shared/ssh";
+import type { CommandArgs, SshAdditionalSetup } from "../commands/shared/ssh";
 import {
   AwsSsh,
   AwsSshPermissionSpec,


### PR DESCRIPTION
**Problem**

The Azure Bastion SSH provider (`ssh-bastion.ts`) previously contained a mix of Azure-specific plumbing — login handling, install checks, key generation, sudo-propagation detection, and repro-command construction — inline in the provider definition. As this codebase adds more ways to reach an Azure host (e.g. jump hosts), that logic needs to be reused by other Azure SSH providers rather than duplicated or copy-pasted.

**Change**

This PR extracts the pieces of `ssh-bastion.ts` that are not specific to Bastion tunneling into `src/plugins/azure/ssh-shared.ts`, so future Azure SSH providers can reuse them:

- `azureSshProviderBase`: an `SshProvider` partial with the shared `cloudProviderLogin`, `ensureInstall`, `friendlyName`, `loginRequiredMessage`, `propagationTimeoutMs`, `preTestAccessPropagationArgs`, `generateKeys`, access-provisioning patterns, and `toCliRequest`. `ssh-bastion.ts` now spreads this (`...azureSshProviderBase`) and only defines the Bastion-specific `proxyCommand`, `reproCommands`, and `setup`.
- `azureSshLoginReproCommands`: the shared `az login` / `az account set` / cert-generation repro command sequence, which `ssh-bastion.ts` now appends its tunnel command to.

To avoid a require cycle (`ssh-shared.ts` → `commands/shared/ssh.ts` → `ssh-bastion.ts`, which spreads `azureSshProviderBase` at module load time), `ssh-shared.ts` imports `isSudoCommand` as a value but `SshAdditionalSetup` as a type-only import.

No behavior change — this is a pure extraction/refactor.

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Expanded `src/plugins/azure/__tests__/ssh-shared.test.ts` with coverage for the newly-extracted `azureSshLoginReproCommands` (including the identity-file-present vs. home-directory-fallback key path cases). Ran the full suite for this file — 15/15 tests pass. `tsc --noEmit` is clean. No behavior changes were made, so existing `ssh-bastion` tests continue to cover the composed provider.

**Tracking (optional)**

CUS-647

**Implementation (optional)**

The main technical decision was the type-only import of `SshAdditionalSetup` in `ssh-shared.ts` to break a require cycle back through `commands/shared/ssh.ts`, since `ssh-bastion.ts` spreads `azureSshProviderBase` at module load time.

**Attachments (optional)**

N/A

**Follow-up Work (optional)**

`azureSshProviderBase` and `azureSshLoginReproCommands` are intended to be reused by an upcoming jump-host Azure SSH provider.
