### PR TITLE
adding cli commands for audit logs

### DIFF
--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -193,13 +193,12 @@ const fileTransferAction = async (
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        void auditFileTransferActivity({
+        await auditFileTransferActivity({
           authn,
           requestId,
           fileTransferId: target.prefix,
           action: "file-transfer.upload",
           outcome: "failure",
-          bucketName: target.bucket,
           debug: args.debug,
         });
         throw `Upload failed: ${message}`;
@@ -213,7 +212,6 @@ const fileTransferAction = async (
         fileTransferId: target.prefix,
         action: "file-transfer.upload",
         outcome: "success",
-        bucketName: target.bucket,
         debug: args.debug,
       });
 
@@ -289,7 +287,6 @@ const fileTransferAction = async (
           fileTransferId: target.prefix,
           action: "file-transfer.download",
           outcome: "success",
-          bucketName: target.bucket,
           debug: args.debug,
         });
         const deleteSucceeded = await deleteUploadedObject(
@@ -304,7 +301,6 @@ const fileTransferAction = async (
           fileTransferId: target.prefix,
           action: "file-transfer.object-delete",
           outcome: deleteSucceeded ? "success" : "failure",
-          bucketName: target.bucket,
           debug: args.debug,
         });
       } else if (exitCode === null) {
@@ -316,7 +312,6 @@ const fileTransferAction = async (
           fileTransferId: target.prefix,
           action: "file-transfer.download",
           outcome: "failure",
-          bucketName: target.bucket,
           debug: args.debug,
         });
         throw `Remote download exited with code ${exitCode}`;

--- a/src/commands/file-transfer.ts
+++ b/src/commands/file-transfer.ts
@@ -10,6 +10,7 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import { createKeyPair } from "../common/keys";
 import { retryWithSleep } from "../common/retry";
+import { auditFileTransferActivity } from "../drivers/api";
 import { authenticate } from "../drivers/auth";
 import { print2 } from "../drivers/stdio";
 import { exitProcess, traceSpan } from "../opentelemetry/otel-helpers";
@@ -62,6 +63,7 @@ const deleteUploadedObject = async (
     if (debug) {
       print2(`Deleted s3://${bucket}/${key} from the bucket.`);
     }
+    return true;
   } catch (err) {
     print2(
       `Warning: could not delete s3://${bucket}/${key}. The file transfer succeeded, so this is safe to ignore. You may delete this object manually, or it will be removed automatically by the file-transfer bucket's lifecycle expiration rule.`
@@ -71,6 +73,7 @@ const deleteUploadedObject = async (
       const message = err instanceof Error ? err.message : String(err);
       print2(`Delete error: ${message}`);
     }
+    return false;
   }
 };
 
@@ -190,10 +193,29 @@ const fileTransferAction = async (
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        void auditFileTransferActivity({
+          authn,
+          requestId,
+          fileTransferId: target.prefix,
+          action: "file-transfer.upload",
+          outcome: "failure",
+          bucketName: target.bucket,
+          debug: args.debug,
+        });
         throw `Upload failed: ${message}`;
       }
 
       print2("Uploaded.");
+
+      await auditFileTransferActivity({
+        authn,
+        requestId,
+        fileTransferId: target.prefix,
+        action: "file-transfer.upload",
+        outcome: "success",
+        bucketName: target.bucket,
+        debug: args.debug,
+      });
 
       print2(`Preparing to ssh into ${args.destination}...`);
 
@@ -261,10 +283,42 @@ const fileTransferAction = async (
       if (exitCode === SUCCESS_EXIT_CODE) {
         // Success path: the file is on the instance, so clean it from the bucket.
         print2(`Downloaded to ${remotePath}. File transfer succeeded.`);
-        await deleteUploadedObject(s3, target.bucket, uploadKey, args.debug);
+        await auditFileTransferActivity({
+          authn,
+          requestId,
+          fileTransferId: target.prefix,
+          action: "file-transfer.download",
+          outcome: "success",
+          bucketName: target.bucket,
+          debug: args.debug,
+        });
+        const deleteSucceeded = await deleteUploadedObject(
+          s3,
+          target.bucket,
+          uploadKey,
+          args.debug
+        );
+        await auditFileTransferActivity({
+          authn,
+          requestId,
+          fileTransferId: target.prefix,
+          action: "file-transfer.object-delete",
+          outcome: deleteSucceeded ? "success" : "failure",
+          bucketName: target.bucket,
+          debug: args.debug,
+        });
       } else if (exitCode === null) {
         throw `Remote download was interrupted before completing ... re-run the file-transfer command`;
       } else {
+        await auditFileTransferActivity({
+          authn,
+          requestId,
+          fileTransferId: target.prefix,
+          action: "file-transfer.download",
+          outcome: "failure",
+          bucketName: target.bucket,
+          debug: args.debug,
+        });
         throw `Remote download exited with code ${exitCode}`;
       }
 

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -29,6 +29,8 @@ const certSignRequestUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/certificates`;
 const sshAuditUrl = (tenant: string) =>
   `${tenantUrl(tenant)}/integrations/ssh/audit`;
+const fileTransferAuditUrl = (tenant: string) =>
+  `${tenantUrl(tenant)}/integrations/file-transfer/audit`;
 
 const commandUrl = (tenant: string) => `${tenantUrl(tenant)}/command/`;
 export const requestStatusUrl = (tenant: string, requestId: string) =>
@@ -303,6 +305,54 @@ export const auditSshSessionActivity = async (args: {
         requestId,
         action,
         sshSessionId,
+      }),
+    });
+    if (debug) {
+      print2(`Audit log submitted for request: ${requestId}`);
+    }
+  } catch (error) {
+    if (debug) {
+      print2(`Failed to submit audit log for request: ${requestId}`);
+      print2(`Error: ${JSON.stringify(error)}`);
+    }
+  }
+};
+
+export const auditFileTransferActivity = async (args: {
+  authn: Authn;
+  requestId: string;
+  fileTransferId: string;
+  action: `file-transfer.${"download" | "object-delete" | "upload"}`;
+  outcome: "failure" | "success";
+  bucketName: string;
+  debug: boolean | undefined;
+}) => {
+  const {
+    authn,
+    requestId,
+    action,
+    fileTransferId,
+    outcome,
+    bucketName,
+    debug,
+  } = args;
+
+  if (debug) {
+    print2(
+      `Submitting audit log for request: ${requestId}, action: ${action}, fileTransferId: ${fileTransferId}, outcome: ${outcome}, bucketName: ${bucketName}`
+    );
+  }
+
+  try {
+    await authFetch(authn, {
+      url: fileTransferAuditUrl(authn.identity.org.slug),
+      method: "POST",
+      body: JSON.stringify({
+        requestId,
+        action,
+        fileTransferId,
+        outcome,
+        bucketName,
       }),
     });
     if (debug) {

--- a/src/drivers/api.ts
+++ b/src/drivers/api.ts
@@ -324,22 +324,13 @@ export const auditFileTransferActivity = async (args: {
   fileTransferId: string;
   action: `file-transfer.${"download" | "object-delete" | "upload"}`;
   outcome: "failure" | "success";
-  bucketName: string;
   debug: boolean | undefined;
 }) => {
-  const {
-    authn,
-    requestId,
-    action,
-    fileTransferId,
-    outcome,
-    bucketName,
-    debug,
-  } = args;
+  const { authn, requestId, action, fileTransferId, outcome, debug } = args;
 
   if (debug) {
     print2(
-      `Submitting audit log for request: ${requestId}, action: ${action}, fileTransferId: ${fileTransferId}, outcome: ${outcome}, bucketName: ${bucketName}`
+      `Submitting audit log for request: ${requestId}, action: ${action}, fileTransferId: ${fileTransferId}, outcome: ${outcome}`
     );
   }
 
@@ -352,8 +343,8 @@ export const auditFileTransferActivity = async (args: {
         action,
         fileTransferId,
         outcome,
-        bucketName,
       }),
+      maxTimeoutMs: 5_000,
     });
     if (debug) {
       print2(`Audit log submitted for request: ${requestId}`);


### PR DESCRIPTION
**Problem and Change**

The new File Transfer feature didn't have any audit logging. This PR adds audit logs for File Transfer feature. The CLI will not report the outcome back to the backend via a audit logs. Three events are emitted per successful transfer: file-transfer.upload, file-transfer.download, and file-transfer.object-delete. Each carries a requestId, fileTransferId, bucketName, and outcome. All calls are best-effort; failures are silently swallowed so a reporting error never blocks the transfer itself. The download and delete audit calls are awaited (not fire-and-forget) to ensure they complete beforeprocess is terminated.

