### PR TITLE
fix(ci): stop FIPS OpenSSL env leaking into macOS artifact uploads

### DIFF
--- a/.github/workflows/build-standalone.yml
+++ b/.github/workflows/build-standalone.yml
@@ -302,6 +302,14 @@ jobs:
         with:
           name: p0-macOS-${{ env.VERSION }}
           path: build/sea/p0-macOS-${{ env.VERSION }}.pkg
+        env:
+          # The FIPS OpenSSL config (set via GITHUB_ENV above, intended only for the
+          # bundled app's Node) leaks into GitHub's own Node runtime, which now defaults
+          # to Node 24 / OpenSSL 3.5. Pointing that at the FIPS-node 3.1.2 provider breaks
+          # the action's crypto (EVP_DigestSqueeze: method not supported). Unset them here
+          # so the runner's default OpenSSL is used.
+          OPENSSL_CONF: ""
+          OPENSSL_MODULES: ""
       - name: Upload artifact to release
         if: github.event_name != 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
@@ -309,6 +317,8 @@ jobs:
           files: build/sea/p0-macOS-${{ env.VERSION }}.pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENSSL_CONF: ""
+          OPENSSL_MODULES: ""
       - name: Cleanup keychain
         run: |
           security delete-keychain build.keychain

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@p0security/cli",
-  "version": "0.27.7",
+  "version": "0.27.8",
   "description": "Execute infra CLI commands with P0 grants",
   "main": "index.ts",
   "repository": {


### PR DESCRIPTION
## Problem

The `Upload artifact to workflow` step in the macOS build fails with:

```
Error: Failed to CreateArtifact: ... EVP_DigestSqueeze:method not supported ...
```

Failed job: https://github.com/p0-security/p0cli/actions/runs/29273171141/job/87660325313

## Root cause

The FIPS OpenSSL config (`OPENSSL_CONF` / `OPENSSL_MODULES`) is written to `$GITHUB_ENV` for the bundled app's Node runtime, but because it goes through `$GITHUB_ENV` it persists into **every subsequent step** in the job — including the artifact upload steps.

That was harmless while GitHub ran JS actions on Node 20. Now that Node 20 is deprecated, `actions/upload-artifact@v4` runs on the runner's default **Node 24** (OpenSSL 3.5). At startup it reads the leaked env and loads the **FIPS-node OpenSSL 3.1.2** provider/config. The action's digest step calls `EVP_DigestSqueeze` (SHAKE/XOF), which exists in 3.5 but not in the 3.1.2 FIPS module it's pointed at → `method not supported`.

## Fix

Unset `OPENSSL_CONF` / `OPENSSL_MODULES` on the two macOS upload steps so GitHub's own Node uses its default OpenSSL. FIPS remains fully in effect for the build, package, sign, and notarize steps.

This is preferred over the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` workaround, which only defers the issue until Node 20 is fully removed.