### PR TITLE
Read Azure bastion host ID from permission.bastionHost.id (CUS-796)

### DIFF
--- a/src/plugins/azure/__tests__/ssh.test.ts
+++ b/src/plugins/azure/__tests__/ssh.test.ts
@@ -1,0 +1,70 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { azureSshProvider } from "../ssh";
+import { AzureSsh } from "../types";
+import { describe, expect, it } from "vitest";
+
+const BASTION_ID =
+  "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/bastionHosts/bastion-1";
+
+const makeRequest = (permissionOverrides: object): AzureSsh =>
+  ({
+    cliLocalData: { linuxUserName: "alice" },
+    generated: { directoryId: "dir-1", linuxUserName: "alice" },
+    permission: {
+      provider: "azure",
+      destination: "vm-1",
+      resource: {
+        instanceId:
+          "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/vm-1",
+        instanceName: "vm-1",
+        subscriptionName: "sub-1-name",
+        resourceGroupId: "rg-1",
+        subscriptionId: "sub-1",
+        region: "eastus",
+        networkInterfaceIds: [],
+      },
+      ...permissionOverrides,
+    },
+  }) as unknown as AzureSsh;
+
+describe("requestToSsh", () => {
+  it("reads the bastion host ID from permission.bastionHost.id", () => {
+    const request = makeRequest({
+      bastionHost: { id: BASTION_ID, roleId: "role-1" },
+    });
+
+    expect(azureSshProvider.requestToSsh(request).bastionId).toBe(BASTION_ID);
+  });
+
+  it("falls back to the legacy permission.bastionHostId field", () => {
+    const request = makeRequest({ bastionHostId: BASTION_ID });
+
+    expect(azureSshProvider.requestToSsh(request).bastionId).toBe(BASTION_ID);
+  });
+
+  it("prefers bastionHost.id over the legacy field when both are present", () => {
+    const request = makeRequest({
+      bastionHost: { id: BASTION_ID, roleId: "role-1" },
+      bastionHostId: "/legacy/bastion/id",
+    });
+
+    expect(azureSshProvider.requestToSsh(request).bastionId).toBe(BASTION_ID);
+  });
+
+  it("throws a clear error when no bastion host is present", () => {
+    const request = makeRequest({});
+
+    expect(() => azureSshProvider.requestToSsh(request)).toThrow(
+      /bastion host/i
+    );
+  });
+});

--- a/src/plugins/azure/ssh.ts
+++ b/src/plugins/azure/ssh.ts
@@ -9,6 +9,7 @@ This file is part of @p0security/cli
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
 import { isSudoCommand } from "../../commands/shared/ssh";
+import { getContactMessage } from "../../drivers/config";
 import { SshProvider } from "../../types/ssh";
 import { getOperatingSystem } from "../../util";
 import { createTempDirectoryForKeys } from "../ssh/shared";
@@ -225,16 +226,23 @@ export const azureSshProvider: SshProvider<
     };
   },
 
-  requestToSsh: (request) => ({
-    type: "azure",
-    id: "localhost",
-    ...request.cliLocalData,
-    instanceId: request.permission.resource.instanceId,
-    subscriptionId: request.permission.resource.subscriptionId,
-    instanceResourceGroup: request.permission.resource.resourceGroupId,
-    bastionId: request.permission.bastionHostId,
-    directoryId: request.generated.directoryId,
-  }),
+  requestToSsh: (request) => {
+    const bastionId =
+      request.permission.bastionHost?.id ?? request.permission.bastionHostId;
+    if (!bastionId) {
+      throw `The request does not specify an Azure bastion host for this instance. ${getContactMessage()}`;
+    }
+    return {
+      type: "azure",
+      id: "localhost",
+      ...request.cliLocalData,
+      instanceId: request.permission.resource.instanceId,
+      subscriptionId: request.permission.resource.subscriptionId,
+      instanceResourceGroup: request.permission.resource.resourceGroupId,
+      bastionId,
+      directoryId: request.generated.directoryId,
+    };
+  },
 
   unprovisionedAccessPatterns,
   provisionedAccessPatterns,

--- a/src/plugins/azure/types.ts
+++ b/src/plugins/azure/types.ts
@@ -33,7 +33,10 @@ export type AzureSshPermission = CommonSshPermissionSpec & {
   destination: string;
   parent: string | undefined;
   group: string | undefined;
-  bastionHostId: string;
+  bastionHost?: { id: string; roleId: string };
+  /** @deprecated Replaced by `bastionHost.id`; only present on request documents
+   * staged before the backend removed the flat field. */
+  bastionHostId?: string;
   principal: string;
   resource: {
     instanceId: string;


### PR DESCRIPTION
## Problem

`p0 ssh` to any Azure VM behind a bastion currently fails with:

```
knack.util.CLIError: invalid resource ID: undefined
```

The backend removed the legacy flat `bastionHostId` field from Azure SSH session permissions (p0-security/app#6151, merged 2026-07-08); the permission now carries `bastionHost: { id, roleId }` instead. The CLI still read `request.permission.bastionHostId`, which is now `undefined`, so `az network bastion tunnel` was invoked with `--ids undefined` and failed on every attempt. As a side effect, the failure dump printed the full `az --debug` output (the CLI always passes `--debug` to `az` internally), which made the error very noisy.

Fixes [CUS-796](https://linear.app/p0-security/issue/CUS-796/p0-ssh-azure-fails-cli-reads-removed-permissionbastionhostid-field).

## Change

- `requestToSsh` now reads `permission.bastionHost?.id`, falling back to the legacy flat `permission.bastionHostId` for request documents staged before the backend rename.
- If neither field is present, the CLI fails fast with a clear error instead of retrying the tunnel four times with a bogus resource ID.
- `AzureSshPermission` type updated to the new shape (`bastionHost` object; legacy flat field kept as optional and deprecated).

## Testing

- New unit tests for `requestToSsh` covering the new shape, the legacy fallback, precedence when both are present, and the missing-bastion error.
- `yarn test`: 201 tests pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)