### PR TITLE
Retry access propagation when sshd offers auth methods besides publickey (CUS-800)

### DIFF
--- a/src/plugins/azure/__tests__/ssh-jump-host.test.ts
+++ b/src/plugins/azure/__tests__/ssh-jump-host.test.ts
@@ -348,6 +348,19 @@ describe("unprovisionedAccessPatterns", () => {
     expect(matches("Permission denied (publickey).")).toBe(true);
   });
 
+  it("retries on a certificate rejection when the host's sshd offers other auth methods", () => {
+    // sshd lists every enabled auth method, so a VM that also allows password
+    // (or keyboard-interactive) auth reports more than just (publickey).
+    expect(
+      matches("alice@10.0.0.4: Permission denied (publickey,password).")
+    ).toBe(true);
+    expect(
+      matches(
+        "Permission denied (publickey,gssapi-keyex,gssapi-with-mic,password)."
+      )
+    ).toBe(true);
+  });
+
   it("retries when the connection drops before the SSH banner (e.g. jump host unreachable)", () => {
     expect(
       matches("kex_exchange_identification: Connection closed by remote host")

--- a/src/plugins/azure/ssh-jump-host.ts
+++ b/src/plugins/azure/ssh-jump-host.ts
@@ -52,7 +52,9 @@ const jumpHostUnprovisionedAccessPatterns = [
   {
     // The host rejected our certificate. Until the access role finishes propagating to the jump host / target VM,
     // public key auth is refused; retry within the propagation window rather than failing immediately.
-    pattern: /Permission denied \(publickey\)/,
+    // sshd lists every auth method it allows, so a host that also permits password auth
+    // reports "(publickey,password)" — tolerate any method list that includes publickey.
+    pattern: /Permission denied \([^)]*publickey[^)]*\)/,
   },
   {
     // The connection dropped before the SSH banner — e.g. the jump host ProxyCommand exited after a connect timeout,

--- a/src/plugins/google/__tests__/ssh.test.ts
+++ b/src/plugins/google/__tests__/ssh.test.ts
@@ -1,0 +1,31 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { gcpSshProvider } from "../ssh";
+import { describe, expect, it } from "vitest";
+
+describe("unprovisionedAccessPatterns", () => {
+  const matches = (stderr: string) =>
+    gcpSshProvider.unprovisionedAccessPatterns.some((p) =>
+      p.pattern.test(stderr)
+    );
+
+  it("retries on a key rejection while OS Login access propagates", () => {
+    expect(matches("Permission denied (publickey).")).toBe(true);
+  });
+
+  it("retries on a key rejection when the host's sshd offers other auth methods", () => {
+    // sshd lists every enabled auth method, so a VM that also allows password
+    // (or keyboard-interactive) auth reports more than just (publickey).
+    expect(
+      matches("alice@10.0.0.4: Permission denied (publickey,password).")
+    ).toBe(true);
+  });
+});

--- a/src/plugins/google/ssh.ts
+++ b/src/plugins/google/ssh.ts
@@ -41,7 +41,9 @@ const PROPAGATION_TIMEOUT_LIMIT_MS = 2 * 60 * 1000;
  * 7: results in DESTINATION_READ_ERROR and also CONNECTION_CLOSED_MESSAGE
  */
 const unprovisionedAccessPatterns = [
-  { pattern: /Permission denied \(publickey\)/ },
+  // sshd lists every auth method it allows, so a host that also permits password
+  // auth reports "(publickey,password)" — tolerate any list that includes publickey.
+  { pattern: /Permission denied \([^)]*publickey[^)]*\)/ },
   {
     // The output of `sudo -v` when the user is not allowed to run sudo
     pattern: /Sorry, user .+ may not run sudo on .+/,


### PR DESCRIPTION
## Problem

`p0 ssh` to an Azure VM behind a jump host fails permanently when connecting right after a fresh grant, instead of retrying while the access role propagates.

The access-propagation retry loop (up to 180s) is keyed on each provider's `unprovisionedAccessPatterns`. The Azure jump-host provider (and the GCP provider) matched the literal string `Permission denied (publickey)` — but sshd lists **every** auth method it allows, so a VM whose sshd also permits password auth reports:

```
michael.dimitras@permz.us@10.1.0.6: Permission denied (publickey,password).
```

The pattern misses, `isAccessPropagated()` returns true, and the CLI treats the first failed attempt as a completed session — it submits an `ssh.session.end` audit log and exits after a single try. Since Azure RBAC role assignments take up to ~1 minute to propagate to AAD SSH login, connecting immediately after a grant always fails on such VMs. Reproduced twice against a live jump-host setup (grant at 15:04:12, cert minted at 15:04:14, one attempt, immediate termination, zero retries).

Fixes [CUS-800](https://linear.app/p0-security/issue/CUS-800/azure-ssh-propagation-retry-never-triggers-when-sshd-reports).

## Change

Loosen the pattern to tolerate any parenthesized method list that includes `publickey`:

```
/Permission denied \([^)]*publickey[^)]*\)/
```

Applied to `src/plugins/azure/ssh-jump-host.ts` and `src/plugins/google/ssh.ts` (same latent bug; GCP OS Login VMs are usually publickey-only, which is why it hasn't bitten there yet).

## Testing

- New pattern tests: jump-host provider retries on `(publickey,password)` and `(publickey,gssapi-keyex,gssapi-with-mic,password)`; GCP provider retries on `(publickey,password)`. Both written first and observed failing against the old patterns.
- Full suite: 302 tests pass across 37 files; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)