### PR TITLE
fix(ssh): treat a clean sudo pre-test exit as access propagated

### DIFF
--- a/src/plugins/ssh/__tests__/index.test.ts
+++ b/src/plugins/ssh/__tests__/index.test.ts
@@ -324,3 +324,83 @@ describe("proxyCommand receives setup/setupProxy credentials", () => {
     );
   });
 });
+
+// A `--sudo` session runs a `sudo -nv` pre-test to wait for the sudoers grant to
+// propagate. The Azure providers classify propagation from stderr:
+// `Sorry, user ... may not run sudo` means "still propagating" and
+// `sudo: a password is required` means "provisioned". A user granted passwordless
+// (NOPASSWD) sudo hits neither branch — `sudo -nv` just exits 0 with no output —
+// so the pre-test must treat a clean exit as "access propagated" instead of
+// looping until the propagation timeout (the "stuck pre-testing" bug).
+describe("sudo pre-test access propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Mirrors the Azure providers: sudo commands are pre-tested with `sudo -nv`.
+  // A negative propagation timeout puts endTime in the past, so a pre-test that
+  // is *not* recognized as propagated fails immediately instead of retrying —
+  // letting us assert the exit-0 short-circuit without waiting on a real timer.
+  const sudoProvider = (propagationTimeoutMs: number) =>
+    ({
+      cloudProviderLogin: vi.fn(async () => undefined),
+      proxyCommand: vi.fn(() => ["nc", "localhost", "22"]),
+      reproCommands: () => undefined,
+      preTestAccessPropagationArgs: (cmdArgs: any) => ({
+        ...cmdArgs,
+        command: "sudo",
+        arguments: ["-nv"],
+      }),
+      propagationTimeoutMs,
+    }) as any;
+
+  // type: "azure" (no jump host) makes spawnSshNode resolve the real
+  // azureBastionSshProvider internally, whose provisionedAccessPatterns only
+  // match `sudo: a password is required` — never emitted for NOPASSWD sudo.
+  const request = {
+    type: "azure",
+    id: "localhost",
+    linuxUserName: "user",
+  } as any;
+
+  const runSudoSsh = (sshProvider: any) =>
+    sshOrScp({
+      authn: {} as any,
+      request,
+      requestId: "req-1",
+      cmdArgs: { sudo: true, destination: "my-vm", arguments: [] } as any,
+      privateKey: "pk",
+      sshProvider,
+      sshHostKeys: undefined,
+    });
+
+  it("proceeds to the session when a passwordless `sudo -nv` pre-test exits 0", async () => {
+    // Every spawned child exits 0 with no stderr, mimicking NOPASSWD sudo where
+    // `sudo -nv` succeeds silently. Without treating exit 0 as propagated, the
+    // past-due endTime would make this reject as "did not propagate".
+    mockSpawn.mockImplementation(() => makeFakeChild());
+
+    await expect(runSudoSsh(sudoProvider(-1))).resolves.toBe(0);
+
+    // Both the pre-test probe and the real session ran.
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    const [preTestCommand, preTestArgs] = mockSpawn.mock.calls[0]!;
+    expect(preTestCommand).toBe("ssh");
+    expect((preTestArgs as string[]).join(" ")).toContain('sudo "-nv"');
+  });
+
+  it("keeps failing when the user is still not a sudoer after the window closes", async () => {
+    // While the grant is still propagating, `sudo -nv` prints the not-a-sudoer
+    // message and exits non-zero; with endTime in the past this is terminal.
+    mockSpawn.mockImplementation(() =>
+      makeFailingChild("Sorry, user miguel may not run sudo on my-vm.\n", 1)
+    );
+
+    await expect(runSudoSsh(sudoProvider(-1))).rejects.toMatch(
+      /did not propagate/
+    );
+
+    // Only the pre-test ran; the session is never reached.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/plugins/ssh/index.ts
+++ b/src/plugins/ssh/index.ts
@@ -286,9 +286,21 @@ async function spawnSshNode(
       exitListener.unref();
       cleanupAllListeners();
 
+      // A pre-test probe that exits cleanly has itself succeeded: `sudo -nv`
+      // returns 0 when the user already holds (passwordless, i.e. NOPASSWD, or
+      // freshly-cached) sudo. That is an unambiguous signal that access has
+      // propagated, even though the provider's `provisionedAccessPatterns`
+      // message (`sudo: a password is required`) is only emitted when a password
+      // would be required. Without treating a clean exit as propagated, users
+      // with NOPASSWD sudo keep retrying the pre-test until the propagation
+      // timeout elapses, so the command appears to hang before finally failing.
+      const accessPropagated =
+        isAccessPropagated() ||
+        (!!options.isAccessPropagationPreTest && code === 0);
+
       // In the case of ephemeral AccessDenied exceptions due to unpropagated
       // permissions, continually retry access until success
-      if (!isAccessPropagated()) {
+      if (!accessPropagated) {
         if (options.endTime < Date.now()) {
           const knownError = connectionErrorMessage();
           reject(
@@ -339,8 +351,9 @@ async function spawnSshNode(
         }
       }
 
-      if (options.isAccessPropagationPreTest && isAccessPropagated()) {
-        // override the exit code to 0 if the expected error was found, this means access is ready.
+      if (options.isAccessPropagationPreTest && accessPropagated) {
+        // override the exit code to 0 if the expected error was found (or the
+        // probe already exited 0), this means access is ready.
         resolve(0);
         return;
       }


### PR DESCRIPTION
**Problem**

A `--sudo` SSH/SCP session first runs a `sudo -nv` pre-test and waits for the sudoers grant to propagate on the target host. The propagation guard decides readiness only from stderr patterns — for providers with `provisionedAccessPatterns` (e.g. Azure), it waits for `sudo: a password is required`. When the user holds passwordless (NOPASSWD) sudo, `sudo -nv` succeeds silently with exit code 0 and no output, so no pattern ever matches. The CLI keeps re-running the pre-test until the propagation window closes, appearing to hang before failing with "Access did not propagate ... in time" — even though access was ready the whole time.

**Change**

Treat a clean exit (code 0) from the pre-test probe as an unambiguous signal that access has propagated: `sudo -nv` returning 0 means the user already holds sudo. The check is scoped to the pre-test only, so the normal session retry path is unaffected.

Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

Automated: added regression tests covering the NOPASSWD (exit 0) pre-test case and confirming that a still-propagating, non-sudoer probe still fails once the propagation window closes. `yarn vitest run src/plugins/ssh/__tests__/index.test.ts` — 9/9 passing.

Risk is limited to the pre-test path: a probe that exits non-zero still follows the existing pattern-matching and retry logic unchanged.

**Tracking (optional)**

CUS-801