### PR TITLE
add file-transfer e2e tests

### DIFF
--- a/src/e2e/README.md
+++ b/src/e2e/README.md
@@ -6,19 +6,22 @@ Automated end-to-end tests that exercise the real CLI against a live P0 organiza
 yarn e2e
 ```
 
-Target a single cloud provider's flow by passing its spec file (see "What it does" below for the file names):
+Target a single flow by passing its spec file (see "What it does" below for the file names):
 
 ```
 yarn e2e src/e2e/ssh-aws.e2e.ts
 yarn e2e src/e2e/ssh-azure.e2e.ts
 yarn e2e src/e2e/ssh-gcloud.e2e.ts
+yarn e2e src/e2e/file-transfer-aws.e2e.ts
 ```
 
-Global setup and login still run first; only that provider's node needs to be configured (see Configuration below).
+Global setup and login still run first; only that flow's node needs to be configured (see Configuration below).
 
 ## What it does
 
 Global setup (before any test) smoke-tests the existing build with `p0 --version` and runs `p0 login p0-e2e` — a failure of either step aborts the whole run. Run `yarn build` yourself first; the suite does not build for you.
+
+### The ssh flow
 
 There's one ssh flow spec per cloud provider — `ssh-aws.e2e.ts`, `ssh-azure.e2e.ts`, `ssh-gcloud.e2e.ts` — each driving its configured node through the whole access lifecycle, in order. They share their step logic (`ssh-flow.ts`) but are separate files so you can run one provider independently, e.g. `yarn e2e src/e2e/ssh-aws.e2e.ts`. Each step runs a remote command instead of an interactive shell, so its session ends on its own once the connection succeeds:
 
@@ -36,6 +39,17 @@ Include <P0_PATH>/ssh/configs/*.config
 ```
 
 (`<P0_PATH>` is `~/.p0` or `~/.p0-<env>` depending on your CLI environment; extra `ssh-resolve` flags such as `--debug` are fine, but the `Match` line must come before the `Include`.)
+
+### The file-transfer flow
+
+`file-transfer-aws.e2e.ts` is a separate suite for `p0 file-transfer`, which only supports AWS destinations today. It targets the same AWS node as the ssh flow (`P0_E2E_AWS_NODE`) and runs, in order:
+
+1. `p0 ls file-transfer session destination --json` — confirms the configured node is visible to the e2e user before requesting access
+2. `p0 file-transfer <missing-file> <node-id>` — asserts a nonexistent source path fails fast, before any access request is made
+3. `p0 file-transfer <file> <node-id>` — uploads a marker file through the temporary S3 bucket, waits for approval and propagation, and downloads it onto the instance (this implicitly provisions ssh access to the node)
+4. `p0 ssh <node-id> cat <remote-path>` — verifies the file content actually landed on the instance, reusing the grant from step 3
+
+The suite removes the remote file (best effort) when it finishes, logging a warning if that cleanup fails. Run it together with the ssh flows or on its own — each suite requests its own access.
 
 At the end of the run the suite prints a reminder: **please revoke all access granted to the e2e user before running the suite again**, so the next run requests access from scratch.
 

--- a/src/e2e/file-transfer-aws.e2e.ts
+++ b/src/e2e/file-transfer-aws.e2e.ts
@@ -1,0 +1,159 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import {
+  AWS_TARGET,
+  E2E_REASON,
+  LsDestinationItem,
+  lsItemMatchesNode,
+  runP0,
+  SUCCESS_EXIT_CODE,
+  uniqueMarker,
+} from "./harness";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+// `p0 file-transfer` only supports AWS destinations today, so this suite is a
+// single spec instead of the per-provider flow/spec split the ssh suite uses.
+// It targets the ssh suite's AWS node (P0_E2E_AWS_NODE): the transfer
+// destination is the same instance, and the flow implicitly provisions ssh
+// access to it.
+const { provider, lsProvider, node } = AWS_TARGET;
+
+describe.skipIf(!node)("p0 file-transfer flow (aws)", () => {
+  const marker = uniqueMarker("file-transfer");
+  const localDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "p0-e2e-file-transfer-")
+  );
+  // The marker doubles as the file name, so the remote path is unique per run
+  // and the downloaded content is greppable.
+  const sourcePath = path.join(localDir, `${marker}.txt`);
+
+  /** Remote path reported by the transfer step; later steps verify and clean
+   * up that exact path. */
+  let remotePath: string | undefined;
+
+  afterAll(async () => {
+    fs.rmSync(localDir, { recursive: true, force: true });
+    // Best-effort remote cleanup; not part of the assertion, so a failure
+    // only logs a warning.
+    if (remotePath) {
+      const cleanup = await runP0(
+        [
+          "ssh",
+          node!,
+          "--provider",
+          provider,
+          "--reason",
+          E2E_REASON,
+          "rm",
+          "-f",
+          remotePath,
+        ],
+        { timeoutMs: 5 * 60_000 }
+      );
+      if (cleanup.code !== SUCCESS_EXIT_CODE) {
+        process.stderr.write(
+          `[e2e] warning: failed to remove ${remotePath} from ${node}; remove it manually\n${cleanup.output}\n`
+        );
+      }
+    }
+  });
+
+  it("finds the configured node via p0 ls before requesting access", async () => {
+    const result = await runP0(
+      [
+        "ls",
+        "file-transfer",
+        "session",
+        "destination",
+        "--json",
+        "--size",
+        "500",
+      ],
+      { timeoutMs: 2 * 60_000 }
+    );
+    expect(result.code, result.output).toBe(SUCCESS_EXIT_CODE);
+
+    const { items } = JSON.parse(result.stdout) as {
+      items: LsDestinationItem[];
+    };
+    const found = items.some((item) =>
+      lsItemMatchesNode(item, lsProvider, node!)
+    );
+    expect(
+      found,
+      `${node} was not found among ${lsProvider} destinations in \`p0 ls file-transfer session destination\`; is it visible to the e2e user?\n${result.output}`
+    ).toBe(true);
+  });
+
+  it("fails fast when the source file does not exist", async () => {
+    // The source check runs before the access request, so a bad path must
+    // fail quickly without spending an approval.
+    const result = await runP0(
+      [
+        "file-transfer",
+        path.join(localDir, "does-not-exist.txt"),
+        node!,
+        "--reason",
+        E2E_REASON,
+      ],
+      { timeoutMs: 2 * 60_000 }
+    );
+    expect(result.code, result.output).not.toBe(SUCCESS_EXIT_CODE);
+    expect(result.output).toContain("Source file not found");
+  });
+
+  it("requests access with p0 file-transfer and puts the file on the instance", async () => {
+    fs.writeFileSync(sourcePath, `${marker}\n`);
+
+    const result = await runP0([
+      "file-transfer",
+      sourcePath,
+      node!,
+      "--reason",
+      E2E_REASON,
+    ]);
+
+    expect(result.code, result.output).toBe(SUCCESS_EXIT_CODE);
+    expect(result.output).toContain("File transfer succeeded");
+
+    // "Downloaded to /home/<user>/<file>. File transfer succeeded." names the
+    // remote path the file landed on.
+    remotePath = result.output.match(
+      /Downloaded to (\S+)\. File transfer succeeded/
+    )?.[1];
+    expect(
+      remotePath,
+      `the transfer did not report a remote path\n${result.output}`
+    ).toBeTruthy();
+  });
+
+  it("verifies the remote file content over p0 ssh", async () => {
+    // Reuses the ssh grant the transfer step provisioned.
+    expect(remotePath, "the transfer step did not run or failed").toBeTruthy();
+
+    const result = await runP0([
+      "ssh",
+      node!,
+      "--provider",
+      provider,
+      "--reason",
+      E2E_REASON,
+      "cat",
+      remotePath!,
+    ]);
+
+    expect(result.code, result.output).toBe(SUCCESS_EXIT_CODE);
+    expect(result.output).toContain(marker);
+  });
+});

--- a/src/e2e/harness.ts
+++ b/src/e2e/harness.ts
@@ -65,6 +65,40 @@ export const GCLOUD_TARGET = sshTarget(
   process.env.P0_E2E_GCLOUD_NODE
 );
 
+/** POSIX success exit code, for readable assertions on {@link CliResult}. */
+export const SUCCESS_EXIT_CODE = 0;
+
+/** Item shape of `p0 ls <command> session destination --json` output.
+ *
+ * Beyond the `key`/`value` listing pair, the backend reports the other
+ * identifiers a destination is known by — its cloud instance ID, display
+ * name, and any alternative hostnames. A node matcher should accept all of
+ * them so the configured node ID can be any identifier a user could pass to
+ * `p0 ssh`. */
+export type LsDestinationItem = {
+  provider: string;
+  key: string;
+  value: string;
+  instanceId?: string;
+  name?: string;
+  alternativeNames?: string[];
+};
+
+/** True when an ls destination item refers to the configured node for the
+ * given cloud (matched by key, value, instance ID, name, or alternative
+ * name). */
+export const lsItemMatchesNode = (
+  item: LsDestinationItem,
+  lsProvider: string,
+  node: string
+) =>
+  item.provider === lsProvider &&
+  (item.key === node ||
+    item.value === node ||
+    item.instanceId === node ||
+    item.name === node ||
+    (item.alternativeNames?.includes(node) ?? false));
+
 export type CliResult = {
   code: number | null;
   stdout: string;

--- a/src/e2e/ssh-flow.ts
+++ b/src/e2e/ssh-flow.ts
@@ -10,9 +10,12 @@ You should have received a copy of the GNU General Public License along with @p0
 **/
 import {
   E2E_REASON,
+  LsDestinationItem,
+  lsItemMatchesNode,
   runCommand,
   runP0,
   SshTarget,
+  SUCCESS_EXIT_CODE,
   uniqueMarker,
 } from "./harness";
 import * as fs from "node:fs";
@@ -63,27 +66,13 @@ export const describeSshFlow = ({ provider, lsProvider, node }: SshTarget) => {
         ["ls", "ssh", "session", "destination", "--json", "--size", "500"],
         { timeoutMs: 2 * 60_000 }
       );
-      expect(result.code, result.output).toBe(0);
+      expect(result.code, result.output).toBe(SUCCESS_EXIT_CODE);
 
       const { items } = JSON.parse(result.stdout) as {
-        items: {
-          provider: string;
-          key: string;
-          value: string;
-          instanceId?: string;
-          name?: string;
-          alternativeNames?: string[];
-        }[];
+        items: LsDestinationItem[];
       };
-      const found = items.some(
-        (item) =>
-          item.provider === lsProvider &&
-          (item.key === node ||
-            item.value === node ||
-            item.instanceId === node ||
-            item.name === node ||
-            // eslint is having a hard time realizing that node is not null here.
-            (!!node && item.alternativeNames?.includes(node)))
+      const found = items.some((item) =>
+        lsItemMatchesNode(item, lsProvider, node!)
       );
       expect(
         found,
@@ -103,7 +92,7 @@ export const describeSshFlow = ({ provider, lsProvider, node }: SshTarget) => {
         marker,
       ]);
 
-      expect(result.code, result.output).toBe(0);
+      expect(result.code, result.output).toBe(SUCCESS_EXIT_CODE);
       expect(result.output).toContain(marker);
     });
 
@@ -120,7 +109,7 @@ export const describeSshFlow = ({ provider, lsProvider, node }: SshTarget) => {
         "whoami",
       ]);
 
-      expect(result.code, result.output).toBe(0);
+      expect(result.code, result.output).toBe(SUCCESS_EXIT_CODE);
       expect(result.output).toContain("root");
     });
 
@@ -136,7 +125,7 @@ export const describeSshFlow = ({ provider, lsProvider, node }: SshTarget) => {
         "--reason",
         E2E_REASON,
       ]);
-      expect(upload.code, upload.output).toBe(0);
+      expect(upload.code, upload.output).toBe(SUCCESS_EXIT_CODE);
 
       const download = await runP0([
         "scp",
@@ -147,7 +136,7 @@ export const describeSshFlow = ({ provider, lsProvider, node }: SshTarget) => {
         "--reason",
         E2E_REASON,
       ]);
-      expect(download.code, download.output).toBe(0);
+      expect(download.code, download.output).toBe(SUCCESS_EXIT_CODE);
 
       expect(fs.readFileSync(downloadPath, "utf8")).toBe(`${marker}\n`);
     });
@@ -159,7 +148,7 @@ export const describeSshFlow = ({ provider, lsProvider, node }: SshTarget) => {
       const sshMarker = uniqueMarker(`flow-${provider}-native-ssh`);
       const ssh = await runCommand("ssh", [node!, `echo ${sshMarker}`]);
 
-      expect(ssh.code, ssh.output).toBe(0);
+      expect(ssh.code, ssh.output).toBe(SUCCESS_EXIT_CODE);
       expect(ssh.output).toContain(sshMarker);
     });
   });


### PR DESCRIPTION
**Problem**

`p0 file-transfer` is a recently added command that moves a local file onto an AWS instance through a temporary S3 bucket, but nothing exercised it end to end — the existing e2e suite only covers the ssh flows. Regressions in the transfer path (access provisioning, S3 upload, remote download) would only surface when a user ran the command against real infrastructure.

**Change**

Adds a file-transfer e2e suite, scaffolded on the existing ssh e2e conventions. Since the command only supports AWS destinations today, it is a single spec (`src/e2e/file-transfer-aws.e2e.ts`) targeting the same node as the AWS ssh flow (`P0_E2E_AWS_NODE`), running in order:

1. `p0 ls file-transfer session destination --json` — confirms the node is visible before requesting access
2. `p0 file-transfer` with a nonexistent source — asserts it fails fast, before any access request
3. `p0 file-transfer` with a marker file — asserts the full upload/approval/download path succeeds
4. `p0 ssh ... cat <remote-path>` — verifies the content actually landed on the instance, reusing the grant from step 3

The ls-destination matching logic is extracted from `ssh-flow.ts` into the shared harness so both suites use it, and the e2e README documents the new flow.

Check off any of the following areas of code that are modified:

- [ ] authentication / authorization
- [ ] workflow
- [ ] lifecycle SDK
- [ ] datastore abstractions

**Type of Change**

<!-- Mark the relevant option(s) -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (code changes that neither fix bugs nor add features)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

`yarn lint:types`, `yarn lint:code`, and `prettier --check src/e2e/` all pass. The new spec is only picked up by the e2e config (`src/e2e/**/*.e2e.ts`), so the unit test run (`**/*.test.ts`) is unaffected; no production code is touched.

The suite itself has not yet been run against the live e2e org (it requires a login session, a configured AWS node, and auto-approved access) — that first run is the remaining validation step.

**Tracking (optional)**

CUS-602

**Implementation (optional)**

- Kept the suite as one self-contained spec instead of the flow/spec split the ssh suite uses, since only one provider is supported; a comment notes to split like `ssh-flow.ts` if more providers arrive.
- Step 1 assumes the backend supports `p0 ls file-transfer session destination`, mirroring how the provision request structures its arguments; if the backend doesn't implement that listing, that step is the one to adjust.

**Attachments (optional)**

N/A

