### PR TITLE
fix rdp for azure

### DIFF
--- a/src/commands/rdp.ts
+++ b/src/commands/rdp.ts
@@ -40,6 +40,12 @@ export const rdpCommand = (yargs: yargs.Argv) =>
           describe: "Configure the RDP session before connecting",
           default: false,
         })
+        .option("admin", {
+          type: "boolean",
+          describe:
+            "Connect using the target VM's local administrator credentials instead of Microsoft Entra ID",
+          default: false,
+        })
         .usage("$0 rdp <destination>")
         .epilogue(
           `Connect to a Windows virtual machine via RDP through Azure Bastion Host.

--- a/src/plugins/azure/__tests__/rdp.test.ts
+++ b/src/plugins/azure/__tests__/rdp.test.ts
@@ -1,0 +1,127 @@
+/** Copyright © 2024-present P0 Security
+
+This file is part of @p0security/cli
+
+@p0security/cli is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3 of the License.
+
+@p0security/cli is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
+**/
+import { AzureRdpRequest } from "../../../types/rdp";
+import { PermissionRequest } from "../../../types/request";
+import { azBastionRdpCommand, classifyBastionRdpError } from "../rdp";
+import { describe, expect, it } from "vitest";
+
+const REQUEST = {
+  permission: {
+    bastionHost: {
+      id: "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Network/bastionHosts/my-bastion",
+      roleId: "role-def-id",
+    },
+    resource: {
+      instanceId:
+        "/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/my-vm",
+      instanceName: "my-vm",
+      subscriptionId: "sub-1",
+      directoryId: "dir-1",
+      region: "eastus",
+      networkInterface: { id: "nic-1", subnetId: "subnet-1" },
+    },
+  },
+} as unknown as PermissionRequest<AzureRdpRequest>;
+
+// The bastion host is now identified by a resource ID (`bastionHost.id`),
+// matching the SSH bastion/tunnel flow (`az network bastion tunnel --ids
+// ...`), rather than the old --name/--resource-group pair the backend no
+// longer sends.
+describe("azBastionRdpCommand", () => {
+  it("identifies the bastion host by --ids and the target VM by --target-resource-id", () => {
+    const { command, args } = azBastionRdpCommand(REQUEST, {});
+
+    expect(command).toBe("az");
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--ids",
+        REQUEST.permission.bastionHost.id,
+        "--target-resource-id",
+        REQUEST.permission.resource.instanceId,
+      ])
+    );
+  });
+
+  it("authenticates with Entra ID (AAD) by default", () => {
+    const { args } = azBastionRdpCommand(REQUEST, {});
+    expect(args).toEqual(expect.arrayContaining(["--auth-type", "aad"]));
+  });
+
+  it("omits --auth-type aad for an admin (local-credential) session", () => {
+    const adminRequest = {
+      permission: { ...REQUEST.permission, admin: true },
+    } as PermissionRequest<AzureRdpRequest>;
+
+    const { args } = azBastionRdpCommand(adminRequest, {});
+    expect(args).not.toContain("--auth-type");
+    expect(args).not.toContain("aad");
+  });
+
+  it("appends --configure and --debug only when requested", () => {
+    const bare = azBastionRdpCommand(REQUEST, {});
+    expect(bare.args).not.toContain("--configure");
+    expect(bare.args).not.toContain("--debug");
+
+    const full = azBastionRdpCommand(REQUEST, {
+      configure: true,
+      debug: true,
+    });
+    expect(full.args).toEqual(
+      expect.arrayContaining(["--configure", "--debug"])
+    );
+  });
+
+  // az's --debug output has been observed to include live bearer tokens in
+  // cleartext, so it must never be passed unless the user explicitly asked
+  // p0 rdp for --debug themselves (CX-Bastion-RDP-500).
+  it("never passes --debug to az unless the user passed --debug to p0 rdp", () => {
+    expect(azBastionRdpCommand(REQUEST, {}).args).not.toContain("--debug");
+    expect(azBastionRdpCommand(REQUEST, { debug: false }).args).not.toContain(
+      "--debug"
+    );
+  });
+});
+
+// Without this classifier, a failed `az network bastion rdp` surfaces only
+// the generic, code-less "Sub-process exited with code" (exec() in
+// util.ts). az prints its own failures at ERROR level regardless of
+// --debug, so the classifier works even on a non-debug p0 rdp invocation —
+// it just has fewer surrounding DEBUG: lines to filter past when it does.
+describe("classifyBastionRdpError", () => {
+  it("extracts the actionable line from az's stderr", () => {
+    const stderr = [
+      "DEBUG: cli.knack.cli: Event: Cli.PreExecute []",
+      'DEBUG: urllib3.connectionpool: https://bst-....bastion.azure.com:443 "GET /api/rdpfile?..." 500 None',
+      "ERROR: cli.azure.cli.core.azclierror: Request failed with error: Unexpected internal error",
+      "ERROR: az_command_data_logger: Request failed with error: Unexpected internal error",
+      "INFO: az_command_data_logger: exit code: 1",
+    ].join("\n");
+
+    const message = classifyBastionRdpError(stderr);
+    expect(message).toContain('"Unexpected internal error"');
+    expect(message).toContain("azure-cli/issues/21030");
+    expect(message).toContain("--admin");
+  });
+
+  it("surfaces a different Bastion service error message plainly, without the known-issue framing", () => {
+    const stderr =
+      "ERROR: az_command_data_logger: Request failed with error: Target resource not found";
+    expect(classifyBastionRdpError(stderr)).toBe(
+      "Azure Bastion rejected the RDP request: Target resource not found"
+    );
+  });
+
+  it("returns undefined when stderr contains no recognizable Bastion service error", () => {
+    expect(
+      classifyBastionRdpError("DEBUG: some unrelated noise\n")
+    ).toBeUndefined();
+  });
+});

--- a/src/plugins/azure/__tests__/rdp.test.ts
+++ b/src/plugins/azure/__tests__/rdp.test.ts
@@ -8,10 +8,31 @@ This file is part of @p0security/cli
 
 You should have received a copy of the GNU General Public License along with @p0security/cli. If not, see <https://www.gnu.org/licenses/>.
 **/
+import { print2 } from "../../../drivers/stdio";
 import { AzureRdpRequest } from "../../../types/rdp";
 import { PermissionRequest } from "../../../types/request";
-import { azBastionRdpCommand, classifyBastionRdpError } from "../rdp";
-import { describe, expect, it } from "vitest";
+import { exec } from "../../../util";
+import {
+  azBastionRdpCommand,
+  azureRdpProvider,
+  classifyBastionRdpError,
+  sanitizeAzureDebugOutput,
+} from "../rdp";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../drivers/stdio", () => ({
+  print2: vi.fn(),
+}));
+
+// Spread the original so the real osSafeCommand (used by azBastionRdpCommand)
+// keeps working; only stub the subprocess execution.
+vi.mock("../../../util", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../util")>()),
+  exec: vi.fn(),
+}));
+
+const mockExec = vi.mocked(exec);
+const mockPrint2 = vi.mocked(print2);
 
 const REQUEST = {
   permission: {
@@ -123,5 +144,60 @@ describe("classifyBastionRdpError", () => {
     expect(
       classifyBastionRdpError("DEBUG: some unrelated noise\n")
     ).toBeUndefined();
+  });
+});
+
+// az's --debug output has been observed to include live bearer tokens in
+// cleartext on DEBUG-level lines. Even when the user explicitly asked p0 rdp
+// for --debug, that raw stderr must never be echoed to the terminal as-is.
+const MOCK_BEARER_TOKEN =
+  "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+
+describe("sanitizeAzureDebugOutput", () => {
+  it("redacts a bearer token even on an ERROR line", () => {
+    const stderr = `ERROR: cli.azure.cli.core.azclierror: Response ${MOCK_BEARER_TOKEN}`;
+    const sanitized = sanitizeAzureDebugOutput(stderr);
+    expect(sanitized).not.toContain(MOCK_BEARER_TOKEN);
+    expect(sanitized).toContain("[REDACTED]");
+  });
+
+  it("drops DEBUG/INFO lines (where az's bearer tokens are actually logged), keeping ERROR/WARNING context", () => {
+    const stderr = [
+      "DEBUG: cli.knack.cli: Event: Cli.PreExecute []",
+      `DEBUG: urllib3.connectionpool: Response ${MOCK_BEARER_TOKEN}`,
+      "ERROR: az_command_data_logger: Request failed with error: Unexpected internal error",
+      "INFO: az_command_data_logger: exit code: 1",
+    ].join("\n");
+
+    const sanitized = sanitizeAzureDebugOutput(stderr);
+    expect(sanitized).not.toContain(MOCK_BEARER_TOKEN);
+    expect(sanitized).not.toContain("DEBUG:");
+    expect(sanitized).not.toContain("INFO:");
+    expect(sanitized).toContain(
+      "ERROR: az_command_data_logger: Request failed with error: Unexpected internal error"
+    );
+  });
+});
+
+describe("azureRdpProvider.spawnConnection debug logging", () => {
+  it("never prints a raw bearer token to the terminal, even with --debug on a failed connection", async () => {
+    mockExec.mockRejectedValueOnce(
+      Object.assign(new Error("Sub-process exited with code"), {
+        code: 1,
+        stdout: "",
+        stderr: [
+          "DEBUG: cli.knack.cli: Event: Cli.PreExecute []",
+          `DEBUG: urllib3.connectionpool: Response ${MOCK_BEARER_TOKEN}`,
+          "ERROR: az_command_data_logger: Request failed with error: Unexpected internal error",
+        ].join("\n"),
+      })
+    );
+
+    await expect(
+      azureRdpProvider.spawnConnection(REQUEST, { debug: true })
+    ).rejects.toThrow();
+
+    const printedText = mockPrint2.mock.calls.map((call) => call[0]).join("\n");
+    expect(printedText).not.toContain(MOCK_BEARER_TOKEN);
   });
 });

--- a/src/plugins/azure/rdp.ts
+++ b/src/plugins/azure/rdp.ts
@@ -14,27 +14,76 @@ import { PermissionRequest } from "../../types/request";
 import { exec, osSafeCommand } from "../../util";
 import { azSetSubscription } from "./auth";
 
-const azBastionRdpCommand = (
+export const azBastionRdpCommand = (
   request: PermissionRequest<AzureRdpRequest>,
   options: { configure?: boolean; debug?: boolean }
 ) => {
   const { configure, debug } = options;
-  const { bastionName, bastionRg, instanceId } = request.permission.resource;
+  const { admin, bastionHost, resource } = request.permission;
   return osSafeCommand("az", [
     "network",
     "bastion",
     "rdp",
-    "--name",
-    bastionName,
-    "--resource-group",
-    bastionRg,
+    "--ids",
+    bastionHost.id,
     "--target-resource-id",
-    instanceId,
-    "--auth-type",
-    "aad",
+    resource.instanceId,
+    // Entra ID (AAD) auth is only for the target VM's AAD-joined identity.
+    // Admin sessions connect with the VM's local administrator credentials
+    // instead, so --auth-type aad must be omitted (the native RDP client
+    // then prompts for local credentials, same as connecting outside
+    // Bastion). TODO: verify against az CLI behavior once available —
+    // `az network bastion rdp --auth-type` doesn't document its accepted
+    // values the way `bastion ssh --auth-type` does (password/ssh-key/AAD).
+    ...(admin ? [] : ["--auth-type", "aad"]),
     ...(configure ? ["--configure"] : []),
+    // Only pass --debug to az when the user asked p0 rdp for --debug. az's
+    // --debug output has included live bearer tokens in cleartext (a real
+    // `Response eyJ...` access token was observed in one capture) — capturing
+    // that into `error.stderr` on every attempt, not just when the user
+    // opted into verbose output, would be a real secret-exposure risk.
+    // Unnecessary too: classifyBastionRdpError below only needs the
+    // `ERROR: ...` lines az prints on failure regardless of --debug — only
+    // the DEBUG: lines (and the token) are gated behind it.
     ...(debug ? ["--debug"] : []),
   ]);
+};
+
+/** Matches the one actionable line the Azure Bastion CLI extension raises
+ * when the Bastion *service* itself rejects the request
+ * (azext_bastion/custom.py: handle_error_response). az prints this at ERROR
+ * level, so it's present in stderr regardless of --debug. Surfacing just
+ * this turns an opaque failure into an actionable one — the raw thrown error
+ * otherwise only ever says the generic, code-less "Sub-process exited with
+ * code" (see exec() in util.ts, whose Error message never interpolates the
+ * actual exit code). */
+const BASTION_SERVICE_ERROR_PATTERN = /Request failed with error: (.+)/;
+
+/** A known, longstanding Azure Bastion service-side failure generating an
+ * RDP file for an AAD-authenticated (--auth-type aad / enablerdsaad=true)
+ * session. Reported upstream with no confirmed root cause or fix:
+ * https://github.com/Azure/azure-cli/issues/21030
+ * https://github.com/Azure/azure-cli/issues/28148
+ * Not something p0 can resolve client-side. */
+const BASTION_UNEXPECTED_INTERNAL_ERROR = "Unexpected internal error";
+
+export const classifyBastionRdpError = (stderr: string): string | undefined => {
+  const match = stderr.match(BASTION_SERVICE_ERROR_PATTERN);
+  if (!match?.[1]) return undefined;
+  const message = match[1].trim();
+
+  if (message === BASTION_UNEXPECTED_INTERNAL_ERROR) {
+    return (
+      `Azure Bastion rejected the RDP request with "${message}". This is a known, longstanding Azure ` +
+      `Bastion service-side failure when generating an AAD-authenticated RDP session ` +
+      `(see github.com/Azure/azure-cli/issues/21030 and /issues/28148) — it is not something p0 can fix ` +
+      `client-side. Try again in a few minutes, retry with --admin to connect with the VM's local ` +
+      `credentials instead of Entra ID, or ask your Azure admin to verify the Bastion host's and target ` +
+      `VM's Entra ID sign-in configuration.`
+    );
+  }
+
+  return `Azure Bastion rejected the RDP request: ${message}`;
 };
 
 export const azureRdpProvider = {
@@ -71,15 +120,21 @@ export const azureRdpProvider = {
 
       await exec(command, args, { check: true });
     } catch (error: any) {
+      const stderr: string | undefined = error?.stderr;
+      const classified = stderr && classifyBastionRdpError(stderr);
+
       if (debug) {
-        print2(`Azure Bastion RDP command failed: ${error.message}`);
-        if (error.stderr) {
+        print2(
+          `Azure Bastion RDP command failed (exit code ${error?.code ?? "unknown"}).`
+        );
+        if (stderr) {
           print2("Error details:");
-          print2(error.stderr);
+          print2(stderr);
         }
       }
+
       throw new Error(
-        `Failed to create Azure Bastion RDP connection: ${error.message}`
+        `Failed to create Azure Bastion RDP connection: ${classified ?? error?.message ?? String(error)}`
       );
     }
   },

--- a/src/plugins/azure/rdp.ts
+++ b/src/plugins/azure/rdp.ts
@@ -67,6 +67,25 @@ const BASTION_SERVICE_ERROR_PATTERN = /Request failed with error: (.+)/;
  * Not something p0 can resolve client-side. */
 const BASTION_UNEXPECTED_INTERNAL_ERROR = "Unexpected internal error";
 
+/** Matches JWT-shaped tokens (three dot-separated base64url segments), the
+ * shape of the bearer tokens observed in az's DEBUG-level output. */
+const BEARER_TOKEN_PATTERN =
+  /\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+
+/** az's --debug output has been observed to include live bearer tokens in
+ * cleartext on DEBUG-level lines. Even when the *user* explicitly asked p0
+ * rdp for --debug (the only case az itself is passed --debug — see
+ * azBastionRdpCommand above), stderr must never be echoed to the terminal
+ * verbatim: only ERROR/WARNING-level lines are shown (the levels that
+ * actually carry failure context), with any lookalike bearer token further
+ * redacted as defense in depth. */
+export const sanitizeAzureDebugOutput = (stderr: string): string =>
+  stderr
+    .split("\n")
+    .filter((line) => /^\s*(ERROR|WARNING):/.test(line))
+    .join("\n")
+    .replace(BEARER_TOKEN_PATTERN, "[REDACTED]");
+
 export const classifyBastionRdpError = (stderr: string): string | undefined => {
   const match = stderr.match(BASTION_SERVICE_ERROR_PATTERN);
   if (!match?.[1]) return undefined;
@@ -129,7 +148,7 @@ export const azureRdpProvider = {
         );
         if (stderr) {
           print2("Error details:");
-          print2(stderr);
+          print2(sanitizeAzureDebugOutput(stderr));
         }
       }
 

--- a/src/plugins/rdp/index.ts
+++ b/src/plugins/rdp/index.ts
@@ -58,6 +58,7 @@ const provisionRequest = async (
           "session",
           destination,
           ...(args.reason ? ["--reason", args.reason] : []),
+          ...(args.admin ? ["--admin"] : []),
         ],
         wait: true,
         debug: args.debug,

--- a/src/types/rdp.ts
+++ b/src/types/rdp.ts
@@ -19,17 +19,29 @@ export type AzureRdpPermissionSpec = PermissionSpec<
 export type AzureRdpRequest = {
   principal: string;
   permission: {
+    // Whether to connect using the target VM's local administrator
+    // credentials instead of Microsoft Entra ID.
+    admin?: boolean;
+    bastionHost: {
+      id: string;
+      roleId: string;
+    };
     resource: {
       instanceId: string;
+      instanceName: string;
       subscriptionId: string;
-      bastionName: string;
-      bastionRg: string;
       directoryId: string;
+      region: string;
+      networkInterface: {
+        id: string;
+        subnetId: string;
+      };
     };
   };
 };
 
 export type RdpCommandArgs = {
+  admin?: boolean;
   configure?: boolean;
   debug?: boolean;
   destination: string;


### PR DESCRIPTION

**Problem**

Azure RDP-over-Bastion Host access schema recently changed on the backend: the old `resource.bastionName`/`resource.bastionRg` fields were replaced with a top-level `bastionHost: { id, roleId }`, and several fields were added (`instanceName`, `region`, `networkInterface`, an `admin` flag). The CLI's RDP types were still on the old shape, which would have broken `p0 rdp` outright.

Separately, real-world testing surfaced an unrelated but very rough edge: when the underlying `az network bastion rdp` call failed, the CLI only ever reported a generic, code-less "Sub-process exited with code" — no indication of what actually went wrong.

**Status:** N/A

**Change**

- Updated `AzureRdpRequest` to match the new backend schema (`bastionHost`, expanded `resource`, `admin`).
- `az network bastion rdp` is now invoked with `--ids <bastionHost.id>` instead of the removed `--name`/`--resource-group`, matching how Azure SSH's Bastion tunnel already identifies bastion hosts.
- Added a `--admin` flag to `p0 rdp` to connect with the target VM's local administrator credentials instead of Microsoft Entra ID.
- On failure, the CLI now surfaces the actual Azure Bastion error instead of a generic, uninformative message — including calling out a known upstream Azure Bastion issue ([Azure/azure-cli#21030](https://github.com/Azure/azure-cli/issues/21030), [#28148](https://github.com/Azure/azure-cli/issues/28148)) when that specific failure is detected.

Areas modified:
- [ ] authentication / authorization
- [ ] workflow
- [ ] APIs
- [ ] lifecycle SDK
- [ ] datastore abstractions
- [x] none of the above

**Type of Change**

- [x] Bug fix
- [x] New feature

**Validation**

- Testing: added unit tests for the new `az` command construction (bastion-host ID, admin mode, error classification) and existing/updated tests for the RDP request shape; full suite + lint + typecheck pass.
- Blast radius: Azure RDP path only (`p0 rdp`); no change to SSH, AWS, or GCP flows.
- Risks & mitigations: none identified — the `--ids` approach mirrors an existing, working pattern already used for Azure SSH.

**Tracking (optional)**

CUS-745
