### PR TITLE
mcp client create: add type param

### DIFF
--- a/src/commands/claude/mcp.ts
+++ b/src/commands/claude/mcp.ts
@@ -29,6 +29,7 @@ type CreateMcpClientReq = {
   hostname: string;
   platform: string;
   redirectUri: string;
+  type: "client_credential_post";
   version: string;
 };
 
@@ -148,6 +149,7 @@ const createClient = async (authn: Authn, argv: AddMcpServerArgs) => {
     body: JSON.stringify({
       hostname,
       platform: "claude-code",
+      type: "client_credential_post",
       version,
       redirectUri: `http://localhost:${argv.callbackPort ?? REDIRECT_PORT}`,
     } satisfies CreateMcpClientReq),


### PR DESCRIPTION
**Problem**

`p0 claude mcp add <server>` registers an MCP client through the P0 tenant
client-registration API. That API will require a `type` field to select the kind of client.
The CLI does not send it, and the API will reject the request with HTTP 400.

**Status:** N/A

**Change**

The CLI sends `type: "client_credential_post"` when it registers a client.

  Check off any of the following areas of code that are modified:

  - [ ] authentication / authorization
  - [ ] workflow
  - [ ] APIs
  - [ ] lifecycle SDK
  - [ ] datastore abstractions
  - [x] none of the above

  **Type of Change**

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Security fix

**Validation**

- Testing: `yarn tsc --noEmit` and `yarn build` pass. I ran `p0 claude mcp add <server>`, and the command
  registered a client and provisioned the server.
- Blast radius: one request body. Users with a cached client see no change.
- Risks & mitigations: the released API ignores the new field, so releasing this PR before
  the API change. Older CLI versions cannot register a new client after the API change.
  Users must upgrade.