### PR TITLE
Add sql-text postgres access to p0cli

### DIFF
--- a/src/commands/aws/__tests__/rds.test.ts
+++ b/src/commands/aws/__tests__/rds.test.ts
@@ -124,10 +124,8 @@ describe("rds generate-db-auth-token", () => {
     vi.clearAllMocks();
   });
 
-  const mockAccessResponse = (
-    delegation: DbPermissionSpec["delegation"]
-  ): void => {
-    mockRequest.mockReturnValue(async () => ({
+  const mockAccessResponse = (delegation: DbPermissionSpec["delegation"]) => {
+    const requestFn = vi.fn(async () => ({
       ok: true,
       message: "approved",
       id: "req-1",
@@ -136,7 +134,19 @@ describe("rds generate-db-auth-token", () => {
       isPreapproved: false,
       request: buildAccess(delegation),
     }));
+    mockRequest.mockReturnValue(requestFn);
+    return requestFn;
   };
+
+  const RDS_DELEGATION: DbPermissionSpec["delegation"] = [
+    {
+      key: "aws-rds",
+      request: {
+        permission: { vpcId: "vpc-1" },
+        delegation: [{ key: "aws", request: AWS_DELEGATE }],
+      },
+    },
+  ];
 
   it("passes the inner aws delegate to awsCloudAuth (array form at both levels)", async () => {
     mockAccessResponse([
@@ -214,6 +224,71 @@ describe("rds generate-db-auth-token", () => {
       const output = await runWithShell("/usr/bin/fish", "mysql");
       expect(output).toContain('set -gx MYSQL_PWD "fake-rds-token"');
       expect(output).toContain("mysql -h $RDS_HOST");
+    });
+  });
+
+  describe("access types", () => {
+    const argumentsOf = (requestFn: Mock) =>
+      requestFn.mock.calls[0]?.[0]?.arguments;
+
+    it("requests role access, forwarding the instance and database", async () => {
+      const requestFn = mockAccessResponse(RDS_DELEGATION);
+
+      await buildRdsYargs().parse(
+        "rds generate-db-auth-token --arch postgres --role admin --instance db-1 --database analytics"
+      );
+
+      expect(argumentsOf(requestFn)).toEqual([
+        "postgres",
+        "role",
+        "admin",
+        "--instance",
+        "db-1",
+        "--database",
+        "analytics",
+      ]);
+    });
+
+    it("requests sql access, passing the script as the policy argument", async () => {
+      const requestFn = mockAccessResponse(RDS_DELEGATION);
+
+      await buildRdsYargs().parse(
+        'rds generate-db-auth-token --arch postgres --sql "SELECT * FROM sales.customers" --instance db-1'
+      );
+
+      expect(argumentsOf(requestFn)).toEqual([
+        "postgres",
+        "sql",
+        "SELECT * FROM sales.customers",
+        "--instance",
+        "db-1",
+      ]);
+    });
+
+    it("rejects a request that names neither a role nor a script", async () => {
+      const requestFn = mockAccessResponse(RDS_DELEGATION);
+
+      const error = await failure(
+        buildRdsYargs(),
+        "rds generate-db-auth-token --arch postgres"
+      );
+
+      expect(error).toBe(
+        "Specify the access to request with either --role or --sql."
+      );
+      expect(requestFn).not.toHaveBeenCalled();
+    });
+
+    it("rejects a request that names both a role and a script", async () => {
+      const requestFn = mockAccessResponse(RDS_DELEGATION);
+
+      const error = await failure(
+        buildRdsYargs(),
+        'rds generate-db-auth-token --arch postgres --role admin --sql "SELECT 1"'
+      );
+
+      expect(error).toBe("Specify either --role or --sql, not both.");
+      expect(requestFn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/aws/rds.ts
+++ b/src/commands/aws/rds.ts
@@ -54,7 +54,8 @@ type RdsArgs = yargs.ArgumentsCamelCase<{
   database?: string;
   debug?: boolean;
   instance?: string;
-  role: string;
+  role?: string;
+  sql?: string;
 }>;
 
 export const rds = (
@@ -80,8 +81,12 @@ export const rds = (
             })
             .option("role", {
               type: "string",
-              demandOption: true,
               describe: "Database role to access",
+            })
+            .option("sql", {
+              type: "string",
+              describe:
+                "SQL script to run; P0 grants only the privileges the script requires",
             })
             .option("instance", {
               type: "string",
@@ -100,6 +105,30 @@ export const rds = (
       )
   );
 
+const toAccessArguments = (argv: RdsArgs) => {
+  const instanceArgs = argv.instance ? ["--instance", argv.instance] : [];
+
+  if (argv.sql) {
+    if (argv.role) throw "Specify either --role or --sql, not both.";
+    return [
+      "sql",
+      argv.sql,
+      ...instanceArgs,
+      ...(argv.database ? ["--database", argv.database] : []),
+    ];
+  }
+
+  if (argv.role)
+    return [
+      "role",
+      argv.role,
+      ...instanceArgs,
+      ...(argv.database ? ["--database", argv.database] : []),
+    ];
+
+  throw "Specify the access to request with either --role or --sql.";
+};
+
 const requestRdsAccess = async (argv: RdsArgs, authn: Authn) => {
   const integration = argv.arch;
 
@@ -109,13 +138,7 @@ const requestRdsAccess = async (argv: RdsArgs, authn: Authn) => {
     {
       $0: argv.$0,
       _: [],
-      arguments: [
-        integration,
-        "role",
-        argv.role,
-        ...(argv.instance ? ["--instance", argv.instance] : []),
-        ...(argv.database ? ["--database", argv.database] : []),
-      ],
+      arguments: [integration, ...toAccessArguments(argv)],
       wait: true,
     },
     authn,


### PR DESCRIPTION
**Problem**

`p0 aws rds generate-db-auth-token` could only request access by role (`--role` was required). Users who just need to run a specific query had to pick a role broad enough to cover it, which grants more privileges than the task requires.

**Status:** Preview

**Change**

Adds `--sql` to `p0 aws rds generate-db-auth-token` for Postgres. Instead of naming a role, you pass the SQL script you intend to run and P0 grants only the privileges that script requires:

```
p0 aws rds generate-db-auth-token --arch postgres --sql "SELECT * FROM sales.customers" --instance db-1
```

**Type of Change**

- [x] New feature

**Validation**

- Testing: unit tests added in `src/commands/aws/__tests__/rds.test.ts` covering role access, sql access, and both mutual-exclusion errors.
- Blast radius: limited to the `aws rds generate-db-auth-token` command. Existing `--role` invocations produce the same request arguments as before.
- Risks & mitigations: `--role` changed from required to optional, so a missing role is now caught by our own validation rather than yargs; covered by test.

**Rollout / rollback**

N/A
